### PR TITLE
feat(models): Add Gemini 3.1 Pro thinking config

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -4749,6 +4749,7 @@ class ChatApiService {
           'thinkingConfig': () {
             // Match gemini-3-pro or gemini-3-pro-preview (and similar variants)
             final isGemini3ProImage = modelId.contains(RegExp(r'gemini-3-pro-image(-preview)?', caseSensitive: false));
+            final isGemini31Pro = modelId.contains(RegExp(r'gemini-3\.1-pro(-preview)?', caseSensitive: false));
             final isGemini3Pro = modelId.contains(RegExp(r'gemini-3-pro(-preview)?', caseSensitive: false));
             final isGemini3Flash = modelId.contains(RegExp(r'gemini-3-flash(-preview)?', caseSensitive: false));
             if (isGemini3ProImage) {
@@ -4758,6 +4759,17 @@ class ChatApiService {
                   'thinkingBudget': thinkingBudget,
               };
             }
+            // Gemini 3.1 Pro: supports 'low', 'medium', 'high' (no minimal)
+            if (isGemini31Pro) {
+              String level = 'high';
+              if (off) {
+                level = 'low';
+              } else if (thinkingBudget != null && thinkingBudget > 0) {
+                if (thinkingBudget < 8000) level = 'low';
+                else if (thinkingBudget < 24000) level = 'medium'; // gemini 3.1 pro support medium
+              }
+              return {'includeThoughts': true, 'thinkingLevel': level};
+            }
             // Gemini 3 Pro: supports 'low' and 'high' only (no off)
             if (isGemini3Pro) {
               String level = 'high';
@@ -4765,7 +4777,7 @@ class ChatApiService {
                 // Off or Light (1024) → low
                 level = 'low';
               }
-              return {'includeThoughts': true, 'thinkingLevel': level};
+              return {'includeThoughts': true, 'thinkingLevel': level}; // Gemini 3.0 Pro does not support medium, only low and high
             }
             // Gemini 3 Flash: supports 'minimal', 'low', 'medium', 'high'
             if (isGemini3Flash) {


### PR DESCRIPTION
- detect gemini-3.1-pro variants before 3.0 branches
- map thinkingBudget to low/medium/high without minimal
- keep 3.0 Pro/Flash behavior unchanged

<img width="956" height="512" alt="image" src="https://github.com/user-attachments/assets/f9ccee9e-d6d3-4062-84eb-37fd2385d92f" />
