### PR TITLE
fix(ci): use Ubuntu 22.04 runner for Linux build

### DIFF
--- a/.github/workflows/build-stable-38.yml
+++ b/.github/workflows/build-stable-38.yml
@@ -445,7 +445,7 @@ jobs:
   linux:
     if: ${{ github.event.inputs.build_linux == 'true' }}
     name: 构建 Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: write-all
 
     steps:
@@ -459,7 +459,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config libgtk-3-dev \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libgstreamer1.0-dev libunwind-dev libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
             rpm patchelf libfuse2 file \
             libkeybinder-3.0-dev libayatana-appindicator3-dev


### PR DESCRIPTION
降级Linux构建基础镜像，修复`appimage`文件在`Ubuntu 22.04`下运行报错`symbol lookup error: undefined symbol: g_once_init_enter_pointer`