### PR TITLE
feat: 删除话题前增加确认弹窗

### DIFF
--- a/lib/features/home/widgets/side_drawer.dart
+++ b/lib/features/home/widgets/side_drawer.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 import 'package:characters/characters.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:http/http.dart' as http;
@@ -63,13 +62,11 @@ class SideDrawer extends StatefulWidget {
 
   final String userName;
   final String assistantName;
-  final FutureOr<void> Function(String id, {bool closeDrawer})?
-  onSelectConversation;
+  final FutureOr<void> Function(String id, {bool closeDrawer})? onSelectConversation;
   final FutureOr<void> Function({bool closeDrawer})? onNewConversation;
   final ValueNotifier<int>? closePickerTicker;
   final Set<String> loadingConversationIds;
-  final bool
-  embedded; // when true, render as a fixed side panel instead of a Drawer
+  final bool embedded; // when true, render as a fixed side panel instead of a Drawer
   final double? embeddedWidth; // optional explicit width for embedded mode
   final bool showBottomBar; // desktop can hide this bottom area
   final bool useDesktopTabs; // desktop-only: show tabs (Assistants/Topics)
@@ -81,10 +78,7 @@ class SideDrawer extends StatefulWidget {
 }
 
 class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
-  bool get _isDesktop =>
-      defaultTargetPlatform == TargetPlatform.macOS ||
-      defaultTargetPlatform == TargetPlatform.windows ||
-      defaultTargetPlatform == TargetPlatform.linux;
+  bool get _isDesktop => defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux;
   final TextEditingController _searchController = TextEditingController();
   String _query = '';
   final GlobalKey _assistantTileKey = GlobalKey();
@@ -97,68 +91,62 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
   StreamSubscription<int>? _tabBusSub;
 
   // Assistant avatar renderer shared across drawer views
-  Widget _assistantAvatar(
-    BuildContext context,
-    Assistant? a, {
-    double size = 28,
-    VoidCallback? onTap,
-  }) {
+  Widget _assistantAvatar(BuildContext context, Assistant? a, {double size = 28, VoidCallback? onTap}) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final av = a?.avatar?.trim() ?? '';
     final name = a?.name ?? '';
-
+    
     Widget avatar;
-    if (av.isNotEmpty) {
-      if (av.startsWith('http')) {
-        avatar = FutureBuilder<String?>(
-          future: AvatarCache.getPath(av),
-          builder: (ctx, snap) {
-            final p = snap.data;
-            if (p != null && File(p).existsSync()) {
+      if (av.isNotEmpty) {
+        if (av.startsWith('http')) {
+          avatar = FutureBuilder<String?>(
+            future: AvatarCache.getPath(av),
+            builder: (ctx, snap) {
+              final p = snap.data;
+              if (p != null && File(p).existsSync()) {
+                return ClipOval(
+                  child: Image(
+                    image: FileImage(File(p)),
+                    width: size,
+                    height: size,
+                    fit: BoxFit.cover,
+                  ),
+                );
+              }
               return ClipOval(
-                child: Image(
-                  image: FileImage(File(p)),
+                child: Image.network(
+                  av,
                   width: size,
                   height: size,
                   fit: BoxFit.cover,
+                  errorBuilder: (c, e, s) => _assistantInitialAvatar(cs, name, size),
                 ),
               );
-            }
-            return ClipOval(
-              child: Image.network(
-                av,
+            },
+          );
+        } else if (!kIsWeb && (av.startsWith('/') || av.contains(':'))) {
+          final fixed = SandboxPathResolver.fix(av);
+          final f = File(fixed);
+          if (f.existsSync()) {
+            avatar = ClipOval(
+              child: Image(
+                image: FileImage(f),
                 width: size,
                 height: size,
                 fit: BoxFit.cover,
-                errorBuilder: (c, e, s) =>
-                    _assistantInitialAvatar(cs, name, size),
               ),
             );
-          },
-        );
-      } else if (!kIsWeb && (av.startsWith('/') || av.contains(':'))) {
-        final fixed = SandboxPathResolver.fix(av);
-        final f = File(fixed);
-        if (f.existsSync()) {
-          avatar = ClipOval(
-            child: Image(
-              image: FileImage(f),
-              width: size,
-              height: size,
-              fit: BoxFit.cover,
-            ),
-          );
+          } else {
+            avatar = _assistantInitialAvatar(cs, name, size);
+          }
         } else {
-          avatar = _assistantInitialAvatar(cs, name, size);
+          avatar = _assistantEmojiAvatar(cs, av, size);
         }
       } else {
-        avatar = _assistantEmojiAvatar(cs, av, size);
+        avatar = _assistantInitialAvatar(cs, name, size);
       }
-    } else {
-      avatar = _assistantInitialAvatar(cs, name, size);
-    }
-
+    
     // Add border
     final child = Container(
       width: size,
@@ -237,13 +225,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     DesktopSidebarTabBus.instance.setCurrentIndex(_tabController!.index);
     _tabBusSub = DesktopSidebarTabBus.instance.stream.listen((idx) {
       if (widget.useDesktopTabs && mounted) {
-        try {
-          _tabController!.animateTo(
-            idx,
-            duration: const Duration(milliseconds: 140),
-            curve: Curves.easeOutCubic,
-          );
-        } catch (_) {}
+        try { _tabController!.animateTo(idx, duration: const Duration(milliseconds: 140), curve: Curves.easeOutCubic); } catch (_) {}
       }
     });
   }
@@ -254,16 +236,11 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     setState(() {}); // update search hint when switching tabs
   }
 
-  void _showChatMenu(
-    BuildContext context,
-    ChatItem chat, {
-    Offset? anchor,
-  }) async {
+  void _showChatMenu(BuildContext context, ChatItem chat, {Offset? anchor}) async {
     final l10n = AppLocalizations.of(context)!;
     final chatService = context.read<ChatService>();
     final isPinned = chatService.getConversation(chat.id)?.isPinned ?? false;
-    final isDesktop =
-        defaultTargetPlatform == TargetPlatform.macOS ||
+    final isDesktop = defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows ||
         defaultTargetPlatform == TargetPlatform.linux;
 
@@ -277,31 +254,24 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
           DesktopContextMenuItem(
             icon: Lucide.Edit,
             label: l10n.sideDrawerMenuRename,
-            onTap: () async {
-              await _renameChat(context, chat);
-            },
+            onTap: () async { await _renameChat(context, chat); },
           ),
           DesktopContextMenuItem(
             icon: Lucide.Pin,
             label: isPinned ? l10n.sideDrawerMenuUnpin : l10n.sideDrawerMenuPin,
-            onTap: () async {
-              await chatService.togglePinConversation(chat.id);
-            },
+            onTap: () async { await chatService.togglePinConversation(chat.id); },
           ),
           DesktopContextMenuItem(
             icon: Lucide.RefreshCw,
             label: l10n.sideDrawerMenuRegenerateTitle,
-            onTap: () async {
-              await _regenerateTitle(context, chat.id);
-            },
+            onTap: () async { await _regenerateTitle(context, chat.id); },
           ),
           DesktopContextMenuItem(
             icon: Lucide.Shuffle,
             label: l10n.sideDrawerMenuMoveTo,
             onTap: () async {
               final conv = chatService.getConversation(chat.id);
-              final movingCurrent =
-                  chatService.currentConversationId == chat.id;
+              final movingCurrent = chatService.currentConversationId == chat.id;
               // Pre-compute next recent conversation for current assistant
               String? nextId;
               try {
@@ -309,36 +279,20 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                 final currentAid = ap.currentAssistantId;
                 if (currentAid != null) {
                   final all = chatService.getAllConversations();
-                  final candidates =
-                      all
-                          .where(
-                            (c) =>
-                                c.assistantId == currentAid && c.id != chat.id,
-                          )
-                          .toList()
-                        ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+                  final candidates = all
+                      .where((c) => c.assistantId == currentAid && c.id != chat.id)
+                      .toList()
+                    ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
                   if (candidates.isNotEmpty) nextId = candidates.first.id;
                 }
               } catch (_) {}
-              final targetId = await showAssistantMoveSelector(
-                context,
-                excludeAssistantId: conv?.assistantId,
-              );
+              final targetId = await showAssistantMoveSelector(context, excludeAssistantId: conv?.assistantId);
               if (targetId != null) {
-                await chatService.moveConversationToAssistant(
-                  conversationId: chat.id,
-                  assistantId: targetId,
-                );
-                if (movingCurrent ||
-                    chatService.currentConversationId == null) {
-                  final closeDrawer = !context
-                      .read<SettingsProvider>()
-                      .keepSidebarOpenOnTopicTap;
+                await chatService.moveConversationToAssistant(conversationId: chat.id, assistantId: targetId);
+                if (movingCurrent || chatService.currentConversationId == null) {
+                  final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
                   if (nextId != null) {
-                    widget.onSelectConversation?.call(
-                      nextId!,
-                      closeDrawer: closeDrawer,
-                    );
+                    widget.onSelectConversation?.call(nextId!, closeDrawer: closeDrawer);
                   } else {
                     widget.onNewConversation?.call(closeDrawer: closeDrawer);
                   }
@@ -353,8 +307,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
             onTap: () async {
               final confirmed = await _confirmDeleteConversation(context, chat);
               if (!confirmed) return;
-              final deletingCurrent =
-                  chatService.currentConversationId == chat.id;
+              final deletingCurrent = chatService.currentConversationId == chat.id;
               final nextId = _nextRecentConversation(chatService, chat.id);
               await chatService.deleteConversation(chat.id);
               showAppSnackBar(
@@ -363,11 +316,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                 type: NotificationType.success,
                 duration: const Duration(seconds: 3),
               );
-              _handlePostDeleteNavigation(
-                chatService: chatService,
-                deletingCurrent: deletingCurrent,
-                nextConversationId: nextId,
-              );
+              _handlePostDeleteNavigation(chatService: chatService, deletingCurrent: deletingCurrent, nextConversationId: nextId);
               Navigator.of(context).maybePop();
             },
           ),
@@ -386,12 +335,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
         final maxH = MediaQuery.sizeOf(ctx).height * 0.8;
-        Widget row({
-          required IconData icon,
-          required String label,
-          Color? color,
-          required Future<void> Function() action,
-        }) {
+        Widget row({required IconData icon, required String label, Color? color, required Future<void> Function() action}) {
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: SizedBox(
@@ -414,11 +358,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                     Expanded(
                       child: Text(
                         label,
-                        style: TextStyle(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w500,
-                          color: color ?? cs.onSurface,
-                        ),
+                        style: TextStyle(fontSize: 15, fontWeight: FontWeight.w500, color: color ?? cs.onSurface),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -429,7 +369,6 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
             ),
           );
         }
-
         return SafeArea(
           top: false,
           child: ConstrainedBox(
@@ -455,33 +394,24 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                     row(
                       icon: Lucide.Edit,
                       label: l10n.sideDrawerMenuRename,
-                      action: () async {
-                        _renameChat(context, chat);
-                      },
+                      action: () async { _renameChat(context, chat); },
                     ),
                     row(
                       icon: Lucide.Pin,
-                      label: isPinned
-                          ? l10n.sideDrawerMenuUnpin
-                          : l10n.sideDrawerMenuPin,
-                      action: () async {
-                        await chatService.togglePinConversation(chat.id);
-                      },
+                      label: isPinned ? l10n.sideDrawerMenuUnpin : l10n.sideDrawerMenuPin,
+                      action: () async { await chatService.togglePinConversation(chat.id); },
                     ),
                     row(
                       icon: Lucide.RefreshCw,
                       label: l10n.sideDrawerMenuRegenerateTitle,
-                      action: () async {
-                        await _regenerateTitle(context, chat.id);
-                      },
+                      action: () async { await _regenerateTitle(context, chat.id); },
                     ),
                     row(
                       icon: Lucide.Shuffle,
                       label: l10n.sideDrawerMenuMoveTo,
                       action: () async {
                         final conv = chatService.getConversation(chat.id);
-                        final movingCurrent =
-                            chatService.currentConversationId == chat.id;
+                        final movingCurrent = chatService.currentConversationId == chat.id;
                         // Pre-compute next recent conversation for current assistant
                         String? nextId;
                         try {
@@ -489,45 +419,22 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                           final currentAid = ap.currentAssistantId;
                           if (currentAid != null) {
                             final all = chatService.getAllConversations();
-                            final candidates =
-                                all
-                                    .where(
-                                      (c) =>
-                                          c.assistantId == currentAid &&
-                                          c.id != chat.id,
-                                    )
-                                    .toList()
-                                  ..sort(
-                                    (a, b) =>
-                                        b.updatedAt.compareTo(a.updatedAt),
-                                  );
-                            if (candidates.isNotEmpty)
-                              nextId = candidates.first.id;
+                            final candidates = all
+                                .where((c) => c.assistantId == currentAid && c.id != chat.id)
+                                .toList()
+                              ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+                            if (candidates.isNotEmpty) nextId = candidates.first.id;
                           }
                         } catch (_) {}
-                        final targetId = await showAssistantMoveSelector(
-                          context,
-                          excludeAssistantId: conv?.assistantId,
-                        );
+                        final targetId = await showAssistantMoveSelector(context, excludeAssistantId: conv?.assistantId);
                         if (targetId != null) {
-                          await chatService.moveConversationToAssistant(
-                            conversationId: chat.id,
-                            assistantId: targetId,
-                          );
-                          if (movingCurrent ||
-                              chatService.currentConversationId == null) {
-                            final closeDrawer = !context
-                                .read<SettingsProvider>()
-                                .keepSidebarOpenOnTopicTap;
+                          await chatService.moveConversationToAssistant(conversationId: chat.id, assistantId: targetId);
+                          if (movingCurrent || chatService.currentConversationId == null) {
+                            final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
                             if (nextId != null) {
-                              widget.onSelectConversation?.call(
-                                nextId!,
-                                closeDrawer: closeDrawer,
-                              );
+                              widget.onSelectConversation?.call(nextId!, closeDrawer: closeDrawer);
                             } else {
-                              widget.onNewConversation?.call(
-                                closeDrawer: closeDrawer,
-                              );
+                              widget.onNewConversation?.call(closeDrawer: closeDrawer);
                             }
                           }
                         }
@@ -538,17 +445,10 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                       label: l10n.sideDrawerMenuDelete,
                       color: Colors.redAccent,
                       action: () async {
-                        final confirmed = await _confirmDeleteConversation(
-                          context,
-                          chat,
-                        );
+                        final confirmed = await _confirmDeleteConversation(context, chat);
                         if (!confirmed) return;
-                        final deletingCurrent =
-                            chatService.currentConversationId == chat.id;
-                        final nextId = _nextRecentConversation(
-                          chatService,
-                          chat.id,
-                        );
+                        final deletingCurrent = chatService.currentConversationId == chat.id;
+                        final nextId = _nextRecentConversation(chatService, chat.id);
                         await chatService.deleteConversation(chat.id);
                         showAppSnackBar(
                           context,
@@ -556,11 +456,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                           type: NotificationType.success,
                           duration: const Duration(seconds: 3),
                         );
-                        _handlePostDeleteNavigation(
-                          chatService: chatService,
-                          deletingCurrent: deletingCurrent,
-                          nextConversationId: nextId,
-                        );
+                        _handlePostDeleteNavigation(chatService: chatService, deletingCurrent: deletingCurrent, nextConversationId: nextId);
                         Navigator.of(context).maybePop();
                       },
                     ),
@@ -575,10 +471,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     );
   }
 
-  Future<bool> _confirmDeleteConversation(
-    BuildContext context,
-    ChatItem chat,
-  ) async {
+  Future<bool> _confirmDeleteConversation(BuildContext context, ChatItem chat) async {
     final l10n = AppLocalizations.of(context)!;
     final confirmed = await showDialog<bool>(
       context: context,
@@ -610,12 +503,11 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       final ap = context.read<AssistantProvider>();
       final currentAid = ap.currentAssistantId;
       if (currentAid == null) return null;
-      final candidates =
-          chatService
-              .getAllConversations()
-              .where((c) => c.assistantId == currentAid && c.id != excludeId)
-              .toList()
-            ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      final candidates = chatService
+          .getAllConversations()
+          .where((c) => c.assistantId == currentAid && c.id != excludeId)
+          .toList()
+        ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
       if (candidates.isEmpty) return null;
       return candidates.first.id;
     } catch (_) {
@@ -629,19 +521,14 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     required String? nextConversationId,
   }) {
     if (!(deletingCurrent || chatService.currentConversationId == null)) return;
-    final closeDrawer = !context
-        .read<SettingsProvider>()
-        .keepSidebarOpenOnTopicTap;
+    final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
     final preferNewChat = context.read<SettingsProvider>().newChatAfterDelete;
     if (preferNewChat && widget.onNewConversation != null) {
       widget.onNewConversation!.call(closeDrawer: closeDrawer);
       return;
     }
     if (!preferNewChat && nextConversationId != null) {
-      widget.onSelectConversation?.call(
-        nextConversationId,
-        closeDrawer: closeDrawer,
-      );
+      widget.onSelectConversation?.call(nextConversationId, closeDrawer: closeDrawer);
       return;
     }
     if (widget.onNewConversation != null) {
@@ -649,10 +536,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       return;
     }
     if (nextConversationId != null) {
-      widget.onSelectConversation?.call(
-        nextConversationId,
-        closeDrawer: closeDrawer,
-      );
+      widget.onSelectConversation?.call(nextConversationId, closeDrawer: closeDrawer);
     }
   }
 
@@ -667,7 +551,9 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
           content: TextField(
             controller: controller,
             autofocus: true,
-            decoration: InputDecoration(hintText: l10n.sideDrawerRenameHint),
+            decoration: InputDecoration(
+              hintText: l10n.sideDrawerRenameHint,
+            ),
             onSubmitted: (_) => Navigator.of(ctx).pop(true),
           ),
           actions: [
@@ -684,47 +570,28 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       },
     );
     if (ok == true) {
-      await context.read<ChatService>().renameConversation(
-        chat.id,
-        controller.text.trim(),
-      );
+      await context.read<ChatService>().renameConversation(chat.id, controller.text.trim());
     }
   }
 
-  Future<void> _regenerateTitle(
-    BuildContext context,
-    String conversationId,
-  ) async {
+  Future<void> _regenerateTitle(BuildContext context, String conversationId) async {
     final settings = context.read<SettingsProvider>();
     final chatService = context.read<ChatService>();
     final convo = chatService.getConversation(conversationId);
     if (convo == null) return;
     // Decide model
-    final provKey =
-        settings.titleModelProvider ?? settings.currentModelProvider;
+    final provKey = settings.titleModelProvider ?? settings.currentModelProvider;
     final mdlId = settings.titleModelId ?? settings.currentModelId;
     if (provKey == null || mdlId == null) return;
     final cfg = settings.getProviderConfig(provKey);
     // Content
     final msgs = chatService.getMessages(conversationId);
-    final joined = msgs
-        .where((m) => m.content.isNotEmpty)
-        .map(
-          (m) =>
-              '${m.role == 'assistant' ? 'Assistant' : 'User'}: ${m.content}',
-        )
-        .join('\n\n');
+    final joined = msgs.where((m) => m.content.isNotEmpty).map((m) => '${m.role == 'assistant' ? 'Assistant' : 'User'}: ${m.content}').join('\n\n');
     final content = joined.length > 3000 ? joined.substring(0, 3000) : joined;
     final locale = Localizations.localeOf(context).toLanguageTag();
-    final prompt = settings.titlePrompt
-        .replaceAll('{locale}', locale)
-        .replaceAll('{content}', content);
+    final prompt = settings.titlePrompt.replaceAll('{locale}', locale).replaceAll('{content}', content);
     try {
-      final title = (await ChatApiService.generateText(
-        config: cfg,
-        modelId: mdlId,
-        prompt: prompt,
-      )).trim();
+      final title = (await ChatApiService.generateText(config: cfg, modelId: mdlId, prompt: prompt)).trim();
       if (title.isNotEmpty) {
         await chatService.renameConversation(conversationId, title);
       }
@@ -740,9 +607,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     _listController.dispose();
     _tabController?.removeListener(_onDesktopTabChanged);
     _tabController?.dispose();
-    try {
-      _tabBusSub?.cancel();
-    } catch (_) {}
+    try { _tabBusSub?.cancel(); } catch (_) {}
     super.dispose();
   }
 
@@ -771,6 +636,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     _closeAssistantPicker();
   }
 
+
   String _greeting(BuildContext context) {
     final hour = DateTime.now().hour;
     final l10n = AppLocalizations.of(context)!;
@@ -789,9 +655,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     if (diff == 0) return l10n.sideDrawerDateToday;
     if (diff == 1) return l10n.sideDrawerDateYesterday;
     final sameYear = now.year == date.year;
-    final pattern = sameYear
-        ? l10n.sideDrawerDateShortPattern
-        : l10n.sideDrawerDateFullPattern;
+    final pattern = sameYear ? l10n.sideDrawerDateShortPattern : l10n.sideDrawerDateFullPattern;
     final fmt = DateFormat(pattern);
     return fmt.format(date);
   }
@@ -805,13 +669,14 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       map.putIfAbsent(d, () => []).add(c);
     }
     // sort groups by date desc (recent first)
-    final keys = map.keys.toList()..sort((a, b) => b.compareTo(a));
+    final keys = map.keys.toList()
+      ..sort((a, b) => b.compareTo(a));
     return [
       for (final k in keys)
         _ChatGroup(
           label: _dateLabel(context, k),
           items: (map[k]!..sort((a, b) => b.created.compareTo(a.created)))!,
-        ),
+        )
     ];
   }
 
@@ -827,9 +692,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     final currentAssistantId = ap.currentAssistantId;
     final conversations = chatService
         .getAllConversations()
-        .where(
-          (c) => c.assistantId == currentAssistantId || c.assistantId == null,
-        )
+        .where((c) => c.assistantId == currentAssistantId || c.assistantId == null)
         .toList();
     // Use last-activity time (updatedAt) for ordering and grouping
     final all = conversations
@@ -838,18 +701,11 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
 
     final base = _query.trim().isEmpty
         ? all
-        : all
-              .where(
-                (c) => c.title.toLowerCase().contains(_query.toLowerCase()),
-              )
-              .toList();
-    final pinnedList =
-        base
-            .where(
-              (c) => (chatService.getConversation(c.id)?.isPinned ?? false),
-            )
-            .toList()
-          ..sort((a, b) => b.created.compareTo(a.created));
+        : all.where((c) => c.title.toLowerCase().contains(_query.toLowerCase())).toList();
+    final pinnedList = base
+        .where((c) => (chatService.getConversation(c.id)?.isPinned ?? false))
+        .toList()
+      ..sort((a, b) => b.created.compareTo(a.created));
     final rest = base
         .where((c) => !(chatService.getConversation(c.id)?.isPinned ?? false))
         .toList();
@@ -904,14 +760,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                     color: cs.primary.withOpacity(0.15),
                     shape: BoxShape.circle,
                   ),
-                  child: Text(
-                    '?',
-                    style: TextStyle(
-                      color: cs.primary,
-                      fontSize: size * 0.42,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
+                  child: Text('?', style: TextStyle(color: cs.primary, fontSize: size * 0.42, fontWeight: FontWeight.w700)),
                 ),
               ),
             );
@@ -954,567 +803,422 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     }
 
     // Desktop-only: enable tabs for embedded sidebar when requested
-    final bool _assistOnly =
-        widget.desktopAssistantsOnly && _isDesktop && widget.embedded;
-    final bool _topicsOnly =
-        widget.desktopTopicsOnly && _isDesktop && widget.embedded;
-    final bool _useTabs =
-        widget.useDesktopTabs &&
-        _isDesktop &&
-        widget.embedded &&
-        !_assistOnly &&
-        !_topicsOnly;
+    final bool _assistOnly = widget.desktopAssistantsOnly && _isDesktop && widget.embedded;
+    final bool _topicsOnly = widget.desktopTopicsOnly && _isDesktop && widget.embedded;
+    final bool _useTabs = widget.useDesktopTabs && _isDesktop && widget.embedded && !_assistOnly && !_topicsOnly;
 
     final inner = SafeArea(
       child: Stack(
         children: [
-          // Main column content
-          Column(
-            children: [
-              // Fixed header + search
-              Padding(
-                padding: EdgeInsets.fromLTRB(16, _isDesktop ? 10 : 4, 16, 0),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // 1. 搜索框 + 历史按钮（固定头部）
-                    if (_isDesktop)
-                      // 桌面端
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        child: AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 240),
-                          switchInCurve: Curves.easeOutCubic,
-                          switchOutCurve: Curves.easeInCubic,
-                          transitionBuilder: (child, anim) =>
-                              FadeTransition(opacity: anim, child: child),
-                          child: Row(
-                            key: ValueKey<String>(
-                              (() {
-                                final l10n = AppLocalizations.of(context)!;
-                                String hint;
-                                if (_useTabs) {
-                                  hint = ((_tabController?.index ?? 0) == 0)
-                                      ? l10n.sideDrawerSearchAssistantsHint
-                                      : l10n.sideDrawerSearchHint;
-                                } else if (_assistOnly) {
-                                  hint = l10n.sideDrawerSearchAssistantsHint;
-                                } else {
-                                  hint = l10n.sideDrawerSearchHint;
-                                }
-                                return hint;
-                              })(),
-                            ),
-                            children: [
-                              Expanded(
-                                child: TextField(
-                                  controller: _searchController,
-                                  decoration: InputDecoration(
-                                    hintText: (() {
-                                      final l10n = AppLocalizations.of(
-                                        context,
-                                      )!;
-                                      if (_useTabs) {
-                                        return ((_tabController?.index ?? 0) ==
-                                                0)
-                                            ? l10n.sideDrawerSearchAssistantsHint
-                                            : l10n.sideDrawerSearchHint;
-                                      }
-                                      if (_assistOnly)
-                                        return l10n
-                                            .sideDrawerSearchAssistantsHint;
-                                      return l10n.sideDrawerSearchHint;
-                                    })(),
-                                    filled: true,
-                                    fillColor: isDark
-                                        ? Colors.white10
-                                        : Colors.grey.shade200.withOpacity(
-                                            0.80,
-                                          ),
-                                    isDense: true,
-                                    isCollapsed: true,
-                                    prefixIcon: Padding(
-                                      padding: const EdgeInsets.only(
-                                        left: 10,
-                                        right: 4,
-                                      ),
-                                      child: Icon(
-                                        Lucide.Search,
-                                        size: 16,
-                                        color: textBase.withOpacity(0.6),
-                                      ),
-                                    ),
-                                    prefixIconConstraints: const BoxConstraints(
-                                      minWidth: 0,
-                                      minHeight: 0,
-                                    ),
-                                    // 右侧（话题列表）不需要历史入口（左侧已有）；左侧或默认仍保留
-                                    suffixIcon: _topicsOnly
-                                        ? null
-                                        : Padding(
-                                            padding: const EdgeInsets.only(
-                                              right: 6,
-                                            ),
-                                            child: IosIconButton(
-                                              size: 16,
-                                              color: textBase,
-                                              icon: Lucide.History,
-                                              padding: const EdgeInsets.all(4),
-                                              onTap: () async {
-                                                final selectedId =
-                                                    await showChatHistoryDesktopDialog(
-                                                      context,
-                                                      assistantId:
-                                                          currentAssistantId,
-                                                    );
-                                                if (selectedId != null &&
-                                                    selectedId.isNotEmpty) {
-                                                  final closeDrawer = !context
-                                                      .read<SettingsProvider>()
-                                                      .keepSidebarOpenOnTopicTap;
-                                                  widget.onSelectConversation
-                                                      ?.call(
-                                                        selectedId,
-                                                        closeDrawer:
-                                                            closeDrawer,
-                                                      );
-                                                }
-                                              },
-                                            ),
-                                          ),
-                                    suffixIconConstraints: const BoxConstraints(
-                                      minWidth: 0,
-                                      minHeight: 0,
-                                    ),
-                                    contentPadding: const EdgeInsets.symmetric(
-                                      horizontal: 14,
-                                      vertical: 11,
-                                    ),
-                                    border: OutlineInputBorder(
-                                      borderRadius: BorderRadius.circular(14),
-                                      borderSide: const BorderSide(
-                                        color: Colors.transparent,
-                                      ),
-                                    ),
-                                    enabledBorder: OutlineInputBorder(
-                                      borderRadius: BorderRadius.circular(14),
-                                      borderSide: const BorderSide(
-                                        color: Colors.transparent,
-                                      ),
-                                    ),
-                                    focusedBorder: OutlineInputBorder(
-                                      borderRadius: BorderRadius.circular(14),
-                                      borderSide: const BorderSide(
-                                        color: Colors.transparent,
-                                      ),
-                                    ),
-                                  ),
-                                  textAlignVertical: TextAlignVertical.center,
-                                  style: TextStyle(
-                                    color: textBase,
-                                    fontSize: 14,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      )
-                    else
-                      Row(
-                        children: [
+            // Main column content
+            Column(
+              children: [
+            // Fixed header + search
+            Padding(
+              padding: EdgeInsets.fromLTRB(16, _isDesktop ? 10 : 4, 16, 0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // 1. 搜索框 + 历史按钮（固定头部）
+                  if (_isDesktop)
+                    // 桌面端
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 2),
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 240),
+                        switchInCurve: Curves.easeOutCubic,
+                        switchOutCurve: Curves.easeInCubic,
+                        transitionBuilder: (child, anim) => FadeTransition(opacity: anim, child: child),
+                        child: Row(
+                          key: ValueKey<String>((() {
+                            final l10n = AppLocalizations.of(context)!;
+                            String hint;
+                            if (_useTabs) {
+                              hint = ((_tabController?.index ?? 0) == 0)
+                                  ? l10n.sideDrawerSearchAssistantsHint
+                                  : l10n.sideDrawerSearchHint;
+                            } else if (_assistOnly) {
+                              hint = l10n.sideDrawerSearchAssistantsHint;
+                            } else {
+                              hint = l10n.sideDrawerSearchHint;
+                            }
+                            return hint;
+                          })()),
+                          children: [
                           Expanded(
                             child: TextField(
                               controller: _searchController,
                               decoration: InputDecoration(
-                                hintText: AppLocalizations.of(
-                                  context,
-                                )!.sideDrawerSearchHint,
+                                hintText: (() {
+                                  final l10n = AppLocalizations.of(context)!;
+                                  if (_useTabs) {
+                                    return ((_tabController?.index ?? 0) == 0)
+                                        ? l10n.sideDrawerSearchAssistantsHint
+                                        : l10n.sideDrawerSearchHint;
+                                  }
+                                  if (_assistOnly) return l10n.sideDrawerSearchAssistantsHint;
+                                  return l10n.sideDrawerSearchHint;
+                                })(),
                                 filled: true,
-                                fillColor: isDark
-                                    ? Colors.white10
-                                    : Colors.grey.shade200.withOpacity(0.80),
+                                fillColor: isDark ? Colors.white10 : Colors.grey.shade200.withOpacity(0.80),
                                 isDense: true,
                                 isCollapsed: true,
                                 prefixIcon: Padding(
-                                  padding: const EdgeInsets.only(
-                                    left: 10,
-                                    right: 4,
-                                  ),
+                                  padding: const EdgeInsets.only(left: 10, right: 4),
                                   child: Icon(
                                     Lucide.Search,
                                     size: 16,
                                     color: textBase.withOpacity(0.6),
                                   ),
                                 ),
-                                prefixIconConstraints: const BoxConstraints(
-                                  minWidth: 0,
-                                  minHeight: 0,
+                                prefixIconConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
+                                // 右侧（话题列表）不需要历史入口（左侧已有）；左侧或默认仍保留
+                                suffixIcon: _topicsOnly ? null : Padding(
+                                  padding: const EdgeInsets.only(right: 6),
+                                  child: IosIconButton(
+                                    size: 16,
+                                    color: textBase,
+                                    icon: Lucide.History,
+                                    padding: const EdgeInsets.all(4),
+                                    onTap: () async {
+                                      final selectedId = await showChatHistoryDesktopDialog(context, assistantId: currentAssistantId);
+                                      if (selectedId != null && selectedId.isNotEmpty) {
+                                        final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
+                                        widget.onSelectConversation?.call(selectedId, closeDrawer: closeDrawer);
+                                      }
+                                    },
+                                  ),
                                 ),
+                                suffixIconConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
                                 contentPadding: const EdgeInsets.symmetric(
                                   horizontal: 14,
-                                  vertical: 10,
+                                  vertical: 11,
                                 ),
                                 border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(16),
-                                  borderSide: const BorderSide(
-                                    color: Colors.transparent,
-                                  ),
+                                  borderRadius: BorderRadius.circular(14),
+                                  borderSide: const BorderSide(color: Colors.transparent),
                                 ),
                                 enabledBorder: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(16),
-                                  borderSide: const BorderSide(
-                                    color: Colors.transparent,
-                                  ),
+                                  borderRadius: BorderRadius.circular(14),
+                                  borderSide: const BorderSide(color: Colors.transparent),
                                 ),
                                 focusedBorder: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(16),
-                                  borderSide: const BorderSide(
-                                    color: Colors.transparent,
-                                  ),
+                                  borderRadius: BorderRadius.circular(14),
+                                  borderSide: const BorderSide(color: Colors.transparent),
                                 ),
                               ),
                               textAlignVertical: TextAlignVertical.center,
                               style: TextStyle(color: textBase, fontSize: 14),
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          // 历史按钮（圆形，无水波纹）
-                          SizedBox(
-                            width: 44,
-                            height: 44,
-                            child: Center(
-                              child: IosIconButton(
-                                size: 20,
-                                color: textBase,
-                                icon: Lucide.History,
-                                padding: const EdgeInsets.all(8),
-                                onTap: () async {
-                                  final selectedId = await Navigator.of(context)
-                                      .push<String>(
-                                        MaterialPageRoute(
-                                          builder: (_) => ChatHistoryPage(
-                                            assistantId: currentAssistantId,
-                                          ),
-                                        ),
-                                      );
-                                  if (selectedId != null &&
-                                      selectedId.isNotEmpty) {
-                                    final closeDrawer = !context
-                                        .read<SettingsProvider>()
-                                        .keepSidebarOpenOnTopicTap;
-                                    widget.onSelectConversation?.call(
-                                      selectedId,
-                                      closeDrawer: closeDrawer,
-                                    );
-                                  }
-                                },
-                              ),
-                            ),
-                          ),
                         ],
                       ),
-
-                    SizedBox(height: _isDesktop ? 8 : 12),
-
-                    // 桌面端：替换为 Tab（助手 / 话题）
-                    if (_useTabs)
-                      _DesktopSidebarTabs(
-                        textColor: textBase,
-                        controller: _tabController!,
-                      )
-                    else if (!_assistOnly && !_topicsOnly)
-                      // 当前助手区域（固定）
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        child: KeyedSubtree(
-                          key: _assistantTileKey,
-                          child: MouseRegion(
-                            onEnter: (_) {
-                              if (_isDesktop)
-                                setState(() => _assistantHeaderHovered = true);
-                            },
-                            onExit: (_) {
-                              if (_isDesktop)
-                                setState(() => _assistantHeaderHovered = false);
-                            },
-                            cursor: _isDesktop
-                                ? SystemMouseCursors.click
-                                : SystemMouseCursors.basic,
-                            child: IosCardPress(
-                              baseColor: (() {
-                                final embedded = widget.embedded;
-                                final base = embedded
-                                    ? Colors.transparent
-                                    : cs.surface;
-                                if (_isDesktop && _assistantHeaderHovered) {
-                                  return embedded
-                                      ? cs.primary.withOpacity(0.08)
-                                      : cs.surface.withOpacity(0.9);
+                      ),
+                    )
+                  else
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: _searchController,
+                            decoration: InputDecoration(
+                              hintText: AppLocalizations.of(context)!.sideDrawerSearchHint,
+                              filled: true,
+                              fillColor: isDark ? Colors.white10 : Colors.grey.shade200.withOpacity(0.80),
+                              isDense: true,
+                              isCollapsed: true,
+                              prefixIcon: Padding(
+                                padding: const EdgeInsets.only(left: 10, right: 4),
+                                child: Icon(
+                                  Lucide.Search,
+                                  size: 16,
+                                  color: textBase.withOpacity(0.6),
+                                ),
+                              ),
+                              prefixIconConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 10,
+                              ),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(16),
+                                borderSide: const BorderSide(color: Colors.transparent),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(16),
+                                borderSide: const BorderSide(color: Colors.transparent),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(16),
+                                borderSide: const BorderSide(color: Colors.transparent),
+                              ),
+                            ),
+                            textAlignVertical: TextAlignVertical.center,
+                            style: TextStyle(color: textBase, fontSize: 14),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        // 历史按钮（圆形，无水波纹）
+                        SizedBox(
+                          width: 44,
+                          height: 44,
+                          child: Center(
+                            child: IosIconButton(
+                              size: 20,
+                              color: textBase,
+                              icon: Lucide.History,
+                              padding: const EdgeInsets.all(8),
+                              onTap: () async {
+                                final selectedId = await Navigator.of(context).push<String>(
+                                  MaterialPageRoute(builder: (_) => ChatHistoryPage(assistantId: currentAssistantId)),
+                                );
+                                if (selectedId != null && selectedId.isNotEmpty) {
+                                  final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
+                                  widget.onSelectConversation?.call(selectedId, closeDrawer: closeDrawer);
                                 }
-                                return base;
-                              })(),
-                              borderRadius: BorderRadius.circular(16),
-                              onTap: _toggleAssistantPicker,
-                              onLongPress: _isDesktop
-                                  ? null
-                                  : () {
-                                      _closeAssistantPicker();
-                                      final id = context
-                                          .read<AssistantProvider>()
-                                          .currentAssistantId;
-                                      if (id != null) {
-                                        Navigator.of(context).push(
-                                          MaterialPageRoute(
-                                            builder: (_) =>
-                                                AssistantSettingsEditPage(
-                                                  assistantId: id,
-                                                ),
-                                          ),
-                                        );
-                                      }
-                                    },
-                              padding: const EdgeInsets.fromLTRB(4, 6, 12, 6),
-                              child: Row(
-                                children: [
-                                  _assistantAvatar(
-                                    context,
-                                    ap.currentAssistant,
-                                    size: 32,
-                                  ),
-                                  const SizedBox(width: 16),
-                                  Expanded(
-                                    child: Text(
-                                      (ap.currentAssistant?.name ??
-                                          widget.assistantName),
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: TextStyle(
-                                        fontSize: _isDesktop ? 14 : 15,
-                                        fontWeight: FontWeight.w500,
-                                        color: textBase,
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  AnimatedRotation(
-                                    turns: _assistantsExpanded ? 0.5 : 0.0,
-                                    duration: const Duration(milliseconds: 350),
-                                    curve: Curves.easeOutCubic,
-                                    child: Icon(
-                                      Lucide.ChevronDown,
-                                      size: 18,
-                                      color: textBase.withOpacity(0.7),
-                                    ),
-                                  ),
-                                ],
-                              ),
+                              },
                             ),
                           ),
                         ),
-                      ),
-
-                    // 注意：内联助手列表已移动至下方可滚动区域
-                  ],
-                ),
-              ),
-
-              // Scrollable area below header
-              Expanded(
-                child: () {
-                  if (_useTabs) {
-                    return _DesktopTabViews(
-                      controller: _tabController!,
-                      listController: _listController,
-                      buildAssistants: () => _buildAssistantsList(context),
-                      buildConversations: () => _buildConversationsList(
-                        context,
-                        cs,
-                        textBase,
-                        chatService,
-                        pinnedList,
-                        groups,
-                        includeUpdateBanner: true,
-                      ),
-                    );
-                  }
-                  if (_assistOnly) {
-                    return ListView(
-                      controller: _listController,
-                      padding: const EdgeInsets.fromLTRB(10, 2, 10, 16),
-                      children: [
-                        _buildAssistantsList(context, inlineMode: true),
                       ],
-                    );
-                  }
-                  if (_topicsOnly) {
-                    final isDesktop = _isDesktop;
-                    final topPad =
-                        context.watch<SettingsProvider>().showChatListDate
-                        ? (isDesktop ? 2.0 : 4.0)
-                        : 10.0;
-                    return ListView(
-                      controller: _listController,
-                      padding: EdgeInsets.fromLTRB(10, topPad, 10, 16),
-                      children: [
-                        _buildConversationsList(
-                          context,
-                          cs,
-                          textBase,
-                          chatService,
-                          pinnedList,
-                          groups,
-                          includeUpdateBanner: true,
-                        ),
-                      ],
-                    );
-                  }
-                  return _LegacyListArea(
-                    listController: _listController,
-                    isDesktop: _isDesktop,
-                    assistantsExpanded: _assistantsExpanded,
-                    buildAssistants: () =>
-                        _buildAssistantsList(context, inlineMode: true),
-                    buildConversations: () => _buildConversationsList(
-                      context,
-                      cs,
-                      textBase,
-                      chatService,
-                      pinnedList,
-                      groups,
-                      includeUpdateBanner: true,
                     ),
-                  );
-                }(),
-              ),
 
-              if (widget.showBottomBar && (!widget.embedded || !_isDesktop))
-                Container(
-                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
-                  decoration: BoxDecoration(
-                    color: widget.embedded ? Colors.transparent : cs.surface,
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          const SizedBox(width: 6),
-                          // 用户头像（可点击更换）—移除水波纹
-                          GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: () => _editAvatar(context),
-                            child: avatarWidget(
-                              widget.userName,
-                              context.watch<UserProvider>(),
-                              size: 40,
-                            ),
-                          ),
-                          const SizedBox(width: 20),
-                          // 用户名称（可点击编辑，垂直居中）
-                          Expanded(
-                            child: IosCardPress(
-                              borderRadius: BorderRadius.circular(6),
-                              baseColor: Colors.transparent,
-                              onTap: () => _editUserName(context),
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 0,
-                              ),
-                              child: SizedBox(
-                                height: 45,
-                                child: Align(
-                                  alignment: Alignment.centerLeft,
+                  SizedBox(height: _isDesktop ? 8 : 12),
+                  
+                  // 桌面端：替换为 Tab（助手 / 话题）
+                  if (_useTabs)
+                    _DesktopSidebarTabs(textColor: textBase, controller: _tabController!)
+                  else if (!_assistOnly && !_topicsOnly)
+                    // 当前助手区域（固定）
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 2),
+                      child: KeyedSubtree(
+                        key: _assistantTileKey,
+                        child: MouseRegion(
+                          onEnter: (_) { if (_isDesktop) setState(() => _assistantHeaderHovered = true); },
+                          onExit: (_) { if (_isDesktop) setState(() => _assistantHeaderHovered = false); },
+                          cursor: _isDesktop ? SystemMouseCursors.click : SystemMouseCursors.basic,
+                          child: IosCardPress(
+                            baseColor: (() {
+                              final embedded = widget.embedded;
+                              final base = embedded ? Colors.transparent : cs.surface;
+                              if (_isDesktop && _assistantHeaderHovered) {
+                                return embedded ? cs.primary.withOpacity(0.08) : cs.surface.withOpacity(0.9);
+                              }
+                              return base;
+                            })(),
+                            borderRadius: BorderRadius.circular(16),
+                            onTap: _toggleAssistantPicker,
+                            onLongPress: _isDesktop ? null : () {
+                              _closeAssistantPicker();
+                              final id = context.read<AssistantProvider>().currentAssistantId;
+                              if (id != null) {
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(builder: (_) => AssistantSettingsEditPage(assistantId: id)),
+                                );
+                              }
+                            },
+                            padding: const EdgeInsets.fromLTRB(4, 6, 12, 6),
+                            child: Row(
+                              children: [
+                                _assistantAvatar(
+                                  context,
+                                  ap.currentAssistant,
+                                  size: 32,
+                                ),
+                                const SizedBox(width: 16),
+                                Expanded(
                                   child: Text(
-                                    widget.userName,
+                                    (ap.currentAssistant?.name ?? widget.assistantName),
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
-                                    style: TextStyle(
-                                      fontSize: _isDesktop ? 14 : 16,
-                                      fontWeight: FontWeight.w700,
-                                      color: textBase,
-                                    ),
+                                    style: TextStyle(fontSize: _isDesktop ? 14 : 15, fontWeight: FontWeight.w500, color: textBase),
                                   ),
+                                ),
+                                const SizedBox(width: 8),
+                                AnimatedRotation(
+                                  turns: _assistantsExpanded ? 0.5 : 0.0,
+                                  duration: const Duration(milliseconds: 350),
+                                  curve: Curves.easeOutCubic,
+                                  child: Icon(
+                                    Lucide.ChevronDown,
+                                    size: 18,
+                                    color: textBase.withOpacity(0.7),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+
+                  // 注意：内联助手列表已移动至下方可滚动区域
+                ],
+              ),
+            ),
+
+            // Scrollable area below header
+            Expanded(
+              child: () {
+                if (_useTabs) {
+                  return _DesktopTabViews(
+                    controller: _tabController!,
+                    listController: _listController,
+                    buildAssistants: () => _buildAssistantsList(context),
+                    buildConversations: () => _buildConversationsList(context, cs, textBase, chatService, pinnedList, groups, includeUpdateBanner: true),
+                  );
+                }
+                if (_assistOnly) {
+                  return ListView(
+                    controller: _listController,
+                    padding: const EdgeInsets.fromLTRB(10, 2, 10, 16),
+                    children: [
+                      _buildAssistantsList(context, inlineMode: true),
+                    ],
+                  );
+                }
+                if (_topicsOnly) {
+                  final isDesktop = _isDesktop;
+                  final topPad = context.watch<SettingsProvider>().showChatListDate ? (isDesktop ? 2.0 : 4.0) : 10.0;
+                  return ListView(
+                    controller: _listController,
+                    padding: EdgeInsets.fromLTRB(10, topPad, 10, 16),
+                    children: [
+                      _buildConversationsList(context, cs, textBase, chatService, pinnedList, groups, includeUpdateBanner: true),
+                    ],
+                  );
+                }
+                return _LegacyListArea(
+                  listController: _listController,
+                  isDesktop: _isDesktop,
+                  assistantsExpanded: _assistantsExpanded,
+                  buildAssistants: () => _buildAssistantsList(context, inlineMode: true),
+                  buildConversations: () => _buildConversationsList(context, cs, textBase, chatService, pinnedList, groups, includeUpdateBanner: true),
+                );
+              }(),
+            ),
+
+            if (widget.showBottomBar && (!widget.embedded || !_isDesktop)) Container(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+              decoration: BoxDecoration(
+                color: widget.embedded ? Colors.transparent : cs.surface,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      const SizedBox(width: 6),
+                      // 用户头像（可点击更换）—移除水波纹
+                      GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => _editAvatar(context),
+                        child: avatarWidget(
+                          widget.userName,
+                          context.watch<UserProvider>(),
+                          size: 40,
+                        ),
+                      ),
+                      const SizedBox(width: 20),
+                      // 用户名称（可点击编辑，垂直居中）
+                      Expanded(
+                        child: IosCardPress(
+                          borderRadius: BorderRadius.circular(6),
+                          baseColor: Colors.transparent,
+                          onTap: () => _editUserName(context),
+                          padding: const EdgeInsets.symmetric(horizontal: 0),
+                          child: SizedBox(
+                            height: 45,
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                widget.userName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: _isDesktop ? 14 : 16,
+                                  fontWeight: FontWeight.w700,
+                                  color: textBase,
                                 ),
                               ),
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          // 翻译按钮（圆形，无水波纹）
-                          SizedBox(
-                            width: 45,
-                            height: 45,
-                            child: Center(
-                              child: IosIconButton(
-                                size: 22,
-                                color: textBase,
-                                icon: Lucide.Languages,
-                                padding: const EdgeInsets.all(10),
-                                onTap: () {
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (_) => const TranslatePage(),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      // 翻译按钮（圆形，无水波纹）
+                      SizedBox(
+                        width: 45,
+                        height: 45,
+                        child: Center(
+                          child: IosIconButton(
+                            size: 22,
+                            color: textBase,
+                            icon: Lucide.Languages,
+                            padding: const EdgeInsets.all(10),
+                            onTap: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(builder: (_) => const TranslatePage()),
+                              );
+                            },
                           ),
-                          const SizedBox(width: 4),
-                          // 设置按钮（圆形，无水波纹）
-                          SizedBox(
-                            width: 45,
-                            height: 45,
-                            child: Center(
-                              child: IosIconButton(
-                                size: 22,
-                                color: textBase,
-                                icon: Lucide.Settings,
-                                padding: const EdgeInsets.all(10),
-                                onTap: () {
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (_) => const SettingsPage(),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      // 设置按钮（圆形，无水波纹）
+                      SizedBox(
+                        width: 45,
+                        height: 45,
+                        child: Center(
+                          child: IosIconButton(
+                            size: 22,
+                            color: textBase,
+                            icon: Lucide.Settings,
+                            padding: const EdgeInsets.all(10),
+                            onTap: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(builder: (_) => const SettingsPage()),
+                              );
+                            },
                           ),
-                        ],
+                        ),
                       ),
                     ],
                   ),
-                ),
-            ],
-          ),
+                ],
+              ),
+            ),
+              ],
+            ),
 
-          // iOS-style blur/fade effect above user area
-          if (!widget.embedded)
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 62, // Approximate height of user area
-              child: IgnorePointer(
-                child: Container(
-                  height: 20,
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        cs.surface.withOpacity(0.0),
-                        cs.surface.withOpacity(0.8),
-                        cs.surface.withOpacity(1.0),
-                      ],
-                      stops: const [0.0, 0.6, 1.0],
+            // iOS-style blur/fade effect above user area
+            if (!widget.embedded)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 62, // Approximate height of user area
+                child: IgnorePointer(
+                  child: Container(
+                    height: 20,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          cs.surface.withOpacity(0.0),
+                          cs.surface.withOpacity(0.8),
+                          cs.surface.withOpacity(1.0),
+                        ],
+                        stops: const [0.0, 0.6, 1.0],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-        ],
-      ),
-    );
+          ],
+        ),
+      );
 
     if (widget.embedded) {
       return ClipRect(
@@ -1522,7 +1226,10 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
           filter: ui.ImageFilter.blur(sigmaX: 6, sigmaY: 6),
           child: Material(
             color: cs.surface.withOpacity(0.60),
-            child: SizedBox(width: widget.embeddedWidth ?? 300, child: inner),
+            child: SizedBox(
+              width: widget.embeddedWidth ?? 300,
+              child: inner,
+            ),
           ),
         ),
       );
@@ -1573,20 +1280,12 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     await ap.setCurrentAssistant(assistant.id);
     // Desktop: optionally switch to Topics tab per user preference
     try {
-      if (_isDesktop &&
-          widget.embedded &&
-          widget.useDesktopTabs &&
-          sp.desktopAutoSwitchTopics) {
-        _tabController?.animateTo(
-          1,
-          duration: const Duration(milliseconds: 140),
-          curve: Curves.easeOutCubic,
-        );
+      if (_isDesktop && widget.embedded && widget.useDesktopTabs && sp.desktopAutoSwitchTopics) {
+        _tabController?.animateTo(1, duration: const Duration(milliseconds: 140), curve: Curves.easeOutCubic);
       }
     } catch (_) {}
     if (!mounted) return;
-    final forceNewChat =
-        sp.newChatOnAssistantSwitch && widget.onNewConversation != null;
+    final forceNewChat = sp.newChatOnAssistantSwitch && widget.onNewConversation != null;
     if (forceNewChat) {
       widget.onNewConversation?.call(closeDrawer: closeDrawer);
     } else {
@@ -1596,13 +1295,12 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
         final chatService = context.read<ChatService>();
         final all = chatService.getAllConversations();
         // Filter conversations owned by this assistant and pick the newest
-        final recent = all.where((c) => c.assistantId == assistant.id).toList();
+        final recent = all
+            .where((c) => c.assistantId == assistant.id)
+            .toList();
         if (recent.isNotEmpty) {
           // getAllConversations is already sorted by updatedAt desc
-          widget.onSelectConversation?.call(
-            recent.first.id,
-            closeDrawer: closeDrawer,
-          );
+          widget.onSelectConversation?.call(recent.first.id, closeDrawer: closeDrawer);
         } else {
           widget.onNewConversation?.call(closeDrawer: closeDrawer);
         }
@@ -1618,8 +1316,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
 
   void _openAssistantSettings(String id) {
     _closeAssistantPicker();
-    final isDesktop =
-        defaultTargetPlatform == TargetPlatform.macOS ||
+    final isDesktop = defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows ||
         defaultTargetPlatform == TargetPlatform.linux;
     if (isDesktop) {
@@ -1629,20 +1326,19 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
     }
     // Fallback to mobile edit page on non-desktop platforms
     Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => AssistantSettingsEditPage(assistantId: id),
-      ),
+      MaterialPageRoute(builder: (_) => AssistantSettingsEditPage(assistantId: id)),
     );
   }
+
 }
 
 extension on _SideDrawerState {
   Future<void> _duplicateAssistantFromMenu(Assistant assistant) async {
     final l10n = AppLocalizations.of(context)!;
     final newId = await context.read<AssistantProvider>().duplicateAssistant(
-      assistant.id,
-      l10n: l10n,
-    );
+          assistant.id,
+          l10n: l10n,
+        );
     if (!mounted) return;
     if (newId != null) {
       showAppSnackBar(
@@ -1653,10 +1349,7 @@ extension on _SideDrawerState {
     }
   }
 
-  Future<void> _showAssistantItemMenuDesktop(
-    Assistant a,
-    Offset globalPosition,
-  ) async {
+  Future<void> _showAssistantItemMenuDesktop(Assistant a, Offset globalPosition) async {
     if (!_isDesktop) return;
     final l10n = AppLocalizations.of(context)!;
     final tp = context.read<TagProvider>();
@@ -1704,31 +1397,17 @@ extension on _SideDrawerState {
                 title: Text(l10n.assistantSettingsDeleteDialogTitle),
                 content: Text(l10n.assistantSettingsDeleteDialogContent),
                 actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(ctx).pop(false),
-                    child: Text(l10n.assistantSettingsDeleteDialogCancel),
-                  ),
-                  TextButton(
-                    onPressed: () => Navigator.of(ctx).pop(true),
-                    child: Text(l10n.assistantSettingsDeleteDialogConfirm),
-                  ),
+                  TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text(l10n.assistantSettingsDeleteDialogCancel)),
+                  TextButton(onPressed: () => Navigator.of(ctx).pop(true), child: Text(l10n.assistantSettingsDeleteDialogConfirm)),
                 ],
               ),
             );
             if (confirmed != true) return;
-            final ok = await context.read<AssistantProvider>().deleteAssistant(
-              a.id,
-            );
+            final ok = await context.read<AssistantProvider>().deleteAssistant(a.id);
             if (!ok) {
-              showAppSnackBar(
-                context,
-                message: l10n.assistantSettingsAtLeastOneAssistantRequired,
-                type: NotificationType.warning,
-              );
+              showAppSnackBar(context, message: l10n.assistantSettingsAtLeastOneAssistantRequired, type: NotificationType.warning);
             } else {
-              try {
-                await context.read<TagProvider>().unassignAssistant(a.id);
-              } catch (_) {}
+              try { await context.read<TagProvider>().unassignAssistant(a.id); } catch (_) {}
             }
           },
         ),
@@ -1745,17 +1424,10 @@ extension on _SideDrawerState {
       context: context,
       isScrollControlled: false,
       backgroundColor: Theme.of(context).colorScheme.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
-        Widget row(
-          String text,
-          IconData icon,
-          VoidCallback onTap, {
-          bool danger = false,
-        }) {
+        Widget row(String text, IconData icon, VoidCallback onTap, {bool danger = false}) {
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: SizedBox(
@@ -1773,22 +1445,13 @@ extension on _SideDrawerState {
                   children: [
                     Icon(icon, size: 18, color: danger ? cs.error : cs.primary),
                     const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        text,
-                        style: const TextStyle(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                    ),
+                    Expanded(child: Text(text, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w500))),
                   ],
                 ),
               ),
             ),
           );
         }
-
         return SafeArea(
           top: false,
           child: Padding(
@@ -1796,11 +1459,7 @@ extension on _SideDrawerState {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                row(
-                  l10n.assistantTagsContextMenuEditAssistant,
-                  Lucide.Pencil,
-                  () => _openAssistantSettings(a.id),
-                ),
+                row(l10n.assistantTagsContextMenuEditAssistant, Lucide.Pencil, () => _openAssistantSettings(a.id)),
                 row(l10n.assistantSettingsCopyButton, Lucide.Copy, () async {
                   await _duplicateAssistantFromMenu(a);
                 }),
@@ -1808,66 +1467,30 @@ extension on _SideDrawerState {
                   row(l10n.assistantTagsClearTag, Lucide.Eraser, () async {
                     await context.read<TagProvider>().unassignAssistant(a.id);
                   }),
-                row(
-                  l10n.assistantTagsContextMenuManageTags,
-                  Lucide.Bookmark,
-                  () async {
-                    // Navigate to manage tags page
-                    await Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => TagsManagerPage(assistantId: a.id),
-                      ),
-                    );
-                  },
-                ),
-                row(
-                  l10n.assistantTagsContextMenuDeleteAssistant,
-                  Lucide.Trash2,
-                  () async {
-                    final confirmed = await showDialog<bool>(
-                      context: context,
-                      builder: (ctx2) => AlertDialog(
-                        title: Text(l10n.assistantSettingsDeleteDialogTitle),
-                        content: Text(
-                          l10n.assistantSettingsDeleteDialogContent,
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.of(ctx2).pop(false),
-                            child: Text(
-                              l10n.assistantSettingsDeleteDialogCancel,
-                            ),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.of(ctx2).pop(true),
-                            child: Text(
-                              l10n.assistantSettingsDeleteDialogConfirm,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                    if (confirmed != true) return;
-                    final ok = await context
-                        .read<AssistantProvider>()
-                        .deleteAssistant(a.id);
-                    if (!ok) {
-                      showAppSnackBar(
-                        context,
-                        message:
-                            l10n.assistantSettingsAtLeastOneAssistantRequired,
-                        type: NotificationType.warning,
-                      );
-                    } else {
-                      try {
-                        await context.read<TagProvider>().unassignAssistant(
-                          a.id,
-                        );
-                      } catch (_) {}
-                    }
-                  },
-                  danger: true,
-                ),
+                row(l10n.assistantTagsContextMenuManageTags, Lucide.Bookmark, () async {
+                  // Navigate to manage tags page
+                  await Navigator.of(context).push(MaterialPageRoute(builder: (_) => TagsManagerPage(assistantId: a.id)));
+                }),
+                row(l10n.assistantTagsContextMenuDeleteAssistant, Lucide.Trash2, () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx2) => AlertDialog(
+                      title: Text(l10n.assistantSettingsDeleteDialogTitle),
+                      content: Text(l10n.assistantSettingsDeleteDialogContent),
+                      actions: [
+                        TextButton(onPressed: () => Navigator.of(ctx2).pop(false), child: Text(l10n.assistantSettingsDeleteDialogCancel)),
+                        TextButton(onPressed: () => Navigator.of(ctx2).pop(true), child: Text(l10n.assistantSettingsDeleteDialogConfirm)),
+                      ],
+                    ),
+                  );
+                  if (confirmed != true) return;
+                  final ok = await context.read<AssistantProvider>().deleteAssistant(a.id);
+                  if (!ok) {
+                    showAppSnackBar(context, message: l10n.assistantSettingsAtLeastOneAssistantRequired, type: NotificationType.warning);
+                  } else {
+                    try { await context.read<TagProvider>().unassignAssistant(a.id); } catch (_) {}
+                  }
+                }, danger: true),
               ],
             ),
           ),
@@ -1906,19 +1529,12 @@ extension on _SideDrawerState {
                 padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Align(
                   alignment: Alignment.centerLeft,
-                  child: Text(
-                    text,
-                    style: const TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
+                  child: Text(text, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w500)),
                 ),
               ),
             ),
           );
         }
-
         return SafeArea(
           top: false,
           child: ConstrainedBox(
@@ -1941,26 +1557,16 @@ extension on _SideDrawerState {
                       ),
                     ),
                     const SizedBox(height: 10),
-                    row(l10n.sideDrawerChooseImage, () async {
-                      await _pickLocalImage(context);
-                    }),
+                    row(l10n.sideDrawerChooseImage, () async { await _pickLocalImage(context); }),
                     row(l10n.sideDrawerChooseEmoji, () async {
                       final emoji = await _pickEmoji(context);
                       if (emoji != null) {
-                        await context.read<UserProvider>().setAvatarEmoji(
-                          emoji,
-                        );
+                        await context.read<UserProvider>().setAvatarEmoji(emoji);
                       }
                     }),
-                    row(l10n.sideDrawerEnterLink, () async {
-                      await _inputAvatarUrl(context);
-                    }),
-                    row(l10n.sideDrawerImportFromQQ, () async {
-                      await _inputQQAvatar(context);
-                    }),
-                    row(l10n.sideDrawerReset, () async {
-                      await context.read<UserProvider>().resetAvatar();
-                    }),
+                    row(l10n.sideDrawerEnterLink, () async { await _inputAvatarUrl(context); }),
+                    row(l10n.sideDrawerImportFromQQ, () async { await _inputQQAvatar(context); }),
+                    row(l10n.sideDrawerReset, () async { await context.read<UserProvider>().resetAvatar(); }),
                     const SizedBox(height: 4),
                   ],
                 ),
@@ -1982,261 +1588,127 @@ extension on _SideDrawerState {
       final trimmed = s.characters.take(1).toString().trim();
       return trimmed.isNotEmpty && trimmed == s.trim();
     }
-
     final List<String> quick = const [
-      '😀',
-      '😁',
-      '😂',
-      '🤣',
-      '😃',
-      '😄',
-      '😅',
-      '😊',
-      '😍',
-      '😘',
-      '😗',
-      '😙',
-      '😚',
-      '🙂',
-      '🤗',
-      '🤩',
-      '🫶',
-      '🤝',
-      '👍',
-      '👎',
-      '👋',
-      '🙏',
-      '💪',
-      '🔥',
-      '✨',
-      '🌟',
-      '💡',
-      '🎉',
-      '🎊',
-      '🎈',
-      '🌈',
-      '☀️',
-      '🌙',
-      '⭐',
-      '⚡',
-      '☁️',
-      '❄️',
-      '🌧️',
-      '🍎',
-      '🍊',
-      '🍋',
-      '🍉',
-      '🍇',
-      '🍓',
-      '🍒',
-      '🍑',
-      '🥭',
-      '🍍',
-      '🥝',
-      '🍅',
-      '🥕',
-      '🌽',
-      '🍞',
-      '🧀',
-      '🍔',
-      '🍟',
-      '🍕',
-      '🌮',
-      '🌯',
-      '🍣',
-      '🍜',
-      '🍰',
-      '🍪',
-      '🍩',
-      '🍫',
-      '🍻',
-      '☕',
-      '🧋',
-      '🥤',
-      '⚽',
-      '🏀',
-      '🏈',
-      '🎾',
-      '🏐',
-      '🎮',
-      '🎧',
-      '🎸',
-      '🎹',
-      '🎺',
-      '📚',
-      '✏️',
-      '💼',
-      '💻',
-      '🖥️',
-      '📱',
-      '🛩️',
-      '✈️',
-      '🚗',
-      '🚕',
-      '🚙',
-      '🚌',
-      '🚀',
-      '🛰️',
-      '🧠',
-      '🫀',
-      '💊',
-      '🩺',
-      '🐶',
-      '🐱',
-      '🐭',
-      '🐹',
-      '🐰',
-      '🦊',
-      '🐻',
-      '🐼',
-      '🐨',
-      '🐯',
-      '🦁',
-      '🐮',
-      '🐷',
-      '🐸',
-      '🐵',
+      '😀','😁','😂','🤣','😃','😄','😅','😊','😍','😘','😗','😙','😚','🙂','🤗','🤩','🫶','🤝','👍','👎','👋','🙏','💪','🔥','✨','🌟','💡','🎉','🎊','🎈','🌈','☀️','🌙','⭐','⚡','☁️','❄️','🌧️','🍎','🍊','🍋','🍉','🍇','🍓','🍒','🍑','🥭','🍍','🥝','🍅','🥕','🌽','🍞','🧀','🍔','🍟','🍕','🌮','🌯','🍣','🍜','🍰','🍪','🍩','🍫','🍻','☕','🧋','🥤','⚽','🏀','🏈','🎾','🏐','🎮','🎧','🎸','🎹','🎺','📚','✏️','💼','💻','🖥️','📱','🛩️','✈️','🚗','🚕','🚙','🚌','🚀','🛰️','🧠','🫀','💊','🩺','🐶','🐱','🐭','🐹','🐰','🦊','🐻','🐼','🐨','🐯','🦁','🐮','🐷','🐸','🐵'
     ];
     return showDialog<String>(
       context: context,
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
-        return StatefulBuilder(
-          builder: (ctx, setLocal) {
-            // Revert to non-scrollable dialog but cap grid height
-            // based on available height when keyboard is visible.
-            final size = MediaQuery.sizeOf(ctx);
-            final viewInsets = MediaQuery.viewInsetsOf(ctx);
-            final avail = size.height - viewInsets.bottom;
-            final double gridHeight = (avail * 0.28).clamp(120.0, 220.0);
-            return AlertDialog(
-              scrollable: true,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
-              backgroundColor: cs.surface,
-              title: Text(l10n.sideDrawerEmojiDialogTitle),
-              content: SizedBox(
-                width: 360,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Container(
-                      width: 72,
-                      height: 72,
-                      decoration: BoxDecoration(
-                        color: cs.primary.withOpacity(0.08),
-                        shape: BoxShape.circle,
-                      ),
-                      alignment: Alignment.center,
-                      child: EmojiText(
-                        value.isEmpty
-                            ? '🙂'
-                            : value.characters.take(1).toString(),
-                        fontSize: 40,
-                        optimizeEmojiAlign: true,
-                        nudge: Offset
-                            .zero, // mobile/desktop picker preview: no extra nudge
-                      ),
+        return StatefulBuilder(builder: (ctx, setLocal) {
+          // Revert to non-scrollable dialog but cap grid height
+          // based on available height when keyboard is visible.
+          final size = MediaQuery.sizeOf(ctx);
+          final viewInsets = MediaQuery.viewInsetsOf(ctx);
+          final avail = size.height - viewInsets.bottom;
+          final double gridHeight = (avail * 0.28).clamp(120.0, 220.0);
+          return AlertDialog(
+            scrollable: true,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            backgroundColor: cs.surface,
+            title: Text(l10n.sideDrawerEmojiDialogTitle),
+            content: SizedBox(
+              width: 360,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 72,
+                    height: 72,
+                    decoration: BoxDecoration(
+                      color: cs.primary.withOpacity(0.08),
+                      shape: BoxShape.circle,
                     ),
-                    const SizedBox(height: 12),
-                    TextField(
-                      controller: controller,
-                      autofocus: true,
-                      onChanged: (v) => setLocal(() => value = v),
-                      onSubmitted: (_) {
-                        if (validGrapheme(value))
-                          Navigator.of(
-                            ctx,
-                          ).pop(value.characters.take(1).toString());
-                      },
-                      decoration: InputDecoration(
-                        hintText: l10n.sideDrawerEmojiDialogHint,
-                        filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: Colors.transparent),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: Colors.transparent),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: cs.primary.withOpacity(0.4),
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    SizedBox(
-                      height: gridHeight,
-                      child: GridView.builder(
-                        shrinkWrap: true,
-                        padding: EdgeInsets.zero,
-                        gridDelegate:
-                            const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 8,
-                              mainAxisSpacing: 8,
-                              crossAxisSpacing: 8,
-                            ),
-                        itemCount: quick.length,
-                        itemBuilder: (c, i) {
-                          final e = quick[i];
-                          return InkWell(
-                            borderRadius: BorderRadius.circular(12),
-                            onTap: () => Navigator.of(ctx).pop(e),
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: cs.primary.withOpacity(0.08),
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              alignment: Alignment.center,
-                              child: EmojiText(
-                                e,
-                                fontSize: 20,
-                                optimizeEmojiAlign: true,
-                                nudge:
-                                    Offset.zero, // picker grid: no extra nudge
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  child: Text(l10n.sideDrawerCancel),
-                ),
-                TextButton(
-                  onPressed: validGrapheme(value)
-                      ? () => Navigator.of(
-                          ctx,
-                        ).pop(value.characters.take(1).toString())
-                      : null,
-                  child: Text(
-                    l10n.sideDrawerSave,
-                    style: TextStyle(
-                      color: validGrapheme(value)
-                          ? cs.primary
-                          : cs.onSurface.withOpacity(0.38),
-                      fontWeight: FontWeight.w600,
+                    alignment: Alignment.center,
+                    child: EmojiText(
+                      value.isEmpty ? '🙂' : value.characters.take(1).toString(),
+                      fontSize: 40,
+                      optimizeEmojiAlign: true,
+                      nudge: Offset.zero, // mobile/desktop picker preview: no extra nudge
                     ),
                   ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: controller,
+                    autofocus: true,
+                    onChanged: (v) => setLocal(() => value = v),
+                    onSubmitted: (_) {
+                      if (validGrapheme(value)) Navigator.of(ctx).pop(value.characters.take(1).toString());
+                    },
+                    decoration: InputDecoration(
+                      hintText: l10n.sideDrawerEmojiDialogHint,
+                      filled: true,
+                      fillColor: Theme.of(ctx).brightness == Brightness.dark ? Colors.white10 : const Color(0xFFF2F3F5),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(color: Colors.transparent),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(color: Colors.transparent),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  SizedBox(
+                    height: gridHeight,
+                    child: GridView.builder(
+                      shrinkWrap: true,
+                      padding: EdgeInsets.zero,
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 8,
+                        mainAxisSpacing: 8,
+                        crossAxisSpacing: 8,
+                      ),
+                      itemCount: quick.length,
+                      itemBuilder: (c, i) {
+                        final e = quick[i];
+                        return InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () => Navigator.of(ctx).pop(e),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: cs.primary.withOpacity(0.08),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            alignment: Alignment.center,
+                            child: EmojiText(
+                              e,
+                              fontSize: 20,
+                              optimizeEmojiAlign: true,
+                              nudge: Offset.zero, // picker grid: no extra nudge
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: Text(l10n.sideDrawerCancel),
+              ),
+              TextButton(
+                onPressed: validGrapheme(value) ? () => Navigator.of(ctx).pop(value.characters.take(1).toString()) : null,
+                child: Text(
+                  l10n.sideDrawerSave,
+                  style: TextStyle(
+                    color: validGrapheme(value) ? cs.primary : cs.onSurface.withOpacity(0.38),
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ],
-            );
-          },
-        );
+              ),
+            ],
+          );
+        });
       },
     );
   }
@@ -2248,67 +1720,56 @@ extension on _SideDrawerState {
       context: context,
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
-        bool valid(String s) =>
-            s.trim().startsWith('http://') || s.trim().startsWith('https://');
+        bool valid(String s) => s.trim().startsWith('http://') || s.trim().startsWith('https://');
         String value = '';
-        return StatefulBuilder(
-          builder: (ctx, setLocal) {
-            return AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
+        return StatefulBuilder(builder: (ctx, setLocal) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            backgroundColor: cs.surface,
+            title: Text(l10n.sideDrawerImageUrlDialogTitle),
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: InputDecoration(
+                hintText: l10n.sideDrawerImageUrlDialogHint,
+                filled: true,
+                fillColor: Theme.of(ctx).brightness == Brightness.dark ? Colors.white10 : const Color(0xFFF2F3F5),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: Colors.transparent),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: Colors.transparent),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
+                ),
               ),
-              backgroundColor: cs.surface,
-              title: Text(l10n.sideDrawerImageUrlDialogTitle),
-              content: TextField(
-                controller: controller,
-                autofocus: true,
-                decoration: InputDecoration(
-                  hintText: l10n.sideDrawerImageUrlDialogHint,
-                  filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: Colors.transparent),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: Colors.transparent),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
-                  ),
-                ),
-                onChanged: (v) => setLocal(() => value = v),
-                onSubmitted: (_) {
-                  if (valid(value)) Navigator.of(ctx).pop(true);
-                },
+              onChanged: (v) => setLocal(() => value = v),
+              onSubmitted: (_) {
+                if (valid(value)) Navigator.of(ctx).pop(true);
+              },
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: Text(l10n.sideDrawerCancel),
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(false),
-                  child: Text(l10n.sideDrawerCancel),
-                ),
-                TextButton(
-                  onPressed: valid(value)
-                      ? () => Navigator.of(ctx).pop(true)
-                      : null,
-                  child: Text(
-                    l10n.sideDrawerSave,
-                    style: TextStyle(
-                      color: valid(value)
-                          ? cs.primary
-                          : cs.onSurface.withOpacity(0.38),
-                      fontWeight: FontWeight.w600,
-                    ),
+              TextButton(
+                onPressed: valid(value) ? () => Navigator.of(ctx).pop(true) : null,
+                child: Text(
+                  l10n.sideDrawerSave,
+                  style: TextStyle(
+                    color: valid(value) ? cs.primary : cs.onSurface.withOpacity(0.38),
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
-              ],
-            );
-          },
-        );
+              ),
+            ],
+          );
+        });
       },
     );
     if (ok == true) {
@@ -2350,22 +1811,14 @@ extension on _SideDrawerState {
             [5, 6, 7, 8],
             [9],
           ];
-          final firstWeights = <int>[
-            128,
-            4,
-            2,
-            1,
-          ]; // ratio only; ensures 1-2 > 3-4 > 5-8 > 9
+          final firstWeights = <int>[128, 4, 2, 1]; // ratio only; ensures 1-2 > 3-4 > 5-8 > 9
           final firstTotal = firstWeights.fold<int>(0, (a, b) => a + b);
           int r2 = rnd.nextInt(firstTotal) + 1;
           int idx = 0;
           int a2 = 0;
           for (int i = 0; i < firstGroups.length; i++) {
             a2 += firstWeights[i];
-            if (r2 <= a2) {
-              idx = i;
-              break;
-            }
+            if (r2 <= a2) { idx = i; break; }
           }
           final group = firstGroups[idx];
           sb.write(group[rnd.nextInt(group.length)]);
@@ -2374,116 +1827,97 @@ extension on _SideDrawerState {
           }
           return sb.toString();
         }
-
-        return StatefulBuilder(
-          builder: (ctx, setLocal) {
-            return AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
-              backgroundColor: cs.surface,
-              title: Text(l10n.sideDrawerQQAvatarDialogTitle),
-              content: TextField(
-                controller: controller,
-                autofocus: true,
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  hintText: l10n.sideDrawerQQAvatarInputHint,
-                  filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: Colors.transparent),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: Colors.transparent),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
-                  ),
+        return StatefulBuilder(builder: (ctx, setLocal) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            backgroundColor: cs.surface,
+            title: Text(l10n.sideDrawerQQAvatarDialogTitle),
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                hintText: l10n.sideDrawerQQAvatarInputHint,
+                filled: true,
+                fillColor: Theme.of(ctx).brightness == Brightness.dark ? Colors.white10 : const Color(0xFFF2F3F5),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: Colors.transparent),
                 ),
-                onChanged: (v) => setLocal(() => value = v),
-                onSubmitted: (_) {
-                  if (valid(value)) Navigator.of(ctx).pop(true);
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: Colors.transparent),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
+                ),
+              ),
+              onChanged: (v) => setLocal(() => value = v),
+              onSubmitted: (_) {
+                if (valid(value)) Navigator.of(ctx).pop(true);
+              },
+            ),
+            actionsAlignment: MainAxisAlignment.spaceBetween,
+            actions: [
+              TextButton(
+                onPressed: () async {
+                  // Try multiple times until a valid avatar is fetched
+                  const int maxTries = 20;
+                  bool applied = false;
+                  for (int i = 0; i < maxTries; i++) {
+                    final qq = randomQQ();
+                    // debugPrint(qq);
+                    final url = 'https://q2.qlogo.cn/headimg_dl?dst_uin=' + qq + '&spec=100';
+                    try {
+                      final resp = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
+                      if (resp.statusCode == 200 && resp.bodyBytes.isNotEmpty) {
+                        await context.read<UserProvider>().setAvatarUrl(url);
+                        applied = true;
+                        break;
+                      }
+                    } catch (_) {}
+                  }
+                  if (applied) {
+                    if (Navigator.of(ctx).canPop()) Navigator.of(ctx).pop(false);
+                  } else {
+                    showAppSnackBar(
+                      context,
+                      message: l10n.sideDrawerQQAvatarFetchFailed,
+                      type: NotificationType.error,
+                    );
+                  }
                 },
+                child: Text(l10n.sideDrawerRandomQQ),
               ),
-              actionsAlignment: MainAxisAlignment.spaceBetween,
-              actions: [
-                TextButton(
-                  onPressed: () async {
-                    // Try multiple times until a valid avatar is fetched
-                    const int maxTries = 20;
-                    bool applied = false;
-                    for (int i = 0; i < maxTries; i++) {
-                      final qq = randomQQ();
-                      // debugPrint(qq);
-                      final url =
-                          'https://q2.qlogo.cn/headimg_dl?dst_uin=' +
-                          qq +
-                          '&spec=100';
-                      try {
-                        final resp = await http
-                            .get(Uri.parse(url))
-                            .timeout(const Duration(seconds: 5));
-                        if (resp.statusCode == 200 &&
-                            resp.bodyBytes.isNotEmpty) {
-                          await context.read<UserProvider>().setAvatarUrl(url);
-                          applied = true;
-                          break;
-                        }
-                      } catch (_) {}
-                    }
-                    if (applied) {
-                      if (Navigator.of(ctx).canPop())
-                        Navigator.of(ctx).pop(false);
-                    } else {
-                      showAppSnackBar(
-                        context,
-                        message: l10n.sideDrawerQQAvatarFetchFailed,
-                        type: NotificationType.error,
-                      );
-                    }
-                  },
-                  child: Text(l10n.sideDrawerRandomQQ),
-                ),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.of(ctx).pop(false),
-                      child: Text(l10n.sideDrawerCancel),
-                    ),
-                    TextButton(
-                      onPressed: valid(value)
-                          ? () => Navigator.of(ctx).pop(true)
-                          : null,
-                      child: Text(
-                        l10n.sideDrawerSave,
-                        style: TextStyle(
-                          color: valid(value)
-                              ? cs.primary
-                              : cs.onSurface.withOpacity(0.38),
-                          fontWeight: FontWeight.w600,
-                        ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(false),
+                    child: Text(l10n.sideDrawerCancel),
+                  ),
+                  TextButton(
+                    onPressed: valid(value) ? () => Navigator.of(ctx).pop(true) : null,
+                    child: Text(
+                      l10n.sideDrawerSave,
+                      style: TextStyle(
+                        color: valid(value) ? cs.primary : cs.onSurface.withOpacity(0.38),
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
-                  ],
-                ),
-              ],
-            );
-          },
-        );
+                  ),
+                ],
+              ),
+            ],
+          );
+        });
       },
     );
     if (ok == true) {
       final qq = controller.text.trim();
       if (qq.isNotEmpty) {
-        final url =
-            'https://q2.qlogo.cn/headimg_dl?dst_uin=' + qq + '&spec=100';
+        final url = 'https://q2.qlogo.cn/headimg_dl?dst_uin=' + qq + '&spec=100';
         await context.read<UserProvider>().setAvatarUrl(url);
       }
     }
@@ -2529,7 +1963,6 @@ extension on _SideDrawerState {
       return;
     }
   }
-
   Future<void> _editUserName(BuildContext context) async {
     final l10n = AppLocalizations.of(context)!;
     final initial = widget.userName;
@@ -2545,9 +1978,7 @@ extension on _SideDrawerState {
         return StatefulBuilder(
           builder: (ctx, setLocal) {
             return AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
               backgroundColor: cs.surface,
               title: Text(l10n.sideDrawerSetNicknameTitle),
               content: Column(
@@ -2568,9 +1999,7 @@ extension on _SideDrawerState {
                       labelText: l10n.sideDrawerNicknameLabel,
                       hintText: l10n.sideDrawerNicknameHint,
                       filled: true,
-                      fillColor: isDark
-                          ? Colors.white10
-                          : const Color(0xFFF2F3F5),
+                      fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
                       counterText: '',
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -2582,24 +2011,16 @@ extension on _SideDrawerState {
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: cs.primary.withOpacity(0.4),
-                        ),
+                        borderSide: BorderSide(color: cs.primary.withOpacity(0.4)),
                       ),
                     ),
-                    style: TextStyle(
-                      fontSize: 15,
-                      color: Theme.of(ctx).textTheme.bodyMedium?.color,
-                    ),
+                    style: TextStyle(fontSize: 15, color: Theme.of(ctx).textTheme.bodyMedium?.color),
                   ),
                   Align(
                     alignment: Alignment.centerRight,
                     child: Text(
                       '${value.trim().length}/$maxLen',
-                      style: TextStyle(
-                        color: cs.onSurface.withOpacity(0.45),
-                        fontSize: 12,
-                      ),
+                      style: TextStyle(color: cs.onSurface.withOpacity(0.45), fontSize: 12),
                     ),
                   ),
                 ],
@@ -2610,15 +2031,11 @@ extension on _SideDrawerState {
                   child: Text(l10n.sideDrawerCancel),
                 ),
                 TextButton(
-                  onPressed: valid(value)
-                      ? () => Navigator.of(ctx).pop(true)
-                      : null,
+                  onPressed: valid(value) ? () => Navigator.of(ctx).pop(true) : null,
                   child: Text(
                     l10n.sideDrawerSave,
                     style: TextStyle(
-                      color: valid(value)
-                          ? cs.primary
-                          : cs.onSurface.withOpacity(0.38),
+                      color: valid(value) ? cs.primary : cs.onSurface.withOpacity(0.38),
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -2629,7 +2046,7 @@ extension on _SideDrawerState {
         );
       },
     );
-    if (ok == true) {
+  if (ok == true) {
       final text = controller.text.trim();
       if (text.isNotEmpty) {
         await context.read<UserProvider>().setName(text);
@@ -2649,24 +2066,17 @@ extension on _SideDrawerState {
     // Apply search filter when:
     // - Desktop tab mode (inlineMode == false), OR
     // - Desktop assistants-only mode (left sidebar when topics are on right)
-    final shouldFilterAssistants =
-        (!inlineMode) || (widget.desktopAssistantsOnly && _isDesktop);
+    final shouldFilterAssistants = (!inlineMode) || (widget.desktopAssistantsOnly && _isDesktop);
     if (shouldFilterAssistants && _query.trim().isNotEmpty) {
       final q = _query.toLowerCase();
-      assistants = assistants
-          .where((a) => (a.name).toLowerCase().contains(q))
-          .toList();
+      assistants = assistants.where((a) => (a.name).toLowerCase().contains(q)).toList();
     }
 
     final tags = tp.tags;
-    final ungrouped = assistants
-        .where((a) => tp.tagOfAssistant(a.id) == null)
-        .toList();
+    final ungrouped = assistants.where((a) => tp.tagOfAssistant(a.id) == null).toList();
     final groupedByTag = <String, List<Assistant>>{};
     for (final t in tags) {
-      final list = assistants
-          .where((a) => tp.tagOfAssistant(a.id) == t.id)
-          .toList();
+      final list = assistants.where((a) => tp.tagOfAssistant(a.id) == t.id).toList();
       if (list.isNotEmpty) groupedByTag[t.id] = list;
     }
 
@@ -2690,15 +2100,9 @@ extension on _SideDrawerState {
     // Desktop: enable drag-reorder within each group; Mobile/tablet: keep static list
     final bool enableReorder = _isDesktop;
 
-    Widget buildReorderable(
-      List<Assistant> list, {
-      required List<String> subsetIds,
-    }) {
+    Widget buildReorderable(List<Assistant> list, {required List<String> subsetIds}) {
       if (!enableReorder) {
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: list.map(buildTile).toList(),
-        );
+        return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: list.map(buildTile).toList());
       }
       return ReorderableListView.builder(
         shrinkWrap: true,
@@ -2711,7 +2115,10 @@ extension on _SideDrawerState {
             builder: (context, _) {
               return ClipRRect(
                 borderRadius: BorderRadius.circular(16),
-                child: Material(type: MaterialType.transparency, child: child),
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: child,
+                ),
               );
             },
           );
@@ -2748,10 +2155,7 @@ extension on _SideDrawerState {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           if (ungrouped.isNotEmpty)
-            buildReorderable(
-              ungrouped,
-              subsetIds: ungrouped.map((a) => a.id).toList(),
-            ),
+            buildReorderable(ungrouped, subsetIds: ungrouped.map((a) => a.id).toList()),
           for (final t in tags)
             if ((groupedByTag[t.id] ?? const <Assistant>[]).isNotEmpty) ...[
               const SizedBox(height: 4),
@@ -2768,9 +2172,7 @@ extension on _SideDrawerState {
                     ? const SizedBox.shrink()
                     : buildReorderable(
                         groupedByTag[t.id]!,
-                        subsetIds: (groupedByTag[t.id] ?? const <Assistant>[])
-                            .map((a) => a.id)
-                            .toList(),
+                        subsetIds: (groupedByTag[t.id] ?? const <Assistant>[]) .map((a) => a.id).toList(),
                       ),
               ),
             ],
@@ -2791,88 +2193,75 @@ extension on _SideDrawerState {
   }) {
     final children = <Widget>[];
     if (includeUpdateBanner) {
-      children.add(
-        Builder(
-          builder: (context) {
-            final settings = context.watch<SettingsProvider>();
-            final upd = context.watch<UpdateProvider>();
-            if (!settings.showAppUpdates) return const SizedBox.shrink();
-            final info = upd.available;
-            if (upd.checking && info == null) return const SizedBox.shrink();
-            if (info == null) return const SizedBox.shrink();
-            final url = info.bestDownloadUrl();
-            if (url == null || url.isEmpty) return const SizedBox.shrink();
-            final ver = info.version;
-            final build = info.build;
-            final l10n = AppLocalizations.of(context)!;
-            final title = build != null
-                ? l10n.sideDrawerUpdateTitleWithBuild(ver, build)
-                : l10n.sideDrawerUpdateTitle(ver);
-            final cs2 = Theme.of(context).colorScheme;
-            final isDark2 = Theme.of(context).brightness == Brightness.dark;
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Material(
-                color: isDark2 ? Colors.white10 : const Color(0xFFF2F3F5),
-                borderRadius: BorderRadius.circular(12),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(12),
-                  onTap: () async {
-                    final uri = Uri.parse(url);
-                    try {
-                      // ignore: deprecated_member_use
-                      await launchUrl(uri);
-                    } catch (_) {
-                      Clipboard.setData(ClipboardData(text: url));
-                      showAppSnackBar(
-                        context,
-                        message: l10n.sideDrawerLinkCopied,
-                        type: NotificationType.success,
-                      );
-                    }
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+      children.add(Builder(builder: (context) {
+        final settings = context.watch<SettingsProvider>();
+        final upd = context.watch<UpdateProvider>();
+        if (!settings.showAppUpdates) return const SizedBox.shrink();
+        final info = upd.available;
+        if (upd.checking && info == null) return const SizedBox.shrink();
+        if (info == null) return const SizedBox.shrink();
+        final url = info.bestDownloadUrl();
+        if (url == null || url.isEmpty) return const SizedBox.shrink();
+        final ver = info.version;
+        final build = info.build;
+        final l10n = AppLocalizations.of(context)!;
+        final title = build != null
+            ? l10n.sideDrawerUpdateTitleWithBuild(ver, build)
+            : l10n.sideDrawerUpdateTitle(ver);
+        final cs2 = Theme.of(context).colorScheme;
+        final isDark2 = Theme.of(context).brightness == Brightness.dark;
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Material(
+            color: isDark2 ? Colors.white10 : const Color(0xFFF2F3F5),
+            borderRadius: BorderRadius.circular(12),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: () async {
+                final uri = Uri.parse(url);
+                try {
+                  // ignore: deprecated_member_use
+                  await launchUrl(uri);
+                } catch (_) {
+                  Clipboard.setData(ClipboardData(text: url));
+                  showAppSnackBar(
+                    context,
+                    message: l10n.sideDrawerLinkCopied,
+                    type: NotificationType.success,
+                  );
+                }
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
                       children: [
-                        Row(
-                          children: [
-                            Icon(
-                              Lucide.BadgeInfo,
-                              size: 18,
-                              color: cs2.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                title,
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.w700,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        if ((info.notes ?? '').trim().isNotEmpty) ...[
-                          const SizedBox(height: 6),
-                          Text(
-                            info.notes!,
-                            style: TextStyle(
-                              fontSize: 13,
-                              color: cs2.onSurface.withOpacity(0.8),
-                            ),
+                        Icon(Lucide.BadgeInfo, size: 18, color: cs2.primary),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            title,
+                            style: const TextStyle(fontWeight: FontWeight.w700),
                           ),
-                        ],
+                        ),
                       ],
                     ),
-                  ),
+                    if ((info.notes ?? '').trim().isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Text(
+                        info.notes!,
+                        style: TextStyle(fontSize: 13, color: cs2.onSurface.withOpacity(0.8)),
+                      ),
+                    ],
+                  ],
                 ),
               ),
-            );
-          },
-        ),
-      );
+            ),
+          ),
+        );
+      }));
     }
 
     children.add(
@@ -2881,85 +2270,39 @@ extension on _SideDrawerState {
         reverse: false,
         transitionBuilder: (child, primary, secondary) => FadeThroughTransition(
           fillColor: Colors.transparent,
-          animation: CurvedAnimation(
-            parent: primary,
-            curve: Curves.easeOutCubic,
-          ),
-          secondaryAnimation: CurvedAnimation(
-            parent: secondary,
-            curve: Curves.easeInCubic,
-          ),
+          animation: CurvedAnimation(parent: primary, curve: Curves.easeOutCubic),
+          secondaryAnimation: CurvedAnimation(parent: secondary, curve: Curves.easeInCubic),
           child: child,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          key: ValueKey(
-            '${_query}_' +
-                ([
-                  ...pinnedList.map((c) => c.id),
-                  ...groups.expand((g) => g.items.map((c) => c.id)),
-                ].join(',')),
-          ),
+          key: ValueKey('${_query}_' + ([...pinnedList.map((c)=>c.id), ...groups.expand((g)=>g.items.map((c)=>c.id))].join(','))),
           children: [
             if (pinnedList.isNotEmpty) ...[
               Padding(
                 padding: const EdgeInsets.fromLTRB(14, 6, 0, 6),
-                child:
-                    Text(
-                          AppLocalizations.of(context)!.sideDrawerPinnedLabel,
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                            color: cs.primary,
-                          ),
-                        )
-                        .animate()
-                        .fadeIn(duration: 180.ms)
-                        .moveY(
-                          begin: 4,
-                          end: 0,
-                          duration: 220.ms,
-                          curve: Curves.easeOutCubic,
-                        ),
+                child: Text(
+                  AppLocalizations.of(context)!.sideDrawerPinnedLabel,
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: cs.primary),
+                ).animate().fadeIn(duration: 180.ms).moveY(begin: 4, end: 0, duration: 220.ms, curve: Curves.easeOutCubic),
               ),
               Column(
                 children: [
                   for (int i = 0; i < pinnedList.length; i++)
                     _ChatTile(
-                          chat: pinnedList[i],
-                          textColor: textBase,
-                          selected:
-                              pinnedList[i].id ==
-                              chatService.currentConversationId,
-                          loading: widget.loadingConversationIds.contains(
-                            pinnedList[i].id,
-                          ),
-                          onTap: () {
-                            final closeDrawer = !context
-                                .read<SettingsProvider>()
-                                .keepSidebarOpenOnTopicTap;
-                            widget.onSelectConversation?.call(
-                              pinnedList[i].id,
-                              closeDrawer: closeDrawer,
-                            );
-                          },
-                          onLongPress: () =>
-                              _showChatMenu(context, pinnedList[i]),
-                          onSecondaryTap: (pos) => _showChatMenu(
-                            context,
-                            pinnedList[i],
-                            anchor: pos,
-                          ),
-                        )
-                        .animate(key: ValueKey('pin-${pinnedList[i].id}'))
-                        .fadeIn(duration: 220.ms, delay: (20 * i).ms)
-                        .moveY(
-                          begin: 8,
-                          end: 0,
-                          duration: 260.ms,
-                          curve: Curves.easeOutCubic,
-                          delay: (20 * i).ms,
-                        ),
+                      chat: pinnedList[i],
+                      textColor: textBase,
+                      selected: pinnedList[i].id == chatService.currentConversationId,
+                      loading: widget.loadingConversationIds.contains(pinnedList[i].id),
+                      onTap: () {
+                        final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
+                        widget.onSelectConversation?.call(pinnedList[i].id, closeDrawer: closeDrawer);
+                      },
+                      onLongPress: () => _showChatMenu(context, pinnedList[i]),
+                      onSecondaryTap: (pos) => _showChatMenu(context, pinnedList[i], anchor: pos),
+                    ).animate(key: ValueKey('pin-${pinnedList[i].id}'))
+                      .fadeIn(duration: 220.ms, delay: (20 * i).ms)
+                      .moveY(begin: 8, end: 0, duration: 260.ms, curve: Curves.easeOutCubic, delay: (20 * i).ms),
                 ],
               ),
               const SizedBox(height: 8),
@@ -2968,67 +2311,29 @@ extension on _SideDrawerState {
               if (context.watch<SettingsProvider>().showChatListDate)
                 Padding(
                   padding: const EdgeInsets.fromLTRB(14, 6, 0, 6),
-                  child:
-                      Text(
-                            group.label,
-                            textAlign: TextAlign.left,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: cs.primary,
-                            ),
-                          )
-                          .animate()
-                          .fadeIn(duration: 180.ms)
-                          .moveY(
-                            begin: 4,
-                            end: 0,
-                            duration: 220.ms,
-                            curve: Curves.easeOutCubic,
-                          ),
+                  child: Text(
+                    group.label,
+                    textAlign: TextAlign.left,
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: cs.primary),
+                  ).animate().fadeIn(duration: 180.ms).moveY(begin: 4, end: 0, duration: 220.ms, curve: Curves.easeOutCubic),
                 ),
               Column(
                 children: [
                   for (int j = 0; j < group.items.length; j++)
                     _ChatTile(
-                          chat: group.items[j],
-                          textColor: textBase,
-                          selected:
-                              group.items[j].id ==
-                              chatService.currentConversationId,
-                          loading: widget.loadingConversationIds.contains(
-                            group.items[j].id,
-                          ),
-                          onTap: () {
-                            final closeDrawer = !context
-                                .read<SettingsProvider>()
-                                .keepSidebarOpenOnTopicTap;
-                            widget.onSelectConversation?.call(
-                              group.items[j].id,
-                              closeDrawer: closeDrawer,
-                            );
-                          },
-                          onLongPress: () =>
-                              _showChatMenu(context, group.items[j]),
-                          onSecondaryTap: (pos) => _showChatMenu(
-                            context,
-                            group.items[j],
-                            anchor: pos,
-                          ),
-                        )
-                        .animate(
-                          key: ValueKey(
-                            'grp-${group.label}-${group.items[j].id}',
-                          ),
-                        )
-                        .fadeIn(duration: 220.ms, delay: (16 * j).ms)
-                        .moveY(
-                          begin: 6,
-                          end: 0,
-                          duration: 240.ms,
-                          curve: Curves.easeOutCubic,
-                          delay: (16 * j).ms,
-                        ),
+                      chat: group.items[j],
+                      textColor: textBase,
+                      selected: group.items[j].id == chatService.currentConversationId,
+                      loading: widget.loadingConversationIds.contains(group.items[j].id),
+                      onTap: () {
+                        final closeDrawer = !context.read<SettingsProvider>().keepSidebarOpenOnTopicTap;
+                        widget.onSelectConversation?.call(group.items[j].id, closeDrawer: closeDrawer);
+                      },
+                      onLongPress: () => _showChatMenu(context, group.items[j]),
+                      onSecondaryTap: (pos) => _showChatMenu(context, group.items[j], anchor: pos),
+                    ).animate(key: ValueKey('grp-${group.label}-${group.items[j].id}'))
+                      .fadeIn(duration: 220.ms, delay: (16 * j).ms)
+                      .moveY(begin: 6, end: 0, duration: 240.ms, curve: Curves.easeOutCubic, delay: (16 * j).ms),
                 ],
               ),
               if (context.watch<SettingsProvider>().showChatListDate)
@@ -3074,29 +2379,21 @@ class _ChatTile extends StatefulWidget {
 
 class _ChatTileState extends State<_ChatTile> {
   bool _hovered = false;
-  bool get _isDesktop =>
-      defaultTargetPlatform == TargetPlatform.macOS ||
-      defaultTargetPlatform == TargetPlatform.windows ||
-      defaultTargetPlatform == TargetPlatform.linux;
+  bool get _isDesktop => defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final embedded =
-        context.findAncestorWidgetOfExactType<SideDrawer>()?.embedded ?? false;
+    final embedded = context.findAncestorWidgetOfExactType<SideDrawer>()?.embedded ?? false;
     final Color tileColor;
     if (embedded) {
       // In tablet embedded mode, keep selected highlight, others transparent
-      tileColor = widget.selected
-          ? cs.primary.withOpacity(0.16)
-          : Colors.transparent;
+      tileColor = widget.selected ? cs.primary.withOpacity(0.16) : Colors.transparent;
     } else {
       tileColor = widget.selected ? cs.primary.withOpacity(0.12) : cs.surface;
     }
     final base = _isDesktop && !widget.selected && _hovered
-        ? (embedded
-              ? cs.primary.withOpacity(0.08)
-              : cs.surface.withOpacity(0.9))
+        ? (embedded ? cs.primary.withOpacity(0.08) : cs.surface.withOpacity(0.9))
         : tileColor;
     final double _vGap = _isDesktop ? 4 : 4;
     return Padding(
@@ -3112,28 +2409,17 @@ class _ChatTileState extends State<_ChatTile> {
           widget.onLongPress?.call();
         },
         child: MouseRegion(
-          onEnter: (_) {
-            if (_isDesktop) setState(() => _hovered = true);
-          },
-          onExit: (_) {
-            if (_isDesktop) setState(() => _hovered = false);
-          },
-          cursor: _isDesktop
-              ? SystemMouseCursors.click
-              : SystemMouseCursors.basic,
-          child: IosCardPress(
-            baseColor: base,
-            borderRadius: BorderRadius.circular(16),
-            haptics: false,
-            onTap: widget.onTap,
-            onLongPress: _isDesktop ? null : widget.onLongPress,
-            padding: EdgeInsets.fromLTRB(
-              _isDesktop ? 14 : 14,
-              _isDesktop ? 9 : 10,
-              8,
-              _isDesktop ? 9 : 10,
-            ),
-            child: Row(
+          onEnter: (_) { if (_isDesktop) setState(() => _hovered = true); },
+          onExit: (_) { if (_isDesktop) setState(() => _hovered = false); },
+          cursor: _isDesktop ? SystemMouseCursors.click : SystemMouseCursors.basic,
+        child: IosCardPress(
+          baseColor: base,
+          borderRadius: BorderRadius.circular(16),
+          haptics: false,
+          onTap: widget.onTap,
+          onLongPress: _isDesktop ? null : widget.onLongPress,
+          padding: EdgeInsets.fromLTRB(_isDesktop ? 14 : 14, _isDesktop ? 9 : 10, 8, _isDesktop ? 9 : 10),
+          child: Row(
               children: [
                 Expanded(
                   child: Text(
@@ -3165,18 +2451,14 @@ class _LoadingDot extends StatefulWidget {
   State<_LoadingDot> createState() => _LoadingDotState();
 }
 
-class _LoadingDotState extends State<_LoadingDot>
-    with SingleTickerProviderStateMixin {
+class _LoadingDotState extends State<_LoadingDot> with SingleTickerProviderStateMixin {
   late final AnimationController _ctrl;
   late final Animation<double> _anim;
 
   @override
   void initState() {
     super.initState();
-    _ctrl = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 900),
-    )..repeat(reverse: true);
+    _ctrl = AnimationController(vsync: this, duration: const Duration(milliseconds: 900))..repeat(reverse: true);
     _anim = CurvedAnimation(parent: _ctrl, curve: Curves.easeInOut);
   }
 
@@ -3201,11 +2483,7 @@ class _LoadingDotState extends State<_LoadingDot>
 }
 
 class _GroupHeader extends StatelessWidget {
-  const _GroupHeader({
-    required this.title,
-    required this.collapsed,
-    required this.onToggle,
-  });
+  const _GroupHeader({required this.title, required this.collapsed, required this.onToggle});
   final String title;
   final bool collapsed;
   final VoidCallback onToggle;
@@ -3238,11 +2516,7 @@ class _GroupHeader extends StatelessWidget {
                 title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 13.5,
-                  fontWeight: FontWeight.w700,
-                  color: textBase,
-                ),
+                style: TextStyle(fontSize: 13.5, fontWeight: FontWeight.w700, color: textBase),
               ),
             ),
           ],
@@ -3254,10 +2528,7 @@ class _GroupHeader extends StatelessWidget {
 
 // Desktop: Header tabs (Assistants / Topics)
 class _DesktopSidebarTabs extends StatefulWidget {
-  const _DesktopSidebarTabs({
-    required this.textColor,
-    required this.controller,
-  });
+  const _DesktopSidebarTabs({required this.textColor, required this.controller});
   final Color textColor;
   final TabController controller;
   @override
@@ -3301,9 +2572,7 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
             final double segW = (constraints.maxWidth - pad * 2) / 2;
             return Container(
               decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white10
-                    : Colors.grey.shade200.withOpacity(0.80),
+                color: isDark ? Colors.white10 : Colors.grey.shade200.withOpacity(0.80),
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Stack(
@@ -3335,11 +2604,7 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
                           cursor: SystemMouseCursors.click,
                           child: GestureDetector(
                             behavior: HitTestBehavior.opaque,
-                            onTap: () => widget.controller.animateTo(
-                              0,
-                              duration: const Duration(milliseconds: 140),
-                              curve: Curves.easeOutCubic,
-                            ),
+                            onTap: () => widget.controller.animateTo(0, duration: const Duration(milliseconds: 140), curve: Curves.easeOutCubic),
                             child: Stack(
                               children: [
                                 // Hover wash
@@ -3360,24 +2625,12 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
                                   child: AnimatedDefaultTextStyle(
                                     duration: const Duration(milliseconds: 140),
                                     curve: Curves.easeOutCubic,
-                                    style:
-                                        (Theme.of(
-                                                  context,
-                                                ).textTheme.titleSmall ??
-                                                const TextStyle())
-                                            .copyWith(
-                                              fontSize: 13.5,
-                                              fontWeight: FontWeight.w700,
-                                              color: idx == 0
-                                                  ? cs.primary
-                                                  : widget.textColor
-                                                        .withOpacity(0.78),
-                                            ),
-                                    child: Text(
-                                      l10n.desktopSidebarTabAssistants,
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
+                                    style: (Theme.of(context).textTheme.titleSmall ?? const TextStyle()).copyWith(
+                                      fontSize: 13.5,
+                                      fontWeight: FontWeight.w700,
+                                      color: idx == 0 ? cs.primary : widget.textColor.withOpacity(0.78),
                                     ),
+                                    child: Text(l10n.desktopSidebarTabAssistants, maxLines: 1, overflow: TextOverflow.ellipsis),
                                   ),
                                 ),
                               ],
@@ -3392,11 +2645,7 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
                           cursor: SystemMouseCursors.click,
                           child: GestureDetector(
                             behavior: HitTestBehavior.opaque,
-                            onTap: () => widget.controller.animateTo(
-                              1,
-                              duration: const Duration(milliseconds: 140),
-                              curve: Curves.easeOutCubic,
-                            ),
+                            onTap: () => widget.controller.animateTo(1, duration: const Duration(milliseconds: 140), curve: Curves.easeOutCubic),
                             child: Stack(
                               children: [
                                 AnimatedOpacity(
@@ -3415,24 +2664,12 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
                                   child: AnimatedDefaultTextStyle(
                                     duration: const Duration(milliseconds: 140),
                                     curve: Curves.easeOutCubic,
-                                    style:
-                                        (Theme.of(
-                                                  context,
-                                                ).textTheme.titleSmall ??
-                                                const TextStyle())
-                                            .copyWith(
-                                              fontSize: 13.5,
-                                              fontWeight: FontWeight.w700,
-                                              color: idx == 1
-                                                  ? cs.primary
-                                                  : widget.textColor
-                                                        .withOpacity(0.78),
-                                            ),
-                                    child: Text(
-                                      l10n.desktopSidebarTabTopics,
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
+                                    style: (Theme.of(context).textTheme.titleSmall ?? const TextStyle()).copyWith(
+                                      fontSize: 13.5,
+                                      fontWeight: FontWeight.w700,
+                                      color: idx == 1 ? cs.primary : widget.textColor.withOpacity(0.78),
                                     ),
+                                    child: Text(l10n.desktopSidebarTabTopics, maxLines: 1, overflow: TextOverflow.ellipsis),
                                   ),
                                 ),
                               ],
@@ -3467,13 +2704,10 @@ class _DesktopTabViews extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDesktop =
-        defaultTargetPlatform == TargetPlatform.macOS ||
+    final isDesktop = defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows ||
         defaultTargetPlatform == TargetPlatform.linux;
-    final topPad = context.watch<SettingsProvider>().showChatListDate
-        ? (isDesktop ? 2.0 : 4.0)
-        : 10.0;
+    final topPad = context.watch<SettingsProvider>().showChatListDate ? (isDesktop ? 2.0 : 4.0) : 10.0;
     return TabBarView(
       controller: controller,
       physics: const BouncingScrollPhysics(),
@@ -3516,8 +2750,7 @@ class _LegacyListArea extends StatelessWidget {
       controller: listController,
       padding: EdgeInsets.fromLTRB(
         10,
-        (context.watch<SettingsProvider>().showChatListDate ||
-                assistantsExpanded)
+        (context.watch<SettingsProvider>().showChatListDate || assistantsExpanded)
             ? (isDesktop ? 2 : 4)
             : 10,
         10,
@@ -3533,14 +2766,10 @@ class _LegacyListArea extends StatelessWidget {
             duration: const Duration(milliseconds: 220),
             switchInCurve: Curves.easeOutCubic,
             switchOutCurve: Curves.easeInCubic,
-            transitionBuilder: (child, animation) =>
-                FadeTransition(opacity: animation, child: child),
+            transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
             child: !assistantsExpanded
                 ? const SizedBox.shrink()
-                : KeyedSubtree(
-                    key: const ValueKey('assistants-inline'),
-                    child: buildAssistants(),
-                  ),
+                : KeyedSubtree(key: const ValueKey('assistants-inline'), child: buildAssistants()),
           ),
         ),
         // Conversations
@@ -3579,10 +2808,7 @@ class _AssistantInlineTile extends StatefulWidget {
 
 class _AssistantInlineTileState extends State<_AssistantInlineTile> {
   bool _hovered = false;
-  bool get _isDesktop =>
-      defaultTargetPlatform == TargetPlatform.macOS ||
-      defaultTargetPlatform == TargetPlatform.windows ||
-      defaultTargetPlatform == TargetPlatform.linux;
+  bool get _isDesktop => defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux;
 
   @override
   Widget build(BuildContext context) {
@@ -3590,23 +2816,15 @@ class _AssistantInlineTileState extends State<_AssistantInlineTile> {
     final embedded = widget.embedded;
     final Color tileColor = _isDesktop
         ? (embedded
-              ? (widget.selected
-                    ? cs.primary.withOpacity(0.16)
-                    : Colors.transparent)
-              : (widget.selected ? cs.primary.withOpacity(0.12) : cs.surface))
+            ? (widget.selected ? cs.primary.withOpacity(0.16) : Colors.transparent)
+            : (widget.selected ? cs.primary.withOpacity(0.12) : cs.surface))
         : (embedded ? Colors.transparent : cs.surface);
     final Color bg = _isDesktop && !widget.selected && _hovered
-        ? (embedded
-              ? cs.primary.withOpacity(0.08)
-              : cs.surface.withOpacity(0.9))
+        ? (embedded ? cs.primary.withOpacity(0.08) : cs.surface.withOpacity(0.9))
         : tileColor;
     final content = MouseRegion(
-      onEnter: (_) {
-        if (_isDesktop) setState(() => _hovered = true);
-      },
-      onExit: (_) {
-        if (_isDesktop) setState(() => _hovered = false);
-      },
+      onEnter: (_) { if (_isDesktop) setState(() => _hovered = true); },
+      onExit: (_) { if (_isDesktop) setState(() => _hovered = false); },
       cursor: _isDesktop ? SystemMouseCursors.click : SystemMouseCursors.basic,
       child: IosCardPress(
         baseColor: bg,
@@ -3624,11 +2842,7 @@ class _AssistantInlineTileState extends State<_AssistantInlineTile> {
                 widget.name,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: _isDesktop ? 14 : 15,
-                  fontWeight: FontWeight.w600,
-                  color: widget.textColor,
-                ),
+                style: TextStyle(fontSize: _isDesktop ? 14 : 15, fontWeight: FontWeight.w600, color: widget.textColor),
               ),
             ),
             if (!_isDesktop) ...[


### PR DESCRIPTION
关联 Issue
- Closes #324 

做了什么
- 侧边栏“删除话题”增加二次确认，避免误删。
- 覆盖两个入口：桌面端右键菜单、移动端长按底部菜单。

怎么改的
- 仅修改 `lib/features/home/widgets/side_drawer.dart`。
- 新增私有方法 `_confirmDeleteConversation(BuildContext context, ChatItem chat)`，使用 `AlertDialog` 做确认。
- 两处删除回调先执行确认：取消则直接返回，确认才继续删除。
