### PR TITLE
Fix(backup): WebDAV Deletion Confirmation and List Refresh

### DIFF
--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -587,16 +587,40 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
                                     await context.read<BackupProvider>().restoreFromItem(it, mode: mode);
                                   }),
                                   onDelete: () async {
-                                    final next = await context.read<BackupProvider>().deleteAndReload(it);
-                                    next.sort((a, b) {
-                                      final aTime = a.lastModified;
-                                      final bTime = b.lastModified;
-                                      if (aTime != null && bTime != null) return bTime.compareTo(aTime);
-                                      if (aTime == null && bTime == null) return b.displayName.compareTo(a.displayName);
-                                      if (aTime == null) return 1;
-                                      return -1;
-                                    });
-                                    if (mounted) setState(() => _items = next);
+                                    final confirm = await showDialog<bool>(
+                                      context: context,
+                                      builder: (dctx) => AlertDialog(
+                                        backgroundColor: cs.surface,
+                                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                        title: Text(l10n.backupPageDeleteConfirmTitle),
+                                        content: Text(l10n.backupPageDeleteConfirmContent(it.displayName)),
+                                        actions: [
+                                          TextButton(onPressed: () => Navigator.of(dctx).pop(false), child: Text(l10n.backupPageCancel)),
+                                          TextButton(
+                                            onPressed: () => Navigator.of(dctx).pop(true),
+                                            style: TextButton.styleFrom(foregroundColor: cs.error),
+                                            child: Text(l10n.backupPageDeleteTooltip),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                    if (confirm != true) return;
+
+                                    setState(() => _loading = true); // Show loading inside dialog
+                                    try {
+                                      final next = await context.read<BackupProvider>().deleteAndReload(it);
+                                      next.sort((a, b) {
+                                        final aTime = a.lastModified;
+                                        final bTime = b.lastModified;
+                                        if (aTime != null && bTime != null) return bTime.compareTo(aTime);
+                                        if (aTime == null && bTime == null) return b.displayName.compareTo(a.displayName);
+                                        if (aTime == null) return 1;
+                                        return -1;
+                                      });
+                                      if (mounted) setState(() => _items = next);
+                                    } finally {
+                                      if (mounted) setState(() => _loading = false);
+                                    }
                                   },
                                 );
                               },

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -384,22 +384,140 @@ class _BackupPageState extends State<BackupPage> {
                         items: _remote,
                         loading: _loadingRemote,
                         onDelete: (item) async {
-                          final list = await vm.deleteAndReload(item);
-                          // 按时间倒序排列（最新的在前）
-                          list.sort((a, b) {
-                            // 优先使用 lastModified
-                            if (a.lastModified != null && b.lastModified != null) {
-                              return b.lastModified!.compareTo(a.lastModified!);
+                          final confirm = await showDialog<bool>(
+                            context: context,
+                            builder: (dctx) => AlertDialog(
+                              title: Text(l10n.backupPageDeleteConfirmTitle),
+                              content: Text(l10n.backupPageDeleteConfirmContent(item.displayName)),
+                              actions: [
+                                TextButton(onPressed: () => Navigator.of(dctx).pop(false), child: Text(l10n.backupPageCancel)),
+                                TextButton(
+                                  onPressed: () => Navigator.of(dctx).pop(true),
+                                  style: TextButton.styleFrom(foregroundColor: cs.error),
+                                  child: Text(l10n.backupPageDeleteTooltip),
+                                ),
+                              ],
+                            ),
+                          );
+                          
+                          if (confirm != true) return;
+                          
+                          // 1. Close current sheet
+                          if (context.mounted) Navigator.of(context).pop();
+
+                          // 2. Show loading dialog
+                          if (context.mounted) {
+                            showDialog(
+                              context: context,
+                              barrierDismissible: false,
+                              builder: (ctx) => const Center(child: CupertinoActivityIndicator(radius: 16)),
+                            );
+                          }
+                          
+                          try {
+                            final list = await vm.deleteAndReload(item);
+                            
+                            // Close loading dialog
+                            if (context.mounted) Navigator.of(context, rootNavigator: true).pop();
+
+                            // Sort list
+                            list.sort((a, b) {
+                              if (a.lastModified != null && b.lastModified != null) {
+                                return b.lastModified!.compareTo(a.lastModified!);
+                              }
+                              if (a.lastModified == null && b.lastModified == null) {
+                                return b.displayName.compareTo(a.displayName);
+                              }
+                              if (a.lastModified == null) return 1;
+                              return -1;
+                            });
+                            
+                            if (mounted) setState(() => _remote = list);
+
+                            if (!mounted) return;
+                            
+                            // Re-open the sheet by calling the same logic again.
+                            await showModalBottomSheet(
+                              context: context,
+                              isScrollControlled: true,
+                              backgroundColor: cs.surface,
+                              shape: const RoundedRectangleBorder(
+                                borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                              ),
+                              builder: (ctx) => _RemoteListSheet(
+                                items: _remote,
+                                loading: false,
+                                onDelete: (item) async {
+                                  // Simplified recursive delete logic for subsequent deletions
+                                  final confirm = await showDialog<bool>(
+                                    context: context,
+                                    builder: (dctx) => AlertDialog(
+                                      title: Text(l10n.backupPageDeleteConfirmTitle),
+                                      content: Text(l10n.backupPageDeleteConfirmContent(item.displayName)),
+                                      actions: [
+                                        TextButton(onPressed: () => Navigator.of(dctx).pop(false), child: Text(l10n.backupPageCancel)),
+                                        TextButton(
+                                          onPressed: () => Navigator.of(dctx).pop(true),
+                                          style: TextButton.styleFrom(foregroundColor: cs.error),
+                                          child: Text(l10n.backupPageDeleteTooltip),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                                  if (confirm == true) {
+                                    Navigator.of(ctx).pop();
+                                    if (context.mounted) {
+                                      showDialog(
+                                        context: context,
+                                        barrierDismissible: false,
+                                        builder: (ctx) => const Center(child: CupertinoActivityIndicator(radius: 16)),
+                                      );
+                                    }
+                                    try {
+                                      final list = await vm.deleteAndReload(item);
+                                      if (context.mounted) Navigator.of(context, rootNavigator: true).pop();
+                                      list.sort((a, b) {
+                                        if (a.lastModified != null && b.lastModified != null) return b.lastModified!.compareTo(a.lastModified!);
+                                        if (a.lastModified == null && b.lastModified == null) return b.displayName.compareTo(a.displayName);
+                                        if (a.lastModified == null) return 1;
+                                        return -1;
+                                      });
+                                      if (mounted) setState(() => _remote = list);
+                                    } catch (_) {
+                                      if (context.mounted && Navigator.canPop(context)) Navigator.of(context, rootNavigator: true).pop();
+                                    }
+                                  }
+                                },
+                                onRestore: (item) async {
+                                  Navigator.of(ctx).pop();
+                                  if (!mounted) return;
+                                  final mode = await _chooseImportModeDialog(context);
+                                  if (mode == null) return;
+                                  await _runWithImportingOverlay(context, () => vm.restoreFromItem(item, mode: mode));
+                                  if (!mounted) return;
+                                  await showDialog(
+                                    context: context,
+                                    builder: (dctx) => AlertDialog(
+                                      title: Text(l10n.backupPageRestartRequired),
+                                      content: Text(l10n.backupPageRestartContent),
+                                      actions: [TextButton(onPressed: () => Navigator.of(dctx).pop(), child: Text(l10n.backupPageOK))],
+                                    ),
+                                  );
+                                },
+                              ),
+                            );
+                            
+                          } catch (e) {
+                            // If error, ensure loading dialog is closed
+                            if (mounted && Navigator.canPop(context)) Navigator.of(context, rootNavigator: true).pop();
+                            if (mounted) {
+                                showAppSnackBar(
+                                context,
+                                message: e.toString(),
+                                type: NotificationType.error,
+                              );
                             }
-                            // 如果都没有 lastModified，按文件名倒序（文件名通常包含时间戳）
-                            if (a.lastModified == null && b.lastModified == null) {
-                              return b.displayName.compareTo(a.displayName);
-                            }
-                            // 有 lastModified 的排在前面
-                            if (a.lastModified == null) return 1;
-                            return -1;
-                          });
-                          setState(() => _remote = list);
+                          }
                         },
                         onRestore: (item) async {
                           Navigator.of(ctx).pop();
@@ -1057,7 +1175,7 @@ class _RemoteListSheet extends StatelessWidget {
                     child: Text(l10n.backupPageRemoteBackups, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
                   ),
                   if (loading)
-                    Positioned(
+                    const Positioned(
                       right: 0,
                       child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
                     ),
@@ -1070,41 +1188,49 @@ class _RemoteListSheet extends StatelessWidget {
                         padding: const EdgeInsets.all(20),
                         child: Text(l10n.backupPageNoBackups, style: TextStyle(color: cs.onSurface.withOpacity(0.6))),
                       )
-                    : ListView.builder(
-                        controller: controller,
-                        itemCount: items.length,
-                        itemBuilder: (ctx, i) {
-                          final it = items[i];
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 6),
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Theme.of(context).brightness == Brightness.dark ? Colors.white10 : const Color(0xFFF7F7F9),
-                                borderRadius: BorderRadius.circular(12),
-                                border: Border.all(color: cs.outlineVariant.withOpacity(0.18)),
-                              ),
-                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                              child: Row(
-                                children: [
-                                  Expanded(
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [
-                                        Text(it.displayName, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontWeight: FontWeight.w600)),
-                                        const SizedBox(height: 4),
-                                        Text(_fmtBytes(it.size), style: TextStyle(fontSize: 12, color: cs.onSurface.withOpacity(0.7))),
-                                      ],
-                                    ),
+                    : StatefulBuilder(
+                        builder: (context, setListState) {
+                          // We pass the parent loading/items, but in case we want localized refresh...
+                          // Actually, the parent rebuilds this widget when _loadingRemote changes.
+                          // But ListView.builder might not update if only the items list reference changes?
+                          // In our case _BackupPageState calls setState, so _RemoteListSheet is rebuilt with new items.
+                          return ListView.builder(
+                            controller: controller,
+                            itemCount: items.length,
+                            itemBuilder: (ctx, i) {
+                              final it = items[i];
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(vertical: 6),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).brightness == Brightness.dark ? Colors.white10 : const Color(0xFFF7F7F9),
+                                    borderRadius: BorderRadius.circular(12),
+                                    border: Border.all(color: cs.outlineVariant.withOpacity(0.18)),
                                   ),
-                                  _SmallTactileIcon(icon: Lucide.Import, onTap: () => onRestore(it)),
-                                  const SizedBox(width: 6),
-                                  _SmallTactileIcon(icon: Lucide.Trash2, onTap: () => onDelete(it), baseColor: cs.error),
-                                ],
-                              ),
-                            ),
+                                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                                  child: Row(
+                                    children: [
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            Text(it.displayName, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontWeight: FontWeight.w600)),
+                                            const SizedBox(height: 4),
+                                            Text(_fmtBytes(it.size), style: TextStyle(fontSize: 12, color: cs.onSurface.withOpacity(0.7))),
+                                          ],
+                                        ),
+                                      ),
+                                      _SmallTactileIcon(icon: Lucide.Import, onTap: () => onRestore(it)),
+                                      const SizedBox(width: 6),
+                                      _SmallTactileIcon(icon: Lucide.Trash2, onTap: () => onDelete(it), baseColor: cs.error),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
                           );
-                        },
+                        }
                       ),
               ),
             ],

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -538,6 +538,8 @@
   "backupPageNoBackups": "No backups",
   "backupPageRestoreTooltip": "Restore",
   "backupPageDeleteTooltip": "Delete",
+  "backupPageDeleteConfirmTitle": "Confirm Deletion",
+  "backupPageDeleteConfirmContent": "Are you sure you want to delete remote backup \"{name}\"? This action cannot be undone.",
   "backupPageBackupManagement": "Backup Management",
   "backupPageWebDavBackup": "WebDAV Backup",
   "backupPageWebDavServerSettings": "WebDAV Server Settings",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2483,6 +2483,18 @@ abstract class AppLocalizations {
   /// **'Delete'**
   String get backupPageDeleteTooltip;
 
+  /// No description provided for @backupPageDeleteConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Deletion'**
+  String get backupPageDeleteConfirmTitle;
+
+  /// No description provided for @backupPageDeleteConfirmContent.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to delete remote backup \"{name}\"? This action cannot be undone.'**
+  String backupPageDeleteConfirmContent(Object name);
+
   /// No description provided for @backupPageBackupManagement.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1275,6 +1275,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupPageDeleteTooltip => 'Delete';
 
   @override
+  String get backupPageDeleteConfirmTitle => 'Confirm Deletion';
+
+  @override
+  String backupPageDeleteConfirmContent(Object name) {
+    return 'Are you sure you want to delete remote backup \"$name\"? This action cannot be undone.';
+  }
+
+  @override
   String get backupPageBackupManagement => 'Backup Management';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1241,6 +1241,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backupPageDeleteTooltip => '删除';
 
   @override
+  String get backupPageDeleteConfirmTitle => '确认删除';
+
+  @override
+  String backupPageDeleteConfirmContent(Object name) {
+    return '确定要删除远程备份“$name”吗？此操作不可撤销。';
+  }
+
+  @override
   String get backupPageBackupManagement => '备份管理';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -408,6 +408,8 @@
   "backupPageNoBackups": "暂无备份",
   "backupPageRestoreTooltip": "恢复",
   "backupPageDeleteTooltip": "删除",
+  "backupPageDeleteConfirmTitle": "确认删除",
+  "backupPageDeleteConfirmContent": "确定要删除远程备份“{name}”吗？此操作不可撤销。",
   "backupPageBackupManagement": "备份管理",
   "backupPageWebDavBackup": "WebDAV 备份",
   "backupPageWebDavServerSettings": "WebDAV 服务器设置",


### PR DESCRIPTION
# Fix: WebDAV Deletion Confirmation and List Refresh

**Description:**

This PR addresses two key issues related to WebDAV backups:

1.  **Missing Confirmation on Deletion:** Previously, deleting a remote WebDAV backup happened immediately without any user confirmation, leading to potential accidental data loss. A confirmation dialog has now been added to both Mobile (Android/iOS) and Desktop platforms.
2.  **Backup List Not Refreshing on Android:** On Android devices, the list of remote backups did not refresh after a deletion, showing stale data. This has been resolved by automatically closing the menu upon confirmation, performing the deletion, and then re-opening the menu with the updated list.

**Changes:**

-   **Mobile (`lib/features/backup/pages/backup_page.dart`):**
    -   Added a confirmation dialog before deletion.
    -   Implemented logic to close the current bottom sheet, show a loading indicator, perform the deletion, and then re-open the bottom sheet with the fresh list.
-   **Desktop (`lib/desktop/setting/backup_pane.dart`):**
    -   Added a confirmation dialog to the remote backup management dialog.
-   **Localization:**
    -   Added new translation keys `backupPageDeleteConfirmTitle` and `backupPageDeleteConfirmContent` to `app_en.arb` and `app_zh.arb`.

**Testing:**

-   Verified on **Android**: The confirmation dialog appears, and after deletion, the menu reloads correctly reflecting the changes.
-   Verified on **macOS**: The confirmation dialog appears correctly before deletion.

---

# 修复：WebDAV 删除确认及列表刷新问题

**描述：**

此 PR 修复了两个与 WebDAV 备份相关的问题：

1.  **删除时缺少确认提示：** 之前删除远程 WebDAV 备份时会立即执行，没有任何用户确认，容易导致误删。现在已在移动端 (Android/iOS) 和桌面端添加了删除确认对话框。
2.  **Android 端备份列表未刷新：** 在 Android 设备上，删除操作后远程备份列表不会自动刷新，仍显示旧数据。通过在确认删除后自动关闭当前菜单，执行删除操作，然后重新打开菜单加载最新列表，解决了此问题。

**变更：**

-   **移动端 (`lib/features/backup/pages/backup_page.dart`)：**
    -   添加了删除前的确认对话框。
    -   实现了关闭当前底部菜单、显示加载提示、执行删除、然后重新打开底部菜单加载新列表的逻辑。
-   **桌面端 (`lib/desktop/setting/backup_pane.dart`)：**
    -   在远程备份管理对话框中添加了确认提示。
-   **本地化：**
    -   在 `app_en.arb` 和 `app_zh.arb` 中添加了新的翻译键值 `backupPageDeleteConfirmTitle` 和 `backupPageDeleteConfirmContent`。

**测试：**

-   **Android** 验证：确认对话框正常显示，删除后菜单会自动重新加载并显示最新数据。
-   **macOS** 验证：删除前能正确显示确认对话框。