### PR TITLE
Domain Migration: Replace afdian.com with ifdian.net

### DIFF
--- a/lib/desktop/setting/about_pane.dart
+++ b/lib/desktop/setting/about_pane.dart
@@ -560,7 +560,7 @@ Future<void> _showSponsorDesktopDialog(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
   final l10n = AppLocalizations.of(context)!;
   final isDark = Theme.of(context).brightness == Brightness.dark;
-  const afdianUrl = 'https://afdian.com/a/kelivo';
+  const afdianUrl = 'https://ifdian.net/a/kelivo';
   final wechatQrUrl = isDark
       ? 'https://c.img.dasctf.com/LightPicture/2025/10/ee10ae78acbd01f3.png'
       : 'https://c.img.dasctf.com/LightPicture/2025/10/6ba60ac0f2f8e2b4.png';

--- a/lib/features/settings/pages/sponsor_page.dart
+++ b/lib/features/settings/pages/sponsor_page.dart
@@ -100,7 +100,7 @@ class _SponsorPageState extends State<SponsorPage> {
                 icon: Lucide.Heart,
                 label: l10n.sponsorPageAfdianTitle,
                 onTap: () async {
-                  final uri = Uri.parse('https://afdian.com/a/kelivo');
+                  final uri = Uri.parse('https://ifdian.net/a/kelivo');
                   if (!await launchUrl(uri, mode: LaunchMode.platformDefault)) {
                     await launchUrl(uri, mode: LaunchMode.externalApplication);
                   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -161,7 +161,7 @@
   "sponsorPageSponsorsSectionTitle": "Sponsors",
   "sponsorPageEmpty": "No sponsors yet",
   "sponsorPageAfdianTitle": "Afdian",
-  "sponsorPageAfdianSubtitle": "afdian.com/a/kelivo",
+  "sponsorPageAfdianSubtitle": "ifdian.net/a/kelivo",
   "sponsorPageWeChatTitle": "WeChat Sponsor",
   "sponsorPageWeChatSubtitle": "WeChat sponsor code",
   "sponsorPageScanQrHint": "Scan the QR code to sponsor",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -595,7 +595,7 @@ abstract class AppLocalizations {
   /// No description provided for @sponsorPageAfdianSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'afdian.com/a/kelivo'**
+  /// **'ifdian.net/a/kelivo'**
   String get sponsorPageAfdianSubtitle;
 
   /// No description provided for @sponsorPageWeChatTitle.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -280,7 +280,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sponsorPageAfdianTitle => 'Afdian';
 
   @override
-  String get sponsorPageAfdianSubtitle => 'afdian.com/a/kelivo';
+  String get sponsorPageAfdianSubtitle => 'ifdian.net/a/kelivo';
 
   @override
   String get sponsorPageWeChatTitle => 'WeChat Sponsor';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -277,7 +277,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sponsorPageAfdianTitle => '爱发电';
 
   @override
-  String get sponsorPageAfdianSubtitle => 'afdian.com/a/kelivo';
+  String get sponsorPageAfdianSubtitle => 'ifdian.net/a/kelivo';
 
   @override
   String get sponsorPageWeChatTitle => '微信赞助';
@@ -4477,7 +4477,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get sponsorPageAfdianTitle => '爱发电';
 
   @override
-  String get sponsorPageAfdianSubtitle => 'afdian.com/a/kelivo';
+  String get sponsorPageAfdianSubtitle => 'ifdian.net/a/kelivo';
 
   @override
   String get sponsorPageWeChatTitle => '微信赞助';
@@ -8625,7 +8625,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get sponsorPageAfdianTitle => '愛發電';
 
   @override
-  String get sponsorPageAfdianSubtitle => 'afdian.com/a/kelivo';
+  String get sponsorPageAfdianSubtitle => 'ifdian.net/a/kelivo';
 
   @override
   String get sponsorPageWeChatTitle => '微信贊助';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -83,7 +83,7 @@
   "sponsorPageSponsorsSectionTitle": "赞助用户",
   "sponsorPageEmpty": "暂无赞助者",
   "sponsorPageAfdianTitle": "爱发电",
-  "sponsorPageAfdianSubtitle": "afdian.com/a/kelivo",
+  "sponsorPageAfdianSubtitle": "ifdian.net/a/kelivo",
   "sponsorPageWeChatTitle": "微信赞助",
   "sponsorPageWeChatSubtitle": "微信赞助码",
   "sponsorPageScanQrHint": "扫描二维码赞助",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -83,7 +83,7 @@
   "sponsorPageSponsorsSectionTitle": "赞助用户",
   "sponsorPageEmpty": "暂无赞助者",
   "sponsorPageAfdianTitle": "爱发电",
-  "sponsorPageAfdianSubtitle": "afdian.com/a/kelivo",
+  "sponsorPageAfdianSubtitle": "ifdian.net/a/kelivo",
   "sponsorPageWeChatTitle": "微信赞助",
   "sponsorPageWeChatSubtitle": "微信赞助码",
   "sponsorPageScanQrHint": "扫描二维码赞助",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -83,7 +83,7 @@
   "sponsorPageSponsorsSectionTitle": "贊助用戶",
   "sponsorPageEmpty": "暫無贊助者",
   "sponsorPageAfdianTitle": "愛發電",
-  "sponsorPageAfdianSubtitle": "afdian.com/a/kelivo",
+  "sponsorPageAfdianSubtitle": "ifdian.net/a/kelivo",
   "sponsorPageWeChatTitle": "微信贊助",
   "sponsorPageWeChatSubtitle": "微信贊助碼",
   "sponsorPageScanQrHint": "掃描二維碼贊助",


### PR DESCRIPTION
爱发电的 afdian.com 已不在使用，替换为 ifdian.net