### PR TITLE
refactor: migrate Gemini API key from query parameter to x-goog-api-key header

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -844,7 +844,7 @@ class ChatApiService {
           final base = config.baseUrl.endsWith('/')
               ? config.baseUrl.substring(0, config.baseUrl.length - 1)
               : config.baseUrl;
-          url = '$base/models/$upstreamModelId:generateContent?key=${Uri.encodeComponent(_apiKeyForRequest(config, modelId))}';
+          url = '$base/models/$upstreamModelId:generateContent';
         }
         final body = {
           'contents': [
@@ -878,6 +878,13 @@ class ChatApiService {
           }
         }
         final headers = <String, String>{'Content-Type': 'application/json'};
+        // Add API Key header for non-Vertex
+        if (!(config.vertexAI == true)) {
+          final apiKey = _apiKeyForRequest(config, modelId);
+          if (apiKey.isNotEmpty) {
+            headers['x-goog-api-key'] = apiKey;
+          }
+        }
         // Add Bearer for Vertex via service account JSON
         if (config.vertexAI == true) {
           final token = await _maybeVertexAccessToken(config);
@@ -4265,8 +4272,7 @@ class ChatApiService {
       if (isVertex && (config.projectId?.isNotEmpty == true) && (config.location?.isNotEmpty == true)) {
         url = 'https://aiplatform.googleapis.com/v1/projects/${config.projectId}/locations/${config.location}/publishers/google/models/$modelId:generateContent';
       } else {
-        final key = Uri.encodeComponent(_effectiveApiKey(config));
-        url = '$base/models/$modelId:generateContent?key=$key';
+        url = '$base/models/$modelId:generateContent';
       }
 
       // Convert messages to contents
@@ -4386,6 +4392,11 @@ class ChatApiService {
       if (isVertex) {
         final token = await GoogleServiceAccountAuth.getAccessTokenFromJson(config.serviceAccountJson ?? '');
         headers['Authorization'] = 'Bearer $token';
+      } else {
+        final apiKey = _effectiveApiKey(config);
+        if (apiKey.isNotEmpty) {
+          headers['x-goog-api-key'] = apiKey;
+        }
       }
 
       // Built-in tools and function_declarations (MCP) are mutually exclusive in Gemini API
@@ -4486,13 +4497,9 @@ class ChatApiService {
       baseUrl = '$base/models/$modelId:streamGenerateContent';
     }
 
-    // Build query with key (for non-Vertex) and alt=sse
+    // Build query with alt=sse
     final uriBase = Uri.parse(baseUrl);
     final qp = Map<String, String>.from(uriBase.queryParameters);
-    if (!(config.vertexAI == true)) {
-      final eff = _effectiveApiKey(config);
-      if (eff.isNotEmpty) qp['key'] = eff;
-    }
     qp['alt'] = 'sse';
     final uri = uriBase.replace(queryParameters: qp);
     final isVertex = config.vertexAI == true;
@@ -4732,6 +4739,11 @@ class ChatApiService {
         }
         final proj = (config.projectId ?? '').trim();
         if (proj.isNotEmpty) headers['X-Goog-User-Project'] = proj;
+      } else {
+        final apiKey = _effectiveApiKey(config);
+        if (apiKey.isNotEmpty) {
+          headers['x-goog-api-key'] = apiKey;
+        }
       }
       headers.addAll(_customHeaders(config, modelId));
       if (extraHeaders != null && extraHeaders.isNotEmpty) headers.addAll(extraHeaders);


### PR DESCRIPTION
This PR refactors the authentication mechanism for Google's Gemini API by migrating the API key from URL query parameters to the `x-goog-api-key` HTTP header. This change aligns with Google's recommended best practices for API authentication and improves security by keeping sensitive credentials out of URLs.

## Motivation

- **Security**: API keys in URLs can be logged in browser history, server logs, and analytics tools
- **Best Practices**: Google recommends using the `x-goog-api-key` header for API authentication
- **URL Cleanliness**: Removes sensitive data from URLs, making them cleaner and more shareable
- **Consistency**: Aligns with modern REST API authentication patterns

## Changes Made

### Files Modified

1. **`lib/core/services/api/chat_api_service.dart`** (5 locations)
2. **`lib/core/providers/model_provider.dart`** (4 locations)

### Technical Details

#### Before (Query Parameter Approach)
```dart
// URL construction with API key
url = '$base/models/$modelId:generateContent?key=${Uri.encodeComponent(apiKey)}';

// Request execution
final response = await http.post(Uri.parse(url), ...);
```

#### After (Header Approach)
```dart
// Clean URL without API key
url = '$base/models/$modelId:generateContent';

// Add API key to headers (only for non-Vertex AI configurations)
if (!(config.vertexAI == true)) {
  headers['x-goog-api-key'] = apiKey;
}

// Request execution
final response = await http.post(Uri.parse(url), headers: headers, ...);
```

### Affected Operations

- ✅ Title generation (non-streaming)
- ✅ Chat requests (non-streaming)
- ✅ Chat requests (streaming)
- ✅ Model listing
- ✅ Connection testing

### Vertex AI Compatibility

**Important**: This change only affects standard Gemini API authentication. Vertex AI mode continues to use Bearer token authentication in headers as before, ensuring backward compatibility.

```dart
// Vertex AI authentication remains unchanged
if (config.vertexAI == true) {
  headers['Authorization'] = 'Bearer $accessToken';
} else {
  // New: Use x-goog-api-key header for standard Gemini API
  headers['x-goog-api-key'] = apiKey;
}
```

## Benefits

1. **Enhanced Security**: API keys are no longer exposed in URLs
2. **Compliance**: Follows Google Cloud API best practices
3. **Maintainability**: Cleaner, more readable URLs
4. **Logging Safety**: Prevents accidental API key leakage in logs
5. **Consistent Architecture**: Unified header-based authentication approach

## Testing Checklist

- [x] Test standard Gemini API chat (non-streaming)
- [x] Test standard Gemini API chat (streaming)
- [x] Test title generation with Gemini API
- [x] Test model listing functionality
- [x] Test connection validation
- [x] Verify Vertex AI mode still works correctly
- [x] Confirm no API keys appear in network request URLs
- [x] Validate error handling for invalid API keys

## Breaking Changes

None. This is an internal implementation change that maintains the same external API surface.

## References

- [Gemini API Authentication Documentation](https://ai.google.dev/gemini-api/docs/api-key)
