### PR TITLE
feat(markdown): support <br> tag rendering via whitelist component

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -110,6 +110,9 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
     final inlineComponents = List<MarkdownComponent>.from(
       MarkdownComponent.inlineComponents,
     );
+    // Add whitelist-based HTML tag renderer (e.g., <br>)
+    inlineComponents.insert(0, AllowedHtmlTagsMd());
+
     final linkIdxInline = inlineComponents.indexWhere((c) => c is ATagMd);
     if (linkIdxInline != -1) {
       inlineComponents[linkIdxInline] = LineSafeLinkMd();
@@ -2606,6 +2609,18 @@ class BackslashEscapeMd extends InlineMd {
     final ch = m.group(1) ?? '';
     // Render only the escaped character (drop the backslash)
     return TextSpan(text: ch, style: config.style);
+  }
+}
+
+/// Whitelist-based HTML tag renderer.
+/// Currently supports <br> tags for manual line breaks.
+class AllowedHtmlTagsMd extends InlineMd {
+  @override
+  RegExp get exp => RegExp(r"<br\s*/?>", caseSensitive: false);
+
+  @override
+  InlineSpan span(BuildContext context, String text, GptMarkdownConfig config) {
+    return const TextSpan(text: '\n');
   }
 }
 


### PR DESCRIPTION
### Description
This PR addresses issue #266 where `<br>` tags in Markdown tables were not rendering as line breaks.

A new whitelist-based inline markdown component, `AllowedHtmlTagsMd`, has been introduced. This component is designed to safely identify and render specific HTML tags (starting with `<br>`, `<br/>`, or `<br />`) as `TextSpan(text: '\n')`. This ensures that line breaks are correctly displayed across all markdown content, including table cells, without compromising the security or integrity of the markdown rendering.

**Reference Implementation (Cherry Studio):**
This architecture draws inspiration from the best practices observed in [Cherry Studio](https://github.com/CherryHQ/cherry-studio).
Implementation file: [`src/renderer/src/pages/home/Markdown/Markdown.tsx`](https://github.com/CherryHQ/cherry-studio/blob/main/src/renderer/src/pages/home/Markdown/Markdown.tsx)

In that project, support for `<br>` line breaks in Markdown tables is achieved using `rehype-raw` combined with an HTML tag whitelist:
1.  **`rehype-raw` Integration**: Used to parse raw HTML strings within Markdown, preventing `react-markdown` from escaping them as plain text.
2.  **Whitelist (`ALLOWED_ELEMENTS`)**: A regex defines allowed HTML tags (including `<br>`).
3.  **Conditional Activation**: `rehype-raw` is added to the plugin list only when the content contains allowed tags.
4.  **Result**: When `<br>` is detected, it is rendered as a genuine HTML line break element rather than escaped text `&lt;br&gt;`.

Our Flutter implementation adopts this exact "whitelist detection + component rendering" philosophy, adapting it to the `gpt_markdown` ecosystem.

### Testing
- **macOS**: Verified that `<br>` tags in tables now correctly produce line breaks.
- **Android**: Confirmed consistent behavior on Android devices.

### Screenshots
<img width="892" height="1061" alt="Screenshot 2026-01-19 at 8 30 02 PM" src="https://github.com/user-attachments/assets/07933a69-8d52-4f91-8f6f-61ebcd230b0f" />
<img width="900" height="1950" alt="image" src="https://github.com/user-attachments/assets/321a63a6-a574-4a9e-a2ec-8243e8a5b053" />


---

### 描述
本 PR 修复了 Markdown 表格中 `<br>` 标签无法换行的问题 (#266)。

引入了一个基于白名单的内联 Markdown 组件 `AllowedHtmlTagsMd`。该组件旨在安全地识别并渲染特定的 HTML 标签（目前支持 `<br>`、`<br/>` 或 `<br />`），将其转换为 `TextSpan(text: '\n')`。这确保了换行符在所有 Markdown 内容（包括表格单元格）中都能正确显示，同时不会破坏 Markdown 渲染的安全性。

**参考实现 (Cherry Studio)：**
本方案参考了 [Cherry Studio](https://github.com/CherryHQ/cherry-studio) 的最佳实践。
实现文件：[`src/renderer/src/pages/home/Markdown/Markdown.tsx`](https://github.com/CherryHQ/cherry-studio/blob/main/src/renderer/src/pages/home/Markdown/Markdown.tsx)

在该项目中，支持 Markdown 表格中使用 `<br>` 换行的实现细节如下：
1.  **引入 `rehype-raw`**：用于解析 Markdown 中的原始 HTML 字符串。`react-markdown` 默认会转义 HTML，而 `rehype-raw` 允许将其重新解析为 HTML 节点。
2.  **定义允许的 HTML 标签 (白名单)**：定义了 `ALLOWED_ELEMENTS` 正则表达式，列出允许渲染的 HTML 标签（包含 `br`）。
3.  **条件启用**：在组件中检测内容是否包含允许的标签。如果检测到（例如包含 `<br>`），才将 `rehypeRaw` 激活。
4.  **总结**：这种机制确保了在保持 Markdown 渲染能力的同时，有选择地支持特定的 HTML 格式化标签。当表格单元格中出现 `<br>` 时，它会被识别并渲染为真正的 HTML 换行元素，而不是转义后的文本。

我们在 Flutter 中也采用了这种“白名单检测 + 组件渲染”的方法，复刻了这一设计理念。

### 测试
- **macOS**: 验证了表格中的 `<br>` 标签现在可以正确产生换行。
- **Android**: 确认在 Android 设备上行为一致。

### 截图
<img width="892" height="1061" alt="Screenshot 2026-01-19 at 8 30 02 PM" src="https://github.com/user-attachments/assets/07933a69-8d52-4f91-8f6f-61ebcd230b0f" />
<img width="900" height="1950" alt="image" src="https://github.com/user-attachments/assets/321a63a6-a574-4a9e-a2ec-8243e8a5b053" />