### PR TITLE
fix: correct raw string regex escaping in world book

### DIFF
--- a/lib/features/world_book/pages/world_book_page.dart
+++ b/lib/features/world_book/pages/world_book_page.dart
@@ -283,7 +283,7 @@ class _WorldBookPageState extends State<WorldBookPage> {
   String _safeFileName(String name) {
     final cleaned = name
         .replaceAll(RegExp(r'[\\\\/:*?\"<>|]'), '_')
-        .replaceAll(RegExp(r'\\s+'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
         .trim();
     if (cleaned.isEmpty) return 'lorebook';
     return cleaned.length > 80 ? cleaned.substring(0, 80) : cleaned;
@@ -1211,7 +1211,7 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
   }
 
   List<String> _parseKeywordInput(String raw) {
-    final parts = raw.split(RegExp(r'[\\n,，;；]'));
+    final parts = raw.split(RegExp(r'[\n,，;；]'));
     final seen = <String>{};
     final out = <String>[];
     for (final p in parts) {


### PR DESCRIPTION
[world_book_page.dart](cci:7://file:///d:/ONE/CODE/kelivo/lib/features/world_book/pages/world_book_page.dart:0:0-0:0) 中有两处正则表达式因 raw string 中反斜杠数量错误导致匹配行为异常：

**1. [_parseKeywordInput](cci:1://file:///d:/ONE/CODE/kelivo/lib/features/world_book/pages/world_book_page.dart:1212:2-1222:3)（第 1214 行）**

`r'[\\n,，;；]'` 中的 `\\` 被 RegExp 引擎解释为字面反斜杠字符，`n` 作为独立字符。导致包含 `\` 的正则关键词（如 `\d`、`\s`）在输入时被错误拆分。

修复：`r'[\n,，;；]'`，使 `\n` 被正确解释为换行符。

**2. `_safeFileName`（第 286 行）**

`r'\\s+'` 被 RegExp 解释为两个字面反斜杠 + 字母 s 重复，实际上永远不会匹配到空白字符，导致导出文件名中的连续空格无法被合并。

修复：`r'\s+'`，正确匹配空白字符。