### PR TITLE
fix(ios): resolve iPad window control overlap issue by enabling compatibility mode

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,6 +42,8 @@
 	<string>允许访问相册以选择头像图片 / Allow access to your photos to pick an avatar.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## Problem
On iPadOS 26+, Apple introduced a new window styling (often referred to as "Liquid Glass") for apps running in Stage Manager or Split View. This design places the window control buttons (traffic lights) floating directly over the top-left corner of the app's content area.

In our current layout, the navigation/menu button resides in this exact top-left position. As a result, when the app is windowed on these newer iPadOS versions, the window controls obscure the app's navigation button, making it difficult or impossible for users to open the sidebar or go back (Issue #211).

## Solution
This PR adds the `UIDesignRequiresCompatibility` key with a value of `true` to `ios/Runner/Info.plist`.

### Technical Details
- **Flag Function**: The `UIDesignRequiresCompatibility` key instructs the system that this app is not designed to accommodate the new "Liquid Glass" window style. https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility
- **Result**: Enabling this flag forces the app into a compatibility mode. In this mode, the system renders a traditional window bar or places the window controls in a dedicated safe area, ensuring they do not overlap with the app's UI content.
- **Context**: This is the recommended workaround for the upstream Flutter issue [#170461](https://github.com/flutter/flutter/issues/170461), pending a more permanent framework-level solution for safe area insets on iPad windowed mode.

## Test Plan
1. Run the app on an iPad running iPadOS 26+ (or Simulator).
2. Enable Stage Manager (if supported) or put the app into Split View.
3. Verify that the red/yellow/green window control buttons no longer overlap the top-left menu icon.

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/27dba9d1-d43c-4f96-9180-fff97a062f73) | <img width="1460" height="1157" alt="image" src="https://github.com/user-attachments/assets/60a2c466-06d1-4b22-ac3f-42446386b5b9" /> |

## Related Issues
Closes #211

---

## 问题描述
在 iPadOS 26+ 上，Apple 为在台前调度 (Stage Manager) 或分屏模式 (Split View) 下运行的应用引入了新的窗口样式（通常称为“Liquid Glass”）。这种设计将窗口控制按钮（红绿灯）直接悬浮在应用内容区域的左上角。

在我们目前的布局中，导航/菜单按钮恰好位于左上角。因此，当应用在这些较新版本的 iPadOS 上以窗口模式运行时，窗口控制按钮会遮挡应用的导航按钮，导致用户难以打开侧边栏或返回上一级（Issue #211）。

## 解决方案
本 PR 在 `ios/Runner/Info.plist` 中添加了 `UIDesignRequiresCompatibility` 键，并将其值设为 `true`。

### 技术细节
- **flag功能**：`UIDesignRequiresCompatibility` 键告知系统，该应用尚未适配新的“Liquid Glass”窗口样式。https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility
- **结果**：启用此flag后，应用将被强制进入兼容模式。在此模式下，系统会渲染传统的窗口栏或将窗口控制按钮放置在专用的安全区域内，确保它们不会遮挡应用的 UI 内容。
- **背景**：这是针对上游 Flutter 问题 [#170461](https://github.com/flutter/flutter/issues/170461) 的推荐临时解决方案，直到框架层面提供更完善的 iPad 窗口模式安全区域支持。

## 测试计划
1. 在运行 iPadOS 26+ 的 iPad（或模拟器）上运行应用。
2. 启用台前调度（如果支持）或将应用置于分屏模式。
3. 验证红/黄/绿窗口控制按钮不再遮挡左上角的菜单图标。

## 截图对比
| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/27dba9d1-d43c-4f96-9180-fff97a062f73) | <img width="1460" height="1157" alt="image" src="https://github.com/user-attachments/assets/60a2c466-06d1-4b22-ac3f-42446386b5b9" /> |

## 关联issue
Closes #211
