### PR TITLE
fix: message template preview uses different date/time format than actual send

### DIFF
--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -12,7 +12,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart';
-import 'package:intl/intl.dart';
+import '../../../core/services/chat/prompt_transformer.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';

--- a/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
@@ -289,19 +289,12 @@ class _PromptTabState extends State<_PromptTab> {
 
     String processed(String tpl) {
       final t = (tpl.trim().isEmpty ? '{{ message }}' : tpl);
-      // Simple replacements consistent with PromptTransformer
-      final locale = Localizations.localeOf(context);
-      final dateStr = locale.languageCode == 'zh'
-          ? DateFormat('yyyy年M月d日', 'zh').format(now)
-          : DateFormat('yyyy-MM-dd').format(now);
-      final timeStr = locale.languageCode == 'zh'
-          ? DateFormat('a h:mm:ss', 'zh').format(now)
-          : DateFormat('HH:mm:ss').format(now);
-      return t
-          .replaceAll('{{ role }}', 'user')
-          .replaceAll('{{ message }}', sampleMsg)
-          .replaceAll('{{ time }}', timeStr)
-          .replaceAll('{{ date }}', dateStr);
+      return PromptTransformer.applyMessageTemplate(
+        t,
+        role: 'user',
+        message: sampleMsg,
+        now: now,
+      );
     }
 
     // System Prompt Card (no border, iOS style)


### PR DESCRIPTION
### 背景与目标

助手设置编辑页的消息模板预览中，`{{ date }}` 和 `{{ time }}` 使用了 locale 感知的 `DateFormat`（中文环境显示 `2026年3月19日`、`上午 12:45:02`），而实际发给 API 的消息走的是 `PromptTransformer.applyMessageTemplate()`，始终格式化为 `YYYY-MM-DD` 和 `HH:mm`（无秒数、不随 locale 变化）。

导致预览与 LLM 实际收到的内容不一致，用户无法通过预览准确确认模板效果。

### 变更漫游

| 文件 | 变更要点 | 增删 |
|------|---------|------|
| [assistant_settings_edit_page.dart](cci:7://file:///d:/ONE/CODE/kelivo/lib/features/assistant/pages/assistant_settings_edit_page.dart:0:0-0:0) | `intl` import 替换为 `prompt_transformer.dart` | +1 ~-1~ |
| [assistant_settings_edit_prompt_tab.dart](cci:7://file:///d:/ONE/CODE/kelivo/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart:0:0-0:0) | [processed()](cci:1://file:///d:/ONE/CODE/kelivo/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart:289:4-297:5) 中手写的 `DateFormat` 替换为直接调用 `PromptTransformer.applyMessageTemplate()` | +6 ~-13~ |

### 行为变化

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 中文环境 `{{ date }}` 预览 | `2026年3月19日` | `2026-03-19` |
| 中文环境 `{{ time }}` 预览 | `上午 12:45:02` | `00:45` |
| 英文环境 `{{ date }}` 预览 | `2026-03-19` | `2026-03-19`（不变） |
| 英文环境 `{{ time }}` 预览 | `12:45:02` | `00:45` |

预览现在与 `PromptTransformer.applyMessageTemplate()` 的输出完全一致，所见即所得。

### 验证建议

- [ ] 打开助手设置 → 提示词标签页
- [ ] 输入包含 `{{ date }}` 和 `{{ time }}` 的消息模板
- [ ] 确认预览格式与实际聊天中发出的消息一致
- [ ] 切换语言（中 ↔ 英），确认预览始终与实际发送格式相同
