### PR TITLE
refactor: increase max context message to 1024

### DIFF
--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -56,7 +56,7 @@ part 'assistant_settings_edit_custom_request_tab.dart';
 part 'assistant_settings_edit_mcp_tab.dart';
 
 const int _contextMessageMin = 1;
-const int _contextMessageMax = 256;
+const int _contextMessageMax = 1024;
 
 int _clampContextMessages(num value) =>
     value.clamp(_contextMessageMin, _contextMessageMax).toInt();
@@ -1705,6 +1705,8 @@ class _DesktopAssistantBasicPaneState
                           64.0,
                           128.0,
                           256.0,
+                          512.0,
+                          1024.0,
                         ],
                         onLabelTap: a.limitContextMessages
                             ? () async {


### PR DESCRIPTION
## 概述
对于需要与 AI 进行多回合日常闲聊的用户而言，每轮对话消息的 Token 通常不长，但只有 256 大小的上下文对话窗口不太够用，建议增加到 1024。

## 代码变更
* Updated the `_contextMessageMax` constant in `assistant_settings_edit_page.dart` from 256 to 1024, allowing users to set a higher maximum for context messages.
* Added new selectable values (512 and 1024) to the context message limit options in the `_DesktopAssistantBasicPaneState` class, reflecting the increased maximum in the UI.