### PR TITLE
fix(desktop): queue a single pending send during streaming

### DIFF
--- a/lib/core/models/chat_input_data.dart
+++ b/lib/core/models/chat_input_data.dart
@@ -21,3 +21,12 @@ class ChatInputData {
     this.documents = const [],
   });
 }
+
+enum ChatInputSubmissionResult { sent, queued, rejected }
+
+class QueuedChatInput {
+  final String conversationId;
+  final ChatInputData input;
+
+  const QueuedChatInput({required this.conversationId, required this.input});
+}

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -234,6 +234,8 @@ class HomePageController extends ChangeNotifier {
     return loadingConversationIds.contains(cid);
   }
 
+  QueuedChatInput? get currentQueuedInput => _viewModel.currentQueuedInput;
+
   ValueNotifier<bool> get isProcessingFiles => _viewModel.isProcessingFiles;
 
   @override
@@ -564,21 +566,39 @@ class HomePageController extends ChangeNotifier {
   // Public Methods - Message Actions
   // ============================================================================
 
-  Future<void> sendMessage(ChatInputData input) async {
+  Future<ChatInputSubmissionResult> sendMessage(ChatInputData input) async {
     final content = input.text.trim();
     if (content.isEmpty &&
         input.imagePaths.isEmpty &&
         input.documents.isEmpty) {
-      return;
+      return ChatInputSubmissionResult.rejected;
     }
     if (currentConversation == null) {
       await _createNewConversation();
     }
 
-    final success = await _viewModel.sendMessage(input);
-    if (success) {
+    final result = await _viewModel.sendMessage(input);
+    if (result != ChatInputSubmissionResult.rejected) {
       notifyListeners();
     }
+    return result;
+  }
+
+  void cancelQueuedMessage() {
+    final restored = _viewModel.cancelCurrentQueuedInput();
+    if (restored == null) return;
+
+    _inputController.value = TextEditingValue(
+      text: restored.text,
+      selection: TextSelection.collapsed(offset: restored.text.length),
+      composing: TextRange.empty,
+    );
+    _mediaController.restoreInput(restored);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_context.mounted) return;
+      _inputFocus.requestFocus();
+    });
+    notifyListeners();
   }
 
   Future<void> regenerateAtMessage(

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -84,6 +84,8 @@ class HomeViewModel extends ChangeNotifier {
   final ChatController _chatController;
   final BuildContext _contextProvider;
   late final ChatActions _chatActions;
+  QueuedChatInput? _queuedInput;
+  bool _isDrainingQueuedInput = false;
 
   /// Function to get localized title
   final String Function(BuildContext context) getTitleForLocale;
@@ -137,6 +139,15 @@ class HomeViewModel extends ChangeNotifier {
   bool get isCurrentConversationLoading =>
       _chatController.isCurrentConversationLoading;
 
+  QueuedChatInput? get currentQueuedInput {
+    final cid = currentConversation?.id;
+    final queued = _queuedInput;
+    if (cid == null || queued == null || queued.conversationId != cid) {
+      return null;
+    }
+    return queued;
+  }
+
   final ValueNotifier<bool> isProcessingFiles = ValueNotifier<bool>(false);
 
   // ============================================================================
@@ -150,6 +161,9 @@ class HomeViewModel extends ChangeNotifier {
 
   void _onLoadingChanged(String conversationId, bool loading) {
     notifyListeners();
+    if (!loading) {
+      unawaited(_drainQueuedInputIfReady(conversationId));
+    }
   }
 
   void _onContentUpdated(String messageId, String content, int totalTokens) {
@@ -197,8 +211,15 @@ class HomeViewModel extends ChangeNotifier {
   // Public Methods - Message Actions
   // ============================================================================
 
-  /// Send a new message. Returns true if successful.
-  Future<bool> sendMessage(ChatInputData input) async {
+  /// Send a new message or queue it if the current conversation is busy.
+  Future<ChatInputSubmissionResult> sendMessage(ChatInputData input) async {
+    final content = input.text.trim();
+    if (content.isEmpty &&
+        input.imagePaths.isEmpty &&
+        input.documents.isEmpty) {
+      return ChatInputSubmissionResult.rejected;
+    }
+
     final conversation = currentConversation;
     if (conversation == null) {
       // Create new conversation first
@@ -207,6 +228,44 @@ class HomeViewModel extends ChangeNotifier {
 
     if (currentConversation == null) {
       onError?.call('no_conversation');
+      return ChatInputSubmissionResult.rejected;
+    }
+
+    final activeConversation = currentConversation!;
+    if (_chatController.isConversationLoading(activeConversation.id)) {
+      if (_queuedInput != null) {
+        return ChatInputSubmissionResult.rejected;
+      }
+      _queuedInput = QueuedChatInput(
+        conversationId: activeConversation.id,
+        input: _cloneInput(input),
+      );
+      notifyListeners();
+      return ChatInputSubmissionResult.queued;
+    }
+
+    final success = await _sendMessageToConversation(input, activeConversation);
+    return success
+        ? ChatInputSubmissionResult.sent
+        : ChatInputSubmissionResult.rejected;
+  }
+
+  ChatInputData? cancelCurrentQueuedInput() {
+    final queued = currentQueuedInput;
+    if (queued == null || _isDrainingQueuedInput) return null;
+    _queuedInput = null;
+    notifyListeners();
+    return _cloneInput(queued.input);
+  }
+
+  Future<bool> _sendMessageToConversation(
+    ChatInputData input,
+    Conversation conversation,
+  ) async {
+    final content = input.text.trim();
+    if (content.isEmpty &&
+        input.imagePaths.isEmpty &&
+        input.documents.isEmpty) {
       return false;
     }
 
@@ -221,7 +280,7 @@ class HomeViewModel extends ChangeNotifier {
 
     final result = await _chatActions.sendMessage(
       input: input,
-      conversation: currentConversation!,
+      conversation: conversation,
     );
 
     if (!result.success) {
@@ -235,6 +294,39 @@ class HomeViewModel extends ChangeNotifier {
 
     onScrollToBottom?.call();
     return true;
+  }
+
+  ChatInputData _cloneInput(ChatInputData input) {
+    return ChatInputData(
+      text: input.text,
+      imagePaths: List<String>.of(input.imagePaths),
+      documents: List<DocumentAttachment>.of(input.documents),
+    );
+  }
+
+  Future<void> _drainQueuedInputIfReady(String conversationId) async {
+    if (_isDrainingQueuedInput) return;
+    final queued = _queuedInput;
+    final conversation = currentConversation;
+    if (queued == null || conversation == null) return;
+    if (queued.conversationId != conversationId ||
+        conversation.id != conversationId) {
+      return;
+    }
+    if (_chatController.isConversationLoading(conversationId)) return;
+
+    _isDrainingQueuedInput = true;
+    _queuedInput = null;
+    notifyListeners();
+
+    final input = queued.input;
+    final success = await _sendMessageToConversation(input, conversation);
+    if (!success) {
+      _queuedInput = queued;
+    }
+
+    _isDrainingQueuedInput = false;
+    notifyListeners();
   }
 
   /// Regenerate response at a specific message.
@@ -364,6 +456,7 @@ class HomeViewModel extends ChangeNotifier {
       _streamController.clearGeminiThoughtSigs();
       notifyListeners();
       onConversationSwitched?.call();
+      unawaited(_drainQueuedInputIfReady(id));
     }
   }
 

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -16,6 +16,7 @@ import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
 import '../../../core/models/quick_phrase.dart';
+import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/services/android_process_text.dart';
 import '../../../utils/sandbox_path_resolver.dart';
@@ -849,16 +850,19 @@ class _HomePageState extends State<HomePage>
           );
         }
       },
-      onSend: (text) {
-        _controller.sendMessage(text);
-        _inputController.clear();
-        if (PlatformUtils.isMobile) {
+      onSend: (text) async {
+        final result = await _controller.sendMessage(text);
+        if (!mounted) return result;
+        if (PlatformUtils.isMobile &&
+            result == ChatInputSubmissionResult.sent) {
           _controller.dismissKeyboard();
-        } else {
-          _inputFocus.requestFocus();
         }
+        return result;
       },
       onStop: _controller.cancelStreaming,
+      hasQueuedInput: _controller.currentQueuedInput != null,
+      queuedPreviewText: _controller.currentQueuedInput?.input.text,
+      onCancelQueuedInput: _controller.cancelQueuedMessage,
       onQuickPhrase: _showQuickPhraseMenu,
       onLongPressQuickPhrase: () {
         Navigator.of(

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -37,6 +37,7 @@ class ChatInputBarController {
   void clearImages() => _state?._clearImages();
   void addFiles(List<DocumentAttachment> docs) => _state?._addFiles(docs);
   void clearFiles() => _state?._clearFiles();
+  void restoreInput(ChatInputData input) => _state?._restoreInput(input);
 }
 
 class ChatInputBar extends StatefulWidget {
@@ -58,6 +59,9 @@ class ChatInputBar extends StatefulWidget {
     this.controller,
     this.mediaController,
     this.loading = false,
+    this.hasQueuedInput = false,
+    this.queuedPreviewText,
+    this.onCancelQueuedInput,
     this.reasoningActive = false,
     this.supportsReasoning = true,
     this.showMcpButton = false,
@@ -84,7 +88,7 @@ class ChatInputBar extends StatefulWidget {
     this.onToggleOcr,
   });
 
-  final ValueChanged<ChatInputData>? onSend;
+  final Future<ChatInputSubmissionResult> Function(ChatInputData)? onSend;
   final VoidCallback? onStop;
   final VoidCallback? onSelectModel;
   final VoidCallback? onLongPressSelectModel;
@@ -100,6 +104,9 @@ class ChatInputBar extends StatefulWidget {
   final TextEditingController? controller;
   final ChatInputBarController? mediaController;
   final bool loading;
+  final bool hasQueuedInput;
+  final String? queuedPreviewText;
+  final VoidCallback? onCancelQueuedInput;
   final bool reasoningActive;
   final bool supportsReasoning;
   final bool showMcpButton;
@@ -148,6 +155,9 @@ class _ChatInputBarState extends State<ChatInputBar>
   );
   // Suppress context menu briefly after app resume to avoid flickering
   bool _suppressContextMenu = false;
+  bool _isSubmitting = false;
+
+  bool get _composerLocked => widget.hasQueuedInput;
 
   // Instance method for onChanged to avoid recreating the callback on every build
   void _onTextChanged(String _) => setState(() {});
@@ -168,6 +178,17 @@ class _ChatInputBarState extends State<ChatInputBar>
 
   void _clearFiles() {
     setState(() => _docs.clear());
+  }
+
+  void _restoreInput(ChatInputData input) {
+    setState(() {
+      _images
+        ..clear()
+        ..addAll(input.imagePaths);
+      _docs
+        ..clear()
+        ..addAll(input.documents);
+    });
   }
 
   void _removeImageAt(int index) async {
@@ -248,26 +269,38 @@ class _ChatInputBarState extends State<ChatInputBar>
   /// Whether to show the expand/collapse button (when text has 3+ lines).
   bool get _showExpandButton => _lineCount >= 3;
 
-  void _handleSend() {
+  Future<void> _handleSend() async {
+    if (_isSubmitting) return;
     final text = _controller.text.trim();
     if (text.isEmpty && _images.isEmpty && _docs.isEmpty) return;
-    widget.onSend?.call(
-      ChatInputData(
-        text: text,
-        imagePaths: List.of(_images),
-        documents: List.of(_docs),
-      ),
-    );
-    _controller.clear();
-    _images.clear();
-    _docs.clear();
-    setState(() {});
-    // Keep focus on desktop so user can continue typing
+    _isSubmitting = true;
     try {
-      if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
-        widget.focusNode?.requestFocus();
+      final result =
+          await widget.onSend?.call(
+            ChatInputData(
+              text: text,
+              imagePaths: List.of(_images),
+              documents: List.of(_docs),
+            ),
+          ) ??
+          ChatInputSubmissionResult.rejected;
+      if (!mounted) return;
+      if (result == ChatInputSubmissionResult.sent ||
+          result == ChatInputSubmissionResult.queued) {
+        _controller.clear();
+        _images.clear();
+        _docs.clear();
+        setState(() {});
+        // Keep focus on desktop so user can continue typing
+        try {
+          if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+            widget.focusNode?.requestFocus();
+          }
+        } catch (_) {}
       }
-    } catch (_) {}
+    } finally {
+      _isSubmitting = false;
+    }
   }
 
   void _insertNewlineAtCursor() {
@@ -467,7 +500,7 @@ class _ChatInputBarState extends State<ChatInputBar>
       if (sendShortcut == DesktopSendShortcut.ctrlEnter) {
         // Ctrl/Cmd+Enter to send, Enter to newline
         if (ctrlOrMeta) {
-          _handleSend();
+          unawaited(_handleSend());
         } else if (!shift) {
           _insertNewlineAtCursor();
         } else {
@@ -479,7 +512,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         if (shift || ctrlOrMeta) {
           _insertNewlineAtCursor();
         } else {
-          _handleSend();
+          unawaited(_handleSend());
         }
       }
       return KeyEventResult.handled;
@@ -793,6 +826,10 @@ class _ChatInputBarState extends State<ChatInputBar>
     const double plusButtonW = 32;
 
     final l10n = AppLocalizations.of(context)!;
+    VoidCallback? lockTap(VoidCallback? callback) {
+      if (_composerLocked) return null;
+      return callback;
+    }
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -806,14 +843,14 @@ class _ChatInputBarState extends State<ChatInputBar>
               tooltip: l10n.chatInputBarSelectModelTooltip,
               icon: Lucide.Boxes,
               modelIcon: true,
-              onTap: widget.onSelectModel,
-              onLongPress: widget.onLongPressSelectModel,
+              onTap: lockTap(widget.onSelectModel),
+              onLongPress: lockTap(widget.onLongPressSelectModel),
               child: widget.modelIcon,
             ),
             menu: DesktopContextMenuItem(
               icon: Lucide.Boxes,
               label: l10n.chatInputBarSelectModelTooltip,
-              onTap: widget.onSelectModel,
+              onTap: lockTap(widget.onSelectModel),
             ),
           ),
         );
@@ -860,7 +897,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                   tooltip: l10n.chatInputBarOnlineSearchTooltip,
                   icon: Lucide.Globe,
                   active: false,
-                  onTap: widget.onOpenSearch,
+                  onTap: lockTap(widget.onOpenSearch),
                 );
               }
               // Built-in search -> magnifier icon in theme color
@@ -869,7 +906,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                   tooltip: l10n.chatInputBarOnlineSearchTooltip,
                   icon: Lucide.Search,
                   active: true,
-                  onTap: widget.onOpenSearch,
+                  onTap: lockTap(widget.onOpenSearch),
                 );
               }
               // External provider search -> brand icon
@@ -877,7 +914,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.chatInputBarOnlineSearchTooltip,
                 icon: Lucide.Globe,
                 active: true,
-                onTap: widget.onOpenSearch,
+                onTap: lockTap(widget.onOpenSearch),
                 childBuilder: (c) {
                   final asset = brandAsset;
                   if (asset != null) {
@@ -909,27 +946,27 @@ class _ChatInputBarState extends State<ChatInputBar>
                 return DesktopContextMenuItem(
                   icon: Lucide.Globe,
                   label: l10n.chatInputBarOnlineSearchTooltip,
-                  onTap: widget.onOpenSearch,
+                  onTap: lockTap(widget.onOpenSearch),
                 );
               }
               if (builtinSearchActive) {
                 return DesktopContextMenuItem(
                   icon: Lucide.Search,
                   label: l10n.chatInputBarOnlineSearchTooltip,
-                  onTap: widget.onOpenSearch,
+                  onTap: lockTap(widget.onOpenSearch),
                 );
               }
               if (brandAsset != null && brandAsset.endsWith('.svg')) {
                 return DesktopContextMenuItem(
                   svgAsset: brandAsset,
                   label: l10n.chatInputBarOnlineSearchTooltip,
-                  onTap: widget.onOpenSearch,
+                  onTap: lockTap(widget.onOpenSearch),
                 );
               }
               return DesktopContextMenuItem(
                 icon: Lucide.Globe,
                 label: l10n.chatInputBarOnlineSearchTooltip,
-                onTap: widget.onOpenSearch,
+                onTap: lockTap(widget.onOpenSearch),
               );
             }(),
           ),
@@ -943,7 +980,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.chatInputBarReasoningStrengthTooltip,
                 icon: Lucide.Brain,
                 active: widget.reasoningActive,
-                onTap: widget.onConfigureReasoning,
+                onTap: lockTap(widget.onConfigureReasoning),
                 childBuilder: (c) => SvgPicture.asset(
                   'assets/icons/deepthink.svg',
                   width: 20,
@@ -954,7 +991,7 @@ class _ChatInputBarState extends State<ChatInputBar>
               menu: DesktopContextMenuItem(
                 svgAsset: 'assets/icons/deepthink.svg',
                 label: l10n.chatInputBarReasoningStrengthTooltip,
-                onTap: widget.onConfigureReasoning,
+                onTap: lockTap(widget.onConfigureReasoning),
               ),
             ),
           );
@@ -969,13 +1006,13 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.chatInputBarMcpServersTooltip,
                 icon: Lucide.Hammer,
                 active: widget.mcpActive,
-                onTap: widget.onOpenMcp,
-                onLongPress: widget.onLongPressMcp,
+                onTap: lockTap(widget.onOpenMcp),
+                onLongPress: lockTap(widget.onLongPressMcp),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Hammer,
                 label: l10n.chatInputBarMcpServersTooltip,
-                onTap: widget.onOpenMcp,
+                onTap: lockTap(widget.onOpenMcp),
               ),
             ),
           );
@@ -988,13 +1025,13 @@ class _ChatInputBarState extends State<ChatInputBar>
               builder: () => _CompactIconButton(
                 tooltip: l10n.chatInputBarQuickPhraseTooltip,
                 icon: Lucide.Zap,
-                onTap: widget.onQuickPhrase,
-                onLongPress: widget.onLongPressQuickPhrase,
+                onTap: lockTap(widget.onQuickPhrase),
+                onLongPress: lockTap(widget.onLongPressQuickPhrase),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Zap,
                 label: l10n.chatInputBarQuickPhraseTooltip,
-                onTap: widget.onQuickPhrase,
+                onTap: lockTap(widget.onQuickPhrase),
               ),
             ),
           );
@@ -1007,12 +1044,12 @@ class _ChatInputBarState extends State<ChatInputBar>
               builder: () => _CompactIconButton(
                 tooltip: l10n.bottomToolsSheetCamera,
                 icon: Lucide.Camera,
-                onTap: widget.onPickCamera,
+                onTap: lockTap(widget.onPickCamera),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Camera,
                 label: l10n.bottomToolsSheetCamera,
-                onTap: widget.onPickCamera,
+                onTap: lockTap(widget.onPickCamera),
               ),
             ),
           );
@@ -1025,12 +1062,12 @@ class _ChatInputBarState extends State<ChatInputBar>
               builder: () => _CompactIconButton(
                 tooltip: l10n.bottomToolsSheetPhotos,
                 icon: Lucide.Image,
-                onTap: widget.onPickPhotos,
+                onTap: lockTap(widget.onPickPhotos),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Image,
                 label: l10n.bottomToolsSheetPhotos,
-                onTap: widget.onPickPhotos,
+                onTap: lockTap(widget.onPickPhotos),
               ),
             ),
           );
@@ -1043,12 +1080,12 @@ class _ChatInputBarState extends State<ChatInputBar>
               builder: () => _CompactIconButton(
                 tooltip: l10n.bottomToolsSheetUpload,
                 icon: Lucide.Paperclip,
-                onTap: widget.onUploadFiles,
+                onTap: lockTap(widget.onUploadFiles),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Paperclip,
                 label: l10n.bottomToolsSheetUpload,
-                onTap: widget.onUploadFiles,
+                onTap: lockTap(widget.onUploadFiles),
               ),
             ),
           );
@@ -1062,13 +1099,13 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.instructionInjectionTitle,
                 icon: Lucide.Layers,
                 active: widget.learningModeActive,
-                onTap: widget.onToggleLearningMode,
-                onLongPress: widget.onLongPressLearning,
+                onTap: lockTap(widget.onToggleLearningMode),
+                onLongPress: lockTap(widget.onLongPressLearning),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Layers,
                 label: l10n.instructionInjectionTitle,
-                onTap: widget.onToggleLearningMode,
+                onTap: lockTap(widget.onToggleLearningMode),
               ),
             ),
           );
@@ -1082,12 +1119,12 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.worldBookTitle,
                 icon: Lucide.BookOpen,
                 active: widget.worldBookActive,
-                onTap: widget.onOpenWorldBook,
+                onTap: lockTap(widget.onOpenWorldBook),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.BookOpen,
                 label: l10n.worldBookTitle,
-                onTap: widget.onOpenWorldBook,
+                onTap: lockTap(widget.onOpenWorldBook),
               ),
             ),
           );
@@ -1103,12 +1140,12 @@ class _ChatInputBarState extends State<ChatInputBar>
                   DesktopContextMenuItem(
                     icon: Lucide.package2,
                     label: l10n.compressContext,
-                    onTap: widget.onCompressContext,
+                    onTap: lockTap(widget.onCompressContext),
                   ),
                 DesktopContextMenuItem(
                   icon: Lucide.Eraser,
                   label: l10n.bottomToolsSheetClearContext,
-                  onTap: widget.onClearContext,
+                  onTap: lockTap(widget.onClearContext),
                 ),
               ],
             );
@@ -1122,13 +1159,13 @@ class _ChatInputBarState extends State<ChatInputBar>
                 child: _CompactIconButton(
                   tooltip: l10n.contextManagement,
                   icon: Lucide.Eraser,
-                  onTap: showContextMenu,
+                  onTap: _composerLocked ? null : showContextMenu,
                 ),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Eraser,
                 label: l10n.contextManagement,
-                onTap: showContextMenu,
+                onTap: _composerLocked ? null : showContextMenu,
               ),
             ),
           );
@@ -1141,12 +1178,12 @@ class _ChatInputBarState extends State<ChatInputBar>
               builder: () => _CompactIconButton(
                 tooltip: l10n.miniMapTooltip,
                 icon: Lucide.Map,
-                onTap: widget.onOpenMiniMap,
+                onTap: lockTap(widget.onOpenMiniMap),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Map,
                 label: l10n.miniMapTooltip,
-                onTap: widget.onOpenMiniMap,
+                onTap: lockTap(widget.onOpenMiniMap),
               ),
             ),
           );
@@ -1160,12 +1197,12 @@ class _ChatInputBarState extends State<ChatInputBar>
                 tooltip: l10n.chatInputBarOcrTooltip,
                 icon: Lucide.Eye,
                 active: widget.ocrActive,
-                onTap: widget.onToggleOcr,
+                onTap: lockTap(widget.onToggleOcr),
               ),
               menu: DesktopContextMenuItem(
                 icon: Lucide.Eye,
                 label: l10n.chatInputBarOcrTooltip,
-                onTap: widget.onToggleOcr,
+                onTap: lockTap(widget.onToggleOcr),
               ),
             ),
           );
@@ -1413,6 +1450,17 @@ class _ChatInputBarState extends State<ChatInputBar>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (widget.hasQueuedInput) ...[
+              _QueuedInputBanner(
+                label: AppLocalizations.of(context)!.chatInputBarQueuedPending,
+                previewText: widget.queuedPreviewText,
+                cancelLabel: AppLocalizations.of(
+                  context,
+                )!.chatInputBarQueuedCancel,
+                onCancel: widget.onCancelQueuedInput,
+              ),
+              const SizedBox(height: AppSpacing.xs),
+            ],
             // File attachments (if any)
             if (hasDocs) ...[
               SizedBox(
@@ -1641,6 +1689,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                                         controller: _controller,
                                         focusNode: widget.focusNode,
                                         onChanged: _onTextChanged,
+                                        readOnly: _composerLocked,
                                         minLines: 1,
                                         maxLines: _isExpanded ? 25 : 5,
                                         // On mobile, optionally show "Send" on the return key and submit on tap.
@@ -1650,7 +1699,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                                             ? TextInputAction.send
                                             : TextInputAction.newline,
                                         onSubmitted: enterToSend
-                                            ? (_) => _handleSend()
+                                            ? (_) => unawaited(_handleSend())
                                             : null,
                                         // Custom context menu: use instance method to avoid flickering
                                         // caused by recreating the callback on every build.
@@ -1733,7 +1782,9 @@ class _ChatInputBarState extends State<ChatInputBar>
                                     )!.chatInputBarMoreTooltip,
                                     icon: Lucide.Plus,
                                     active: widget.moreOpen,
-                                    onTap: widget.onMore,
+                                    onTap: _composerLocked
+                                        ? null
+                                        : widget.onMore,
                                     childBuilder: (c) => AnimatedSwitcher(
                                       duration: const Duration(
                                         milliseconds: 200,
@@ -1785,6 +1836,103 @@ class _ChatInputBarState extends State<ChatInputBar>
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _QueuedInputBanner extends StatelessWidget {
+  const _QueuedInputBanner({
+    required this.label,
+    required this.cancelLabel,
+    this.previewText,
+    this.onCancel,
+  });
+
+  final String label;
+  final String cancelLabel;
+  final String? previewText;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final preview = previewText?.trim();
+    final hasPreview = preview != null && preview.isNotEmpty;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark
+            ? Colors.white.withValues(alpha: 0.08)
+            : Colors.white.withValues(alpha: 0.84),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: theme.colorScheme.outline.withValues(alpha: 0.16),
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.xs,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(
+              Icons.schedule_rounded,
+              size: 16,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  label,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (hasPreview) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    preview,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(
+                        alpha: 0.72,
+                      ),
+                      height: 1.3,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          IosCardPress(
+            onTap: onCancel,
+            borderRadius: BorderRadius.circular(10),
+            baseColor: Colors.transparent,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: AppSpacing.xs,
+            ),
+            child: Text(
+              cancelLabel,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/home/widgets/chat_input_section.dart
+++ b/lib/features/home/widgets/chat_input_section.dart
@@ -49,6 +49,9 @@ class ChatInputSection extends StatelessWidget {
     this.onConfigureReasoning,
     this.onSend,
     this.onStop,
+    this.hasQueuedInput = false,
+    this.queuedPreviewText,
+    this.onCancelQueuedInput,
     this.onQuickPhrase,
     this.onLongPressQuickPhrase,
     this.onToggleOcr,
@@ -83,8 +86,11 @@ class ChatInputSection extends StatelessWidget {
   final VoidCallback? onLongPressMcp;
   final VoidCallback? onOpenSearch;
   final VoidCallback? onConfigureReasoning;
-  final ValueChanged<ChatInputData>? onSend;
+  final Future<ChatInputSubmissionResult> Function(ChatInputData)? onSend;
   final VoidCallback? onStop;
+  final bool hasQueuedInput;
+  final String? queuedPreviewText;
+  final VoidCallback? onCancelQueuedInput;
   final VoidCallback? onQuickPhrase;
   final VoidCallback? onLongPressQuickPhrase;
   final VoidCallback? onToggleOcr;
@@ -155,6 +161,9 @@ class ChatInputSection extends StatelessWidget {
       onOpenSearch: onOpenSearch,
       onSend: onSend,
       loading: isLoading,
+      hasQueuedInput: hasQueuedInput,
+      queuedPreviewText: queuedPreviewText,
+      onCancelQueuedInput: onCancelQueuedInput,
       showMcpButton: _shouldShowMcpButton(context, settings, a, pk, mid),
       mcpActive: _isMcpActive(context, a),
       showQuickPhraseButton: _hasQuickPhrases(context, a),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -894,6 +894,8 @@
   "chatInputBarReasoningStrengthTooltip": "Reasoning Strength",
   "chatInputBarMcpServersTooltip": "MCP Servers",
   "chatInputBarMoreTooltip": "Add",
+  "chatInputBarQueuedPending": "Queued to send",
+  "chatInputBarQueuedCancel": "Cancel Queue",
   "chatInputBarInsertNewline": "Newline",
   "chatInputBarExpand": "Expand",
   "chatInputBarCollapse": "Collapse",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3845,6 +3845,18 @@ abstract class AppLocalizations {
   /// **'Add'**
   String get chatInputBarMoreTooltip;
 
+  /// No description provided for @chatInputBarQueuedPending.
+  ///
+  /// In en, this message translates to:
+  /// **'Queued to send'**
+  String get chatInputBarQueuedPending;
+
+  /// No description provided for @chatInputBarQueuedCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel Queue'**
+  String get chatInputBarQueuedCancel;
+
   /// No description provided for @chatInputBarInsertNewline.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2032,6 +2032,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatInputBarMoreTooltip => 'Add';
 
   @override
+  String get chatInputBarQueuedPending => 'Queued to send';
+
+  @override
+  String get chatInputBarQueuedCancel => 'Cancel Queue';
+
+  @override
   String get chatInputBarInsertNewline => 'Newline';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1967,6 +1967,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chatInputBarMoreTooltip => '更多';
 
   @override
+  String get chatInputBarQueuedPending => '排队中';
+
+  @override
+  String get chatInputBarQueuedCancel => '取消排队';
+
+  @override
   String get chatInputBarInsertNewline => '换行';
 
   @override
@@ -6232,6 +6238,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get chatInputBarMoreTooltip => '更多';
 
   @override
+  String get chatInputBarQueuedPending => '排队中';
+
+  @override
+  String get chatInputBarQueuedCancel => '取消排队';
+
+  @override
   String get chatInputBarInsertNewline => '换行';
 
   @override
@@ -10442,6 +10454,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get chatInputBarMoreTooltip => '更多';
+
+  @override
+  String get chatInputBarQueuedPending => '排隊中';
+
+  @override
+  String get chatInputBarQueuedCancel => '取消排隊';
 
   @override
   String get chatInputBarInsertNewline => '換行';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -650,6 +650,8 @@
   "chatInputBarReasoningStrengthTooltip": "思维链强度",
   "chatInputBarMcpServersTooltip": "MCP服务器",
   "chatInputBarMoreTooltip": "更多",
+  "chatInputBarQueuedPending": "排队中",
+  "chatInputBarQueuedCancel": "取消排队",
   "chatInputBarInsertNewline": "换行",
   "chatInputBarExpand": "展开",
   "chatInputBarCollapse": "收起",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -684,6 +684,8 @@
   "chatInputBarReasoningStrengthTooltip": "思维链强度",
   "chatInputBarMcpServersTooltip": "MCP服务器",
   "chatInputBarMoreTooltip": "更多",
+  "chatInputBarQueuedPending": "排队中",
+  "chatInputBarQueuedCancel": "取消排队",
   "chatInputBarInsertNewline": "换行",
   "chatInputBarExpand": "展开",
   "chatInputBarCollapse": "收起",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -638,6 +638,8 @@
   "chatInputBarReasoningStrengthTooltip": "思維鏈強度",
   "chatInputBarMcpServersTooltip": "MCP伺服器",
   "chatInputBarMoreTooltip": "更多",
+  "chatInputBarQueuedPending": "排隊中",
+  "chatInputBarQueuedCancel": "取消排隊",
   "chatInputBarInsertNewline": "換行",
   "chatInputBarExpand": "展開",
   "chatInputBarCollapse": "收起",

--- a/test/features/home/widgets/chat_input_bar_queue_test.dart
+++ b/test/features/home/widgets/chat_input_bar_queue_test.dart
@@ -1,0 +1,143 @@
+import 'package:Kelivo/core/models/chat_input_data.dart';
+import 'package:Kelivo/core/providers/assistant_provider.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/features/home/widgets/chat_input_bar.dart';
+import 'package:Kelivo/icons/lucide_adapter.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget buildHarness({
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    required Future<ChatInputSubmissionResult> Function(ChatInputData input)
+    onSend,
+    SettingsProvider? settingsProvider,
+    AssistantProvider? assistantProvider,
+    bool loading = false,
+    bool hasQueuedInput = false,
+    String? queuedPreviewText,
+    VoidCallback? onCancelQueuedInput,
+  }) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(
+          value: settingsProvider ?? SettingsProvider(),
+        ),
+        ChangeNotifierProvider.value(
+          value: assistantProvider ?? AssistantProvider(),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ChatInputBar(
+            controller: controller,
+            focusNode: focusNode,
+            onSend: onSend,
+            loading: loading,
+            hasQueuedInput: hasQueuedInput,
+            queuedPreviewText: queuedPreviewText,
+            onCancelQueuedInput: onCancelQueuedInput,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('提交结果 queued 时会清空输入', (tester) async {
+    final controller = TextEditingController(text: 'queued message');
+    final focusNode = FocusNode();
+    ChatInputData? submitted;
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        onSend: (input) async {
+          submitted = input;
+          return ChatInputSubmissionResult.queued;
+        },
+      ),
+    );
+
+    await tapSendButton(tester);
+
+    expect(submitted?.text, 'queued message');
+    expect(controller.text, isEmpty);
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('提交结果 rejected 时保留输入内容', (tester) async {
+    final controller = TextEditingController(text: 'keep me');
+    final focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        onSend: (_) async => ChatInputSubmissionResult.rejected,
+      ),
+    );
+
+    await tapSendButton(tester);
+
+    expect(controller.text, 'keep me');
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('有排队项时显示状态并允许取消', (tester) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    var cancelled = false;
+    const preview = '第一行\n第二行\n第三行\n第四行';
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        hasQueuedInput: true,
+        queuedPreviewText: preview,
+        onCancelQueuedInput: () {
+          cancelled = true;
+        },
+        onSend: (_) async => ChatInputSubmissionResult.rejected,
+      ),
+    );
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.readOnly, isTrue);
+    expect(find.text('Queued to send'), findsOneWidget);
+    expect(find.text('Cancel Queue'), findsOneWidget);
+    expect(find.text(preview), findsOneWidget);
+
+    final previewText = tester.widget<Text>(find.text(preview));
+    expect(previewText.maxLines, 3);
+    expect(previewText.overflow, TextOverflow.ellipsis);
+
+    await tester.tap(find.text('Cancel Queue'));
+    await tester.pumpAndSettle();
+
+    expect(cancelled, isTrue);
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+}
+
+Future<void> tapSendButton(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Lucide.ArrowUp));
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
Block desktop shortcut sends from starting a second generation while the current turn is still streaming. Queue one pending composer input instead, show a three-line preview, and allow canceling the queued item back into the editable composer with attachments restored.

Move the guard into the controller/view-model send path so keyboard shortcuts cannot bypass the stop-state protection, and automatically dispatch the queued input when the active generation finishes or is stopped.

Closes #458

Files changed:
- lib/core/models/chat_input_data.dart: add single-queue submission result and queued input model
- lib/features/home/controllers/home_page_controller.dart: return send submission results and restore queued input back into the composer on cancel
- lib/features/home/controllers/home_view_model.dart: add single pending-send queue, block concurrent sends, and auto-drain after streaming stops
- lib/features/home/pages/home_page.dart: pass queued input state and preview text into the shared chat input section
- lib/features/home/widgets/chat_input_bar.dart: make send async-result aware, lock the composer while queued, and render queued preview/cancel UI
- lib/features/home/widgets/chat_input_section.dart: thread queued-input state and preview props into ChatInputBar
- lib/l10n/app_en.arb: add queued pending/cancel strings
- lib/l10n/app_localizations.dart: regenerate localization accessors for queued-input strings
- lib/l10n/app_localizations_en.dart: regenerate English queued-input strings
- lib/l10n/app_localizations_zh.dart: regenerate Chinese queued-input strings
- lib/l10n/app_zh.arb: add queued pending/cancel strings
- lib/l10n/app_zh_Hans.arb: add queued pending/cancel strings
- lib/l10n/app_zh_Hant.arb: add queued pending/cancel strings
- test/features/home/widgets/chat_input_bar_queue_test.dart: cover queued send clearing, rejected send retention, and queued preview/cancel UI