### PR TITLE
fix(gemini): guard toolConfig for built-in tools

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -15,6 +15,7 @@ import 'package:Kelivo/secrets/fallback.dart';
 import '../../../utils/markdown_media_sanitizer.dart';
 import '../../../utils/unicode_sanitizer.dart';
 import 'builtin_tools.dart';
+import 'gemini_tool_config.dart';
 
 class ChatApiService {
   static const String _aihubmixAppCode = 'ZKRT3588';
@@ -4471,6 +4472,7 @@ class ChatApiService {
       } else if (geminiTools != null) {
         toolsArr.addAll(geminiTools);
       }
+      final shouldAttachToolConfig = shouldAttachGeminiFunctionCallingConfig(toolsArr);
 
       Map<String, dynamic> baseBody = {
         'contents': contents,
@@ -4478,7 +4480,7 @@ class ChatApiService {
         if (topP != null) 'topP': topP,
         if (maxTokens != null) 'generationConfig': {'maxOutputTokens': maxTokens},
         if (toolsArr.isNotEmpty) 'tools': toolsArr,
-        if (toolsArr.isNotEmpty) 'toolConfig': {'function_calling_config': {'mode': 'AUTO'}},
+        if (shouldAttachToolConfig) 'toolConfig': {'function_calling_config': {'mode': 'AUTO'}},
       };
       final extraG = _customBody(config, modelId);
       if (extraG.isNotEmpty) baseBody.addAll(extraG);
@@ -4706,6 +4708,7 @@ class ChatApiService {
     } else if (geminiTools != null) {
       toolsArr.addAll(geminiTools);
     }
+    final shouldAttachToolConfig = shouldAttachGeminiFunctionCallingConfig(toolsArr);
 
     // Maintain a rolling conversation for multi-round tool calls
     List<Map<String, dynamic>> convo = List<Map<String, dynamic>>.from(contents);
@@ -4792,7 +4795,7 @@ class ChatApiService {
         'contents': convo,
         if (gen.isNotEmpty) 'generationConfig': gen,
         if (toolsArr.isNotEmpty) 'tools': toolsArr,
-        if (toolsArr.isNotEmpty) 'toolConfig': {'function_calling_config': {'mode': 'AUTO'}},
+        if (shouldAttachToolConfig) 'toolConfig': {'function_calling_config': {'mode': 'AUTO'}},
       };
 
       final request = http.Request('POST', uri);

--- a/lib/core/services/api/gemini_tool_config.dart
+++ b/lib/core/services/api/gemini_tool_config.dart
@@ -1,0 +1,8 @@
+bool shouldAttachGeminiFunctionCallingConfig(List<Map<String, dynamic>> tools) {
+  for (final tool in tools) {
+    if (!tool.containsKey('function_declarations')) continue;
+    final decls = tool['function_declarations'];
+    if (decls is List && decls.isNotEmpty) return true;
+  }
+  return false;
+}

--- a/test/gemini_tool_config_test.dart
+++ b/test/gemini_tool_config_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/services/api/gemini_tool_config.dart';
+
+void main() {
+  group('shouldAttachGeminiFunctionCallingConfig', () {
+    test('returns false for google_search built-in tool', () {
+      final tools = <Map<String, dynamic>>[
+        {'google_search': {}},
+      ];
+      expect(shouldAttachGeminiFunctionCallingConfig(tools), isFalse);
+    });
+
+    test('returns false for url_context built-in tool', () {
+      final tools = <Map<String, dynamic>>[
+        {'url_context': {}},
+      ];
+      expect(shouldAttachGeminiFunctionCallingConfig(tools), isFalse);
+    });
+
+    test('returns false for code_execution built-in tool', () {
+      final tools = <Map<String, dynamic>>[
+        {'code_execution': {}},
+      ];
+      expect(shouldAttachGeminiFunctionCallingConfig(tools), isFalse);
+    });
+
+    test('returns true when function_declarations exists and non-empty', () {
+      final tools = <Map<String, dynamic>>[
+        {
+          'function_declarations': [
+            {'name': 'toolA', 'description': 'A tool'},
+          ],
+        },
+      ];
+      expect(shouldAttachGeminiFunctionCallingConfig(tools), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #317

## 问题
在 Gemini 请求仅使用内置工具（如 `google_search`）时，部分 Gemini 兼容后端不接受 `toolConfig.function_calling_config`，会返回 400：

`Function calling config is set without function_declarations`

## 原因
原逻辑只要 `tools` 非空就附带：

`toolConfig: { function_calling_config: { mode: "AUTO" } }`

这会把内置工具场景（`google_search` / `url_context` / `code_execution`）也一并带上 `toolConfig`，触发后端参数校验错误。

## 改动内容
本次提交涉及 3 个文件：

1. `lib/core/services/api/chat_api_service.dart`
引入 `gemini_tool_config.dart`，在 Gemini 请求构造的两条主要路径中，先计算 `shouldAttachToolConfig`。
仅当 `tools` 中存在 `function_declarations` 时，才附带 `toolConfig.function_calling_config = AUTO`。

2. `lib/core/services/api/gemini_tool_config.dart`
新增 `shouldAttachGeminiFunctionCallingConfig(...)` 纯函数，统一判断是否需要附带 `function_calling_config`。

3. `test/gemini_tool_config_test.dart`

## 验证结果

手工测试
端点：`/gemini/v1beta/models/gemini-2.5-flash:generateContent`

- 基础请求：`200`
- `google_search` + 无 `toolConfig`：`200`
- `google_search` + 有 `toolConfig`：`400`
- `function_declarations` + `toolConfig`：`200`

仅影响 Gemini 聊天请求中 `toolConfig` 的附带条件。
对已有 `function_declarations` 工具调用行为保持兼容。
