### PR TITLE
fix(backup): [dependent on #240] resolve cross-platform path issues and restore crash

### DIFF
--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -105,8 +105,14 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
       context: context,
       builder: (ctx) => _RestoreModeDialog(),
     );
+<<<<<<< HEAD
     if (mode == null) return;
     await action(mode);
+=======
+    if (options == null) return;
+    await action(options);
+    if (!mounted) return;
+>>>>>>> 5f17865 (fix(backup): resolve cross-platform path issues and restore crash (Fixes #243))
     // Inform restart requirement
     await showDialog(
       context: context,
@@ -528,10 +534,18 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     }
   }
 
+<<<<<<< HEAD
   Future<void> _chooseRestoreModeAndRun(Future<void> Function(RestoreMode) action) async {
     final mode = await showDialog<RestoreMode>(context: context, builder: (_) => _RestoreModeDialog());
     if (mode == null) return;
     await action(mode);
+=======
+  Future<void> _chooseRestoreOptionsAndRun(Future<void> Function(RestoreOptions) action) async {
+    final options = await showDialog<RestoreOptions>(context: context, builder: (_) => const _RestoreOptionsDialog());
+    if (options == null) return;
+    await action(options);
+    if (!mounted) return;
+>>>>>>> 5f17865 (fix(backup): resolve cross-platform path issues and restore crash (Fixes #243))
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     await showDialog(context: context, builder: (_) => AlertDialog(


### PR DESCRIPTION
## **Description**
This PR addresses cross-platform image path compatibility issues when restoring backups on different devices (e.g., Windows User A to Windows User B, or PC to Mobile). It ensures that file paths are portable and correctly resolved regardless of the environment.

Additionally, it fixes a crash in the Desktop backup pane that occurred during long restore operations.

**Fixes #243**
**Depends on #240** (Granular backup/restore)

## **Key Changes**

1.  **Cross-Platform Path Resolution (`data_sync.dart`)**:
    *   **Export**: Now converts absolute paths to portable relative paths (e.g., `upload/img.jpg`) before saving to the backup. It uses aggressive directory matching to correctly handle iOS/macOS symlinks.
    *   **Import**: 
        *   Automatically expands relative paths to the current device's absolute path structure.
        *   **Legacy Support**: Heals existing backups containing absolute paths by using `SandboxPathResolver` with a fallback mechanism to locate files in standard subfolders.

2.  **Stability Improvements (`backup_pane.dart`)**:
    *   Fixed a `Widget unmounted` crash in `DesktopBackupPane` by adding `!mounted` checks during asynchronous restore operations.

3.  **Initialization**:
    *   Added `SandboxPathResolver` initialization to the restore flow to ensure path helpers are ready before processing files.

---

## **描述**
本 PR 解决了在不同设备间（例如 Windows 用户 A 到 Windows 用户 B，或电脑到手机）恢复备份时，图片路径不兼容的问题。它确保文件路径具有可移植性，并在不同环境下都能被正确解析。

此外，修复了桌面端在长时间恢复操作过程中可能发生的崩溃问题。

**修复 #243**
**依赖 #240** (颗粒化备份/恢复)

## **主要变更**

1.  **跨平台路径解析 (`data_sync.dart`)**:
    *   **导出**: 在保存备份前，将绝对路径转换为可移植的相对路径（例如 `upload/img.jpg`）。采用了更激进的目录匹配策略，以正确处理 iOS/macOS 的符号链接。
    *   **导入**: 
        *   自动将相对路径扩展为当前设备的绝对路径结构。
        *   **遗留支持**: 使用 `SandboxPathResolver` 修复包含绝对路径的旧备份，并通过回退机制在标准子目录中查找文件。

2.  **稳定性改进 (`backup_pane.dart`)**:
    *   在 `DesktopBackupPane` 的异步恢复操作中添加了 `!mounted` 检查，修复了 `Widget unmounted` 导致的崩溃。

3.  **初始化**:
    *   在恢复流程中添加了 `SandboxPathResolver` 的初始化，确保在处理文件前路径助手已准备就绪。
