### PR TITLE
fix: support additional markdown horizontal rule syntax

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
@@ -47,6 +48,11 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
   // We apply s^(1-k) instead of s to the list rows to gently normalize.
   // Increase k if lists still look larger at small scales; decrease if too small at large scales.
   static const double kMarkdownListScaleCompensation = 0.84;
+  static const String _horizontalRuleTokenPattern = r'(?:-{3,}|\*{3,}|_{3,}|⸻)';
+
+  @visibleForTesting
+  static const String markdownHorizontalRuleLinePattern =
+      r'^\s*' + _horizontalRuleTokenPattern + r'\s*$';
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +61,7 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final sanitizedText = _sanitizeImageLinks(text);
     final imageUrls = _extractImageUrls(sanitizedText);
-    final normalized = _preprocessFences(
+    final normalized = preprocessMarkdownForRendering(
       sanitizedText,
       enableMath: settings.enableMathRendering,
       enableDollarLatex: settings.enableDollarLatex,
@@ -700,7 +706,8 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
     }
   }
 
-  static String _preprocessFences(
+  @visibleForTesting
+  static String preprocessMarkdownForRendering(
     String input, {
     required bool enableMath,
     required bool enableDollarLatex,
@@ -816,7 +823,7 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
     // If a line of only dashes follows a bold label line (e.g., "**作者:** 张三"),
     // insert a blank line so it's treated as an HR, not a Setext heading underline.
     final labelThenDash = RegExp(
-      r"^(\*\*[^\n*]+\*\*.*)\n(\s*-{3,}\s*$)",
+      r"^(\*\*[^\n*]+\*\*.*)\n(\s*" + _horizontalRuleTokenPattern + r"\s*$)",
       multiLine: true,
     );
     out = out.replaceAllMapped(labelThenDash, (m) => "${m[1]}\n\n${m[2]}");
@@ -834,10 +841,7 @@ class MarkdownWithCodeHighlight extends StatelessWidget {
     //    citations as [[1]](url), where the inner [1] is the display text. The
     //    link regex cannot match nested brackets, so flatten them first.
     final doubleBracketLink = RegExp(r'\[\[([^\]]+)\]\]\(([^\s)]+)\)');
-    out = out.replaceAllMapped(
-      doubleBracketLink,
-      (m) => '[${m[1]}](${m[2]})',
-    );
+    out = out.replaceAllMapped(doubleBracketLink, (m) => '[${m[1]}](${m[2]})');
 
     // 8) Fix: when multiple markdown links are placed on separate lines using
     //    trailing double-spaces (hard line breaks), gpt_markdown may treat them
@@ -2001,7 +2005,8 @@ class _MermaidBlockState extends State<_MermaidBlock> {
 // Full-width horizontal rule with softer color
 class SoftHrLine extends BlockMd {
   @override
-  String get expString => (r"^\s*(?:-{3,}|⸻)\s*$");
+  String get expString =>
+      MarkdownWithCodeHighlight.markdownHorizontalRuleLinePattern;
 
   @override
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {

--- a/test/markdown_horizontal_rule_test.dart
+++ b/test/markdown_horizontal_rule_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/shared/widgets/markdown_with_highlight.dart';
+
+void main() {
+  group('markdown horizontal rule pattern', () {
+    final hrRegex = RegExp(
+      MarkdownWithCodeHighlight.markdownHorizontalRuleLinePattern,
+      multiLine: true,
+    );
+
+    test('matches dash, star, underscore and em dash separators', () {
+      expect(hrRegex.hasMatch('---'), isTrue);
+      expect(hrRegex.hasMatch('***'), isTrue);
+      expect(hrRegex.hasMatch('___'), isTrue);
+      expect(hrRegex.hasMatch('⸻'), isTrue);
+    });
+
+    test('does not match list items or emphasis text', () {
+      expect(hrRegex.hasMatch('- item'), isFalse);
+      expect(hrRegex.hasMatch('***bold***'), isFalse);
+      expect(hrRegex.hasMatch('__label__'), isFalse);
+    });
+  });
+
+  group('markdown preprocessing for horizontal rules', () {
+    test(
+      'keeps supported horizontal rules after bold labels as block separators',
+      () {
+        expect(
+          MarkdownWithCodeHighlight.preprocessMarkdownForRendering(
+            '**作者:** 张三\n---',
+            enableMath: false,
+            enableDollarLatex: false,
+          ),
+          '**作者:** 张三\n\n---',
+        );
+        expect(
+          MarkdownWithCodeHighlight.preprocessMarkdownForRendering(
+            '**作者:** 张三\n***',
+            enableMath: false,
+            enableDollarLatex: false,
+          ),
+          '**作者:** 张三\n\n***',
+        );
+        expect(
+          MarkdownWithCodeHighlight.preprocessMarkdownForRendering(
+            '**作者:** 张三\n___',
+            enableMath: false,
+            enableDollarLatex: false,
+          ),
+          '**作者:** 张三\n\n___',
+        );
+      },
+    );
+
+    test(
+      'does not rewrite emphasis or fenced code blocks containing stars',
+      () {
+        expect(
+          MarkdownWithCodeHighlight.preprocessMarkdownForRendering(
+            '***bold***',
+            enableMath: false,
+            enableDollarLatex: false,
+          ),
+          '***bold***',
+        );
+        expect(
+          MarkdownWithCodeHighlight.preprocessMarkdownForRendering(
+            '```\n***\n```',
+            enableMath: false,
+            enableDollarLatex: false,
+          ),
+          '```\n***\n```',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- support `***` and `___` as markdown horizontal rules alongside existing `---`
- add focused tests to keep emphasis text and fenced code blocks from being misparsed

## Test plan
- [x] `flutter test test/markdown_horizontal_rule_test.dart`

Fixed #395