### PR TITLE
fix: 世界书关键词 chip 长文本溢出导致删除按钮被挤出屏幕

### DIFF
--- a/lib/features/world_book/pages/world_book_page.dart
+++ b/lib/features/world_book/pages/world_book_page.dart
@@ -1372,19 +1372,22 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Padding(
-              padding: const EdgeInsets.only(
-                left: 10,
-                right: 6,
-                top: 6,
-                bottom: 6,
-              ),
-              child: Text(
-                keyword,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: cs.onSurface.withOpacity(0.9),
+            Flexible(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  left: 10,
+                  right: 6,
+                  top: 6,
+                  bottom: 6,
+                ),
+                child: Text(
+                  keyword,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface.withOpacity(0.9),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
### 背景与目标

> 世界书条目编辑页中，关键词以 chip 形式展示（`Row` 内含 `Text` + 删除按钮）。
> 当关键词文本过长时，`Text` 无限扩展，将右侧删除按钮挤出屏幕，无法点击。

### 变更漫游

| 文件 | 变更要点 | 增删 |
|------|---------|------|
| `lib/features/world_book/pages/world_book_page.dart` | `Padding > Text` 外层包裹 `Flexible`，`Text` 添加 `overflow: TextOverflow.ellipsis` | +16 ~-13~ |

### 行为变化

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 关键词超出 chip 宽度 | 文本撑开 Row，删除按钮不可见 | 文本省略号截断，删除按钮始终可见 |
| 短关键词 | 正常 | 无变化 |

### 验证建议

- [ ] 添加超长关键词（50+ 字符），确认 chip 显示省略号且删除按钮可点击
- [ ] 短关键词显示和交互无影响