### PR TITLE
fix: Eliminate IM candidate window offset on KDE

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   screen_retriever: ^0.2.0
   tray_manager:
     path: ./dependencies/tray_manager/packages/tray_manager
-  desktop_drop: ^0.7.0
+  desktop_drop: ^0.7.1
   hotkey_manager: ^0.2.3
 
   # Localizations for Chinese/English UI strings


### PR DESCRIPTION
Bump `desktop_drop` to 0.7.1. This version fixes a wrong function signature which causes this problem.

Fixes: https://github.com/Chevey339/kelivo/issues/304