### PR TITLE
feat: add X-Conversation-Id header to API requests

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -251,11 +251,19 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         config.serviceAccountJson ?? '',
       );
       headers['Authorization'] = 'Bearer $token';
+      final proj = (config.projectId ?? '').trim();
+      if (proj.isNotEmpty) {
+        headers['X-Goog-User-Project'] = proj;
+      }
     } else {
       final apiKey = _effectiveApiKey(config);
       if (apiKey.isNotEmpty) {
         headers['x-goog-api-key'] = apiKey;
       }
+    }
+    headers.addAll(_customHeaders(config, modelId));
+    if (extraHeaders != null && extraHeaders.isNotEmpty) {
+      headers.addAll(extraHeaders);
     }
 
     final toolsArr = _buildGeminiToolsArray(

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -25,6 +25,26 @@ typedef OnShowError = void Function(String message);
 typedef OnShowWarning = void Function(String message);
 typedef OnHapticFeedback = void Function();
 
+const String conversationIdHeaderName = 'X-Conversation-Id';
+const String _conversationIdHeaderNameLower = 'x-conversation-id';
+
+Map<String, String>? buildConversationRequestHeaders({
+  required String conversationId,
+  Map<String, String>? customHeaders,
+}) {
+  final headers = <String, String>{
+    if (customHeaders != null)
+      for (final entry in customHeaders.entries)
+        if (entry.key.toLowerCase() != _conversationIdHeaderNameLower)
+          entry.key: entry.value,
+  };
+  final normalizedConversationId = conversationId.trim();
+  if (normalizedConversationId.isNotEmpty) {
+    headers[conversationIdHeaderName] = normalizedConversationId;
+  }
+  return headers.isEmpty ? null : headers;
+}
+
 /// Result of preparing a message generation
 class PreparedGeneration {
   final List<Map<String, dynamic>> apiMessages;
@@ -280,7 +300,10 @@ class MessageGenerationService {
       config: settings.getProviderConfig(providerKey),
       toolDefs: prepared.toolDefs,
       onToolCall: prepared.onToolCall,
-      extraHeaders: generationController.buildCustomHeaders(assistant),
+      extraHeaders: buildConversationRequestHeaders(
+        conversationId: assistantMessage.conversationId,
+        customHeaders: generationController.buildCustomHeaders(assistant),
+      ),
       extraBody: generationController.buildCustomBody(assistant),
       supportsReasoning: supportsReasoning,
       enableReasoning: enableReasoning,

--- a/test/chat_api_extra_headers_test.dart
+++ b/test/chat_api_extra_headers_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+
+const _conversationHeaderName = 'X-Conversation-Id';
+const _conversationId = 'conversation-123';
+
+ProviderConfig _openAiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'OpenAITest',
+    enabled: true,
+    name: 'OpenAITest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+  );
+}
+
+ProviderConfig _claudeConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'ClaudeTest',
+    enabled: true,
+    name: 'ClaudeTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.claude,
+  );
+}
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiTest',
+    enabled: true,
+    name: 'GeminiTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+void main() {
+  group('ChatApiService extra headers', () {
+    test('OpenAI-compatible requests forward conversation id header', () async {
+      String? receivedConversationId;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        receivedConversationId = request.headers.value(_conversationHeaderName);
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'id': 'chatcmpl-1',
+            'object': 'chat.completion',
+            'choices': [
+              {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+            'usage': {
+              'prompt_tokens': 1,
+              'completion_tokens': 1,
+              'total_tokens': 2,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAiConfig(
+          'http://${server.address.address}:${server.port}/v1',
+        ),
+        modelId: 'gpt-4.1',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        extraHeaders: const {_conversationHeaderName: _conversationId},
+        stream: false,
+      ).toList();
+
+      expect(receivedConversationId, _conversationId);
+      expect(chunks.last.isDone, isTrue);
+    });
+
+    test('Claude requests forward conversation id header', () async {
+      String? receivedConversationId;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        receivedConversationId = request.headers.value(_conversationHeaderName);
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'id': 'msg_1',
+            'content': [
+              {'type': 'text', 'text': 'ok'},
+            ],
+            'usage': {'input_tokens': 1, 'output_tokens': 1},
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _claudeConfig(
+          'http://${server.address.address}:${server.port}',
+        ),
+        modelId: 'claude-sonnet-4-5',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        extraHeaders: const {_conversationHeaderName: _conversationId},
+        stream: false,
+      ).toList();
+
+      expect(receivedConversationId, _conversationId);
+      expect(chunks.last.isDone, isTrue);
+    });
+
+    test('Gemini requests forward conversation id header', () async {
+      String? receivedConversationId;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        receivedConversationId = request.headers.value(_conversationHeaderName);
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+              },
+            ],
+            'usageMetadata': {
+              'promptTokenCount': 1,
+              'candidatesTokenCount': 1,
+              'totalTokenCount': 2,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-2.5-pro',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        extraHeaders: const {_conversationHeaderName: _conversationId},
+        stream: false,
+      ).toList();
+
+      expect(receivedConversationId, _conversationId);
+      expect(chunks.last.isDone, isTrue);
+    });
+  });
+}

