### PR TITLE
fix(mcp): only apply enum/waitFor fallbacks for required tool params

### DIFF
--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -1069,7 +1069,9 @@ class McpProvider extends ChangeNotifier {
           if (v == null) {
             if (propSchema.containsKey('default')) {
               v = propSchema['default'];
-            } else {
+            } else if (req.contains(key)) {
+              // Only synthesize enum / waitFor defaults for required fields; optional
+              // omitted keys should stay absent (do not pick enum.first).
               final enumVals = _schemaEnum(propSchema);
               if (enumVals.isNotEmpty) {
                 v = enumVals.first;


### PR DESCRIPTION
## Description

### Problem

When normalizing MCP `callTool` arguments against the tool’s JSON Schema, `_normalizeBySchema` filled missing values with the first `enum` entry (and used a heuristic `0` for `waitFor`) even when the property was not listed in `required`. That could change the intended semantics of optional fields: the server might expect the key to be omitted, but Kelivo sent an arbitrary first enum value instead.

### Solution

- Keep applying explicit JSON Schema `default` values when present (unchanged).
- Apply enum-first and `waitFor` → 0 fallbacks only when the property name appears in the schema’s `required` array.

Optional parameters with no `default` and no model-provided value are left unset so they can be omitted from the normalized payload as before.

### Files changed

- `lib/core/providers/mcp_provider.dart` — `_normalizeBySchema` object-property branch

### How to test

1. Use an MCP tool whose `inputSchema` defines an optional property with `enum` and no `default`.
2. Trigger a call where the model omits that property.
3. Confirm the outgoing arguments do not include that key set to the first enum value 