### PR TITLE
feat：在迷你地图中添加滚动到底部按钮

### DIFF
--- a/lib/features/home/widgets/mini_map_sheet.dart
+++ b/lib/features/home/widgets/mini_map_sheet.dart
@@ -139,7 +139,21 @@ class _MiniMapSheetState extends State<_MiniMapSheet> with TickerProviderStateMi
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
-                    const SizedBox(width: 8),
+                    const SizedBox(width: 4),
+                    SizedBox(
+                      height: 36,
+                      width: 36,
+                      child: IconButton(
+                        padding: EdgeInsets.zero,
+                        icon: Icon(Lucide.ChevronsDown, size: 18, color: cs.onSurface),
+                        tooltip: 'Scroll to bottom',
+                        onPressed: () {
+                          if (controller.hasClients && controller.position.maxScrollExtent > 0) {
+                            controller.jumpTo(controller.position.maxScrollExtent);
+                          }
+                        },
+                      ),
+                    ),
                     _buildSearchToggle(context, searchWidth),
                   ],
                 ),


### PR DESCRIPTION
### 背景与目标

在长对话中使用迷你地图（Mini Map）时，列表可能有大量条目。
目前标题栏只有搜索按钮，用户想快速查看最近的对话需要手动滑到底部，对于几百条消息的对话体验不佳。

本 PR 在迷你地图标题栏中添加一个"跳转底部"按钮（⏬ ChevronsDown 图标），
点击后立即跳转到 DraggableScrollableSheet 的底部，方便快速定位到最新消息。

### 变更漫游

| 文件 | 变更要点 | 增删 |
|------|---------|------|
| [lib/features/home/widgets/mini_map_sheet.dart](cci:7://file:///d:/ONE/CODE/kelivo/lib/features/home/widgets/mini_map_sheet.dart:0:0-0:0) | 标题栏 Row 中搜索按钮前新增 ChevronsDown IconButton，点击跳转到 `controller.position.maxScrollExtent` | +14 ~-1~ |

### 行为变化

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 打开迷你地图后想查看最近消息 | 需要手动向下滚动 | 点击 ⏬ 按钮一键跳到底部 |

### 验证建议

- [ ] 打开一个消息数较多（30+）的对话，呼出迷你地图
- [ ] 点击标题栏中的 ⏬ 按钮，确认列表跳转到底部
- [ ] 在消息数较少（不足一屏）的对话中点击按钮，确认无异常
- [ ] 确认搜索按钮功能不受影响