--- a/test/conversation_request_headers_test.dart
+++ b/test/conversation_request_headers_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/features/home/services/message_generation_service.dart';
+
+void main() {
+  group('conversation request headers', () {
+    test('returns conversation id header when no custom headers', () {
+      final headers = buildConversationRequestHeaders(
+        conversationId: 'conv-789',
+        customHeaders: null,
+      );
+
+      expect(headers, {conversationIdHeaderName: 'conv-789'});
+    });
+
+    test('adds conversation id header and preserves custom headers', () {
+      final headers = buildConversationRequestHeaders(
+        conversationId: 'conversation-123',
+        customHeaders: const {'X-Gateway': 'EchoPort'},
+      );
+
+      expect(headers, {
+        'X-Gateway': 'EchoPort',
+        conversationIdHeaderName: 'conversation-123',
+      });
+    });
+
+    test(
+      'conversation id header overrides stale custom value after trimming',
+      () {
+        final headers = buildConversationRequestHeaders(
+          conversationId: '  conversation-456  ',
+          customHeaders: const {'x-conversation-id': 'old-value'},
+        );
+
+        expect(headers, {conversationIdHeaderName: 'conversation-456'});
+      },
+    );
+
+    test('returns custom headers unchanged when conversation id is blank', () {
+      final headers = buildConversationRequestHeaders(
+        conversationId: '   ',
+        customHeaders: const {'X-Gateway': 'EchoPort'},
+      );
+
+      expect(headers, {'X-Gateway': 'EchoPort'});
+    });
+  });
+}


### PR DESCRIPTION
关联 Issue: #412

改动目标
在发送 API 请求时，将当前对话的本地会话 ID 透传到 HTTP 请求 header（X-Conversation-Id），使中间网关能够识别和区分不同对话窗口。

改动内容
1.在 message_generation_service.dart 新增 buildConversationRequestHeaders 函数，在构建 GenerationContext 时将 assistantMessage.conversationId 注入到 extraHeaders 中
2.修复 google_common.dart 中 Gemini 非流式分支未合并 extraHeaders 的遗漏
3.新增测试覆盖 header 合并规则及 OpenAI / Claude / Gemini 三种 provider 的透传验证

改动范围
・lib/features/home/services/message_generation_service.dart — header 合并 helper + 注入逻辑
・lib/core/services/api/providers/google_common.dart — Gemini 非流式分支补全 extraHeaders
・test/conversation_request_headers_test.dart — header 合并单测
・test/chat_api_extra_headers_test.dart — 各 provider 透传单测

设计说明
・会话 ID 来源为 ChatMessage.conversationId（关联 Conversation.id，UUID v4），每个对话窗口唯一且稳定
・header 注入放在统一组装点，不散落到各 provider 实现中
・合并逻辑保留用户已有的自定义 header，仅覆盖大小写变体的旧 conversation-id 值
・翻译、OCR 等非对话请求路径不经过此组装点，不会携带该 header，这是预期行为
・该 header 对所有 API provider 无副作用，不认识的 provider 会直接忽略

验证
・dart format 通过
・flutter analyze --no-fatal-infos 通过（1 个 warning 为项目原有，非本次引入）
・flutter test 相关子集全绿