### PR TITLE
fix: 修复翻译/OCR使用支持思考的Claude模型时缺少budget_tokens导致报错

### DIFF
--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -185,7 +185,9 @@ Stream<ChatStreamChunk> _sendClaudeStream(
                       caseSensitive: false,
                     ).hasMatch(upstreamModelId)
               ? 'adaptive'
-              : 'enabled',
+              : (thinkingBudget != null && thinkingBudget > 0)
+                  ? 'enabled'
+                  : 'disabled',
           if (thinkingBudget != null && thinkingBudget > 0)
             'budget_tokens': thinkingBudget,
         },

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -365,7 +365,12 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
           }
         else
           'thinking': {
-            'type': (effectiveThinkingBudget == 0) ? 'disabled' : 'enabled',
+            'type': (effectiveThinkingBudget == 0)
+                ? 'disabled'
+                : (effectiveThinkingBudget != null &&
+                        effectiveThinkingBudget > 0)
+                    ? 'enabled'
+                    : 'disabled',
             if (effectiveThinkingBudget != null && effectiveThinkingBudget > 0)
               'budget_tokens': effectiveThinkingBudget,
           },


### PR DESCRIPTION
## 概述

修复翻译功能在使用 Anthropic 格式 + 支持思考的模型时，API 返回 `budget_tokens is required and must be positive when thinking type is enabled` 错误的问题。

Closes #471

## 原因分析

在 `claude_official.dart` 构建请求体时，当 `thinkingBudget` 为 `null`（翻译/OCR 等调用方未传递该参数）且模型不匹配 `claude-opus-4-6`/`claude-sonnet-4-6` 时，thinking type 会被无条件设为 `enabled`，但不附带 `budget_tokens`，违反了 Anthropic API 的要求。`google_vertex.dart` 中存在同样的问题。

## 修复方式

在 provider 层修复逻辑：仅当 `thinkingBudget` 为正数时才设置 `type: 'enabled'`（此时 `budget_tokens` 会被正确附带），否则回退到 `type: 'disabled'`。

主聊天流程始终会传递有效的 `thinkingBudget` 值，因此不受影响。

## 修改文件

- `lib/core/services/api/providers/claude_official.dart` — 修复 thinking type 的 fallback 逻辑
- `lib/core/services/api/providers/google_vertex.dart` — 同步修复相同问题

## 测试计划

- [ ] 使用支持 thinking 的 Claude 模型进行翻译，验证不再报错
- [ ] 使用主聊天流程开启 thinking 功能，验证行为不变
- [ ] OCR 功能使用支持 thinking 的模型，验证不报错