### PR TITLE
feat: add PlantUML support for markdown rendering

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -20,6 +20,7 @@ import 'snackbar.dart';
 import 'mermaid_bridge.dart';
 import 'export_capture_scope.dart';
 import 'mermaid_image_cache.dart';
+import 'plantuml_block.dart';
 import 'package:Kelivo/l10n/app_localizations.dart';
 import 'package:Kelivo/theme/theme_factory.dart' show getPlatformFontFallback;
 import 'package:provider/provider.dart';
@@ -518,6 +519,8 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
         final lang = name.trim();
         if (lang.toLowerCase() == 'mermaid') {
           return _MermaidBlock(code: code);
+        } else if (lang.toLowerCase() == 'plantuml') {
+          return PlantUMLBlock(code: code);
         }
         return _CollapsibleCodeBlock(language: lang, code: code);
       },
@@ -1565,6 +1568,8 @@ class FencedCodeBlockMd extends BlockMd {
     final code = (m.group(2) ?? '');
     if (lang.toLowerCase() == 'mermaid') {
       return _MermaidBlock(code: code);
+    } else if (lang.toLowerCase() == 'plantuml') {
+      return PlantUMLBlock(code: code);
     }
     return _CollapsibleCodeBlock(language: lang, code: code);
   }

--- a/lib/shared/widgets/plantuml_block.dart
+++ b/lib/shared/widgets/plantuml_block.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../utils/plantuml_encoder.dart';
+import '../../icons/lucide_adapter.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'snackbar.dart';
+import 'export_capture_scope.dart';
+import 'dart:io';
+
+class PlantUMLBlock extends StatefulWidget {
+  final String code;
+
+  const PlantUMLBlock({super.key, required this.code});
+
+  @override
+  State<PlantUMLBlock> createState() => _PlantUMLBlockState();
+}
+
+class _PlantUMLBlockState extends State<PlantUMLBlock> {
+  bool _expanded = true;
+  late String _imageUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateUrl();
+  }
+
+  @override
+  void didUpdateWidget(covariant PlantUMLBlock oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.code != widget.code) {
+      _updateUrl();
+    }
+  }
+
+  void _updateUrl() {
+    final encoded = PlantUmlEncoder.encode(widget.code);
+    _imageUrl = 'https://www.plantuml.com/plantuml/svg/$encoded';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    // Use theme-tinted surfaces so headers follow the current theme color.
+    final Color bodyBg = Color.alphaBlend(
+      cs.primary.withValues(alpha: isDark ? 0.06 : 0.03),
+      cs.surface,
+    );
+    final Color headerBg = Color.alphaBlend(
+      cs.primary.withValues(alpha: isDark ? 0.16 : 0.10),
+      cs.surface,
+    );
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+      clipBehavior: Clip.antiAlias,
+      foregroundDecoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Header
+          Material(
+            color: headerBg,
+            elevation: 0,
+            shadowColor: Colors.transparent,
+            surfaceTintColor: Colors.transparent,
+            child: InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
+              splashColor: Platform.isIOS ? Colors.transparent : null,
+              highlightColor: Platform.isIOS ? Colors.transparent : null,
+              hoverColor: Platform.isIOS ? Colors.transparent : null,
+              overlayColor: Platform.isIOS
+                  ? const MaterialStatePropertyAll(Colors.transparent)
+                  : null,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: _expanded
+                        ? BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.28),
+                            width: 1.0,
+                          )
+                        : BorderSide.none,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    const SizedBox(width: 2),
+                    Text(
+                      'plantuml',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: cs.onSurface,
+                        height: 1.0,
+                      ),
+                    ),
+                    const Spacer(),
+                    if (!ExportCaptureScope.of(context)) ...[
+                      // Copy action
+                      InkWell(
+                        onTap: () async {
+                          await Clipboard.setData(
+                            ClipboardData(text: widget.code),
+                          );
+                          if (mounted) {
+                            showAppSnackBar(
+                              context,
+                              message: AppLocalizations.of(
+                                context,
+                              )!.chatMessageWidgetCopiedToClipboard,
+                              type: NotificationType.success,
+                            );
+                          }
+                        },
+                        splashColor: Platform.isIOS ? Colors.transparent : null,
+                        highlightColor: Platform.isIOS
+                            ? Colors.transparent
+                            : null,
+                        hoverColor: Platform.isIOS ? Colors.transparent : null,
+                        overlayColor: Platform.isIOS
+                            ? const MaterialStatePropertyAll(Colors.transparent)
+                            : null,
+                        borderRadius: BorderRadius.circular(6),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 6,
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Lucide.Copy,
+                                size: 14,
+                                color: cs.onSurface.withValues(alpha: 0.6),
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                AppLocalizations.of(
+                                  context,
+                                )!.shareProviderSheetCopyButton,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: cs.onSurface.withValues(alpha: 0.6),
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      // Open in browser
+                      InkWell(
+                        onTap: () async {
+                          final uri = Uri.parse(_imageUrl);
+                          try {
+                            await launchUrl(
+                              uri,
+                              mode: LaunchMode.externalApplication,
+                            );
+                          } catch (_) {
+                            if (!mounted) return;
+                            showAppSnackBar(
+                              context,
+                              message: AppLocalizations.of(
+                                context,
+                              )!.mermaidPreviewOpenFailed, // Reuse or add new string
+                              type: NotificationType.error,
+                            );
+                          }
+                        },
+                        splashColor: Platform.isIOS ? Colors.transparent : null,
+                        highlightColor: Platform.isIOS
+                            ? Colors.transparent
+                            : null,
+                        hoverColor: Platform.isIOS ? Colors.transparent : null,
+                        overlayColor: Platform.isIOS
+                            ? const MaterialStatePropertyAll(Colors.transparent)
+                            : null,
+                        borderRadius: BorderRadius.circular(6),
+                        child: Padding(
+                          padding: const EdgeInsets.all(6),
+                          child: Icon(
+                            Lucide.Link,
+                            size: 14,
+                            color: cs.onSurface.withValues(alpha: 0.6),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      AnimatedRotation(
+                        turns: _expanded ? 0.25 : 0.0,
+                        duration: const Duration(milliseconds: 180),
+                        curve: Curves.easeOutCubic,
+                        child: Icon(
+                          Lucide.ChevronRight,
+                          size: 16,
+                          color: cs.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+          // Content
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 220),
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeInCubic,
+            transitionBuilder: (child, anim) => FadeTransition(
+              opacity: anim,
+              child: SizeTransition(
+                sizeFactor: anim,
+                axisAlignment: -1.0,
+                child: child,
+              ),
+            ),
+            child: _expanded
+                ? Container(
+                    key: const ValueKey('plantuml-expanded'),
+                    width: double.infinity,
+                    color: bodyBg,
+                    padding: const EdgeInsets.all(10),
+                    child: SvgPicture.network(
+                      _imageUrl,
+                      fit: BoxFit.contain,
+                      placeholderBuilder: (BuildContext context) => Container(
+                        padding: const EdgeInsets.all(20),
+                        alignment: Alignment.center,
+                        child: const CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  )
+                : const SizedBox.shrink(key: ValueKey('plantuml-collapsed')),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/plantuml_encoder.dart
+++ b/lib/utils/plantuml_encoder.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:archive/archive.dart';
+
+// References https://plantuml.com/zh/text-encoding
+class PlantUmlEncoder {
+  static const String _mapping =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_";
+
+  static String encode(String text) {
+    List<int> bytes = utf8.encode(text);
+    // Use Deflate algorithm
+    List<int> compressed = Deflate(bytes).getBytes();
+    return _encode64(compressed);
+  }
+
+  static String _encode64(List<int> data) {
+    StringBuffer r = StringBuffer();
+    for (int i = 0; i < data.length; i += 3) {
+      if (i + 2 == data.length) {
+        r.write(_append3bytes(data[i], data[i + 1], 0).substring(0, 3));
+      } else if (i + 1 == data.length) {
+        r.write(_append3bytes(data[i], 0, 0).substring(0, 2));
+      } else {
+        r.write(_append3bytes(data[i], data[i + 1], data[i + 2]));
+      }
+    }
+    return r.toString();
+  }
+
+  static String _append3bytes(int b1, int b2, int b3) {
+    int c1 = b1 >> 2;
+    int c2 = ((b1 & 0x3) << 4) | (b2 >> 4);
+    int c3 = ((b2 & 0xF) << 2) | (b3 >> 6);
+    int c4 = b3 & 0x3F;
+    StringBuffer r = StringBuffer();
+    r.write(_mapping[c1 & 0x3F]);
+    r.write(_mapping[c2 & 0x3F]);
+    r.write(_mapping[c3 & 0x3F]);
+    r.write(_mapping[c4 & 0x3F]);
+    return r.toString();
+  }
+}


### PR DESCRIPTION
目前是这样的：
<img width="1944" height="1849" alt="image" src="https://github.com/user-attachments/assets/30df1095-944c-4ba2-93d4-61c3961f1ec9" />

感觉可以加一个设置 PlantUML 渲染服务器地址的功能，但是我不知道设置放什么地方比较好，就没做,目前走的是官方服务器

closes #98 