### PR TITLE
Fix: assistant avatar not updating from global search results

### DIFF
--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -339,6 +339,8 @@ class HomeViewModel extends ChangeNotifier {
 
   /// Switch to an existing conversation.
   Future<void> switchConversation(String id) async {
+    final assistantProvider = _contextProvider.read<AssistantProvider>();
+
     // Flush current conversation progress before switching
     await _chatActions.flushConversationProgress(currentConversation);
 
@@ -350,6 +352,12 @@ class HomeViewModel extends ChangeNotifier {
     _chatService.setCurrentConversation(id);
     final convo = _chatService.getConversation(id);
     if (convo != null) {
+      final convoAssistantId = convo.assistantId;
+      if (convoAssistantId != null &&
+          assistantProvider.currentAssistantId != convoAssistantId &&
+          assistantProvider.getById(convoAssistantId) != null) {
+        await assistantProvider.setCurrentAssistant(convoAssistantId);
+      }
       _chatController.setCurrentConversation(convo);
       _streamController.clearGeminiThoughtSigs();
       notifyListeners();


### PR DESCRIPTION
## 变更说明
- 修复从全局搜索结果进入会话时，标题栏 assistant avatar 不刷新的问题
- 在切换会话时同步当前会话对应的 assistant，确保标题栏头像状态与会话一致
- 保持改动最小，仅调整会话切换链路，不改动其他导航逻辑
## 验证
- `dart format "lib/features/home/controllers/home_view_model.dart"`
- `flutter analyze`
- `flutter test`
## 备注
- `flutter test` 已通过
- `flutter analyze` 仍有 1 个仓库现存告警与本次改动无关