### PR TITLE
fix(gemini): preserve mixed tool turn thought signatures

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -834,17 +834,35 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     // Collect any function calls in this round
     final List<Map<String, dynamic>> calls =
         <Map<String, dynamic>>[]; // {id,name,args,res}
-    // Capture server-side tool parts (Gemini 3 tool combination)
-    final List<Map<String, dynamic>> roundServerParts =
-        <Map<String, dynamic>>[];
-    // Accumulate text for model turn in convo (needed for Gemini 3 full-parts rebuild)
-    final StringBuffer roundAccumulatedText = StringBuffer();
+    // Preserve the model turn parts in the exact order they were received.
+    final List<Map<String, dynamic>> roundModelParts = <Map<String, dynamic>>[];
     // Counter for server-side code execution tool cards
     int codeExecCounter = 0;
 
-    // Track thought signature across chunks (Gemini 3 requirement)
-    String? persistentThoughtSigKey;
-    dynamic persistentThoughtSigVal;
+    void assignThoughtSignatureToFirstUnassignedCall(
+      String key,
+      dynamic value,
+    ) {
+      for (final call in calls) {
+        if (call['thoughtSigKey'] == null && call['thoughtSigVal'] == null) {
+          call['thoughtSigKey'] = key;
+          call['thoughtSigVal'] = value;
+          final part = call['part'];
+          if (part is Map<String, dynamic>) {
+            part[key] = value;
+          }
+          return;
+        }
+      }
+    }
+
+    bool hasAnyCallThoughtSignature() {
+      return calls.any(
+        (call) =>
+            call['thoughtSigKey'] != null && call['thoughtSigVal'] != null,
+      );
+    }
+
     // Capture thought signatures for history (Gemini 3 image/editing)
     String? responseTextThoughtSigKey;
     dynamic responseTextThoughtSigVal;
@@ -970,18 +988,46 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 }
                 final t = (p['text'] ?? '') as String? ?? '';
                 final thought = p['thought'] as bool? ?? false;
+                final fc = p['functionCall'];
+                final rawPart = Map<String, dynamic>.from(p);
+                bool backfilledThoughtSignatureToCall = false;
+                if (partThoughtSigKey != null &&
+                    partThoughtSigVal != null &&
+                    fc is! Map &&
+                    calls.isNotEmpty &&
+                    !hasAnyCallThoughtSignature()) {
+                  assignThoughtSignatureToFirstUnassignedCall(
+                    partThoughtSigKey,
+                    partThoughtSigVal,
+                  );
+                  backfilledThoughtSignatureToCall = true;
+                }
 
-                // Check for thought signature in this part and update persistence
-                if (partThoughtSigKey != null) {
-                  persistentThoughtSigKey = partThoughtSigKey;
-                  persistentThoughtSigVal = partThoughtSigVal;
+                final hasRelevantPayload =
+                    t.isNotEmpty ||
+                    partThoughtSigKey != null ||
+                    fc is Map ||
+                    p.containsKey('toolCall') ||
+                    p.containsKey('toolResponse') ||
+                    p.containsKey('inlineData') ||
+                    p.containsKey('inline_data') ||
+                    p.containsKey('fileData') ||
+                    p.containsKey('file_data') ||
+                    p.containsKey('executableCode') ||
+                    p.containsKey('executable_code') ||
+                    p.containsKey('codeExecutionResult') ||
+                    p.containsKey('code_execution_result');
+
+                if (isGemini3 && !thought && hasRelevantPayload) {
+                  roundModelParts.add(rawPart);
                 }
 
                 // Capture thought signature for text part (Gemini 3 image/editing)
                 if (persistGeminiThoughtSigs &&
                     !thought &&
                     partThoughtSigKey != null &&
-                    partThoughtSigVal != null) {
+                    partThoughtSigVal != null &&
+                    !backfilledThoughtSignatureToCall) {
                   if (t.isNotEmpty && responseTextThoughtSigKey == null) {
                     responseTextThoughtSigKey = partThoughtSigKey;
                     responseTextThoughtSigVal = partThoughtSigVal;
@@ -995,8 +1041,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                     pendingImageTrailingText += t;
                   } else {
                     textDelta += t;
-                    // Accumulate full text for convo rebuild (Gemini 3)
-                    if (isGemini3) roundAccumulatedText.write(t);
                   }
                 }
                 // Parse inline image data from Gemini (inlineData)
@@ -1116,23 +1160,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                     ],
                   );
                 }
-                // Capture server-side tool parts for convo rebuild (Gemini 3).
-                // Uses deny-list: preserves any part not already handled by client
-                // (text, functionCall, inlineData, fileData, thought, code execution).
-                // Per the API contract, all parts must be returned to maintain context.
-                // TODO: update this deny-list when Gemini API introduces new
-                // client-handled part types to avoid incorrectly capturing them.
-                if (isGemini3 &&
-                    !p.containsKey('text') &&
-                    !p.containsKey('functionCall') &&
-                    !p.containsKey('inlineData') &&
-                    !p.containsKey('inline_data') &&
-                    !p.containsKey('fileData') &&
-                    !p.containsKey('file_data') &&
-                    p['thought'] != true) {
-                  roundServerParts.add(Map<String, dynamic>.from(p));
-                }
-                final fc = p['functionCall'];
                 if (fc is Map) {
                   final name = (fc['name'] ?? '').toString();
                   Map<String, dynamic> args = const <String, dynamic>{};
@@ -1160,13 +1187,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                   } else if (p.containsKey('thought_signature')) {
                     thoughtSigKey = 'thought_signature';
                     thoughtSigVal = p['thought_signature'];
-                  }
-
-                  // Fallback to persistent signature if not found in this part
-                  if (thoughtSigKey == null &&
-                      persistentThoughtSigKey != null) {
-                    thoughtSigKey = persistentThoughtSigKey;
-                    thoughtSigVal = persistentThoughtSigVal;
                   }
 
                   // Emit placeholder immediately
@@ -1205,6 +1225,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                     'result': resText,
                     'thoughtSigKey': thoughtSigKey,
                     'thoughtSigVal': thoughtSigVal,
+                    'part': rawPart,
                   });
                 }
               }
@@ -1364,43 +1385,8 @@ Stream<ChatStreamChunk> _sendGoogleStream(
 
     // Append model functionCall(s) and user functionResponse(s) to conversation, then loop
     if (isGemini3) {
-      // Gemini 3: build a single model turn with all parts (text, server-side
-      // tool parts, and functionCall parts) to preserve full context.
-      final modelParts = <Map<String, dynamic>>[];
-
-      // 1. Accumulated text part (with thought signature if available)
-      final accText = roundAccumulatedText.toString();
-      if (accText.isNotEmpty) {
-        final textPart = <String, dynamic>{'text': accText};
-        if (responseTextThoughtSigKey != null &&
-            responseTextThoughtSigVal != null) {
-          textPart[responseTextThoughtSigKey] = responseTextThoughtSigVal;
-        }
-        modelParts.add(textPart);
-      }
-
-      // 2. Server-side tool parts (toolCall/toolResponse, preserved raw)
-      modelParts.addAll(roundServerParts);
-
-      // 3. functionCall parts (with thought signatures)
-      for (final c in calls) {
-        final name = (c['name'] ?? '').toString();
-        final args =
-            (c['args'] as Map<String, dynamic>? ?? const <String, dynamic>{});
-        final thoughtSigKey = c['thoughtSigKey'] as String?;
-        final thoughtSigVal = c['thoughtSigVal'];
-        final apiId = c['apiId'] as String?;
-        final part = <String, dynamic>{
-          'functionCall': {'name': name, 'args': args},
-          if (apiId != null) 'id': apiId,
-        };
-        if (thoughtSigKey != null && thoughtSigVal != null) {
-          part[thoughtSigKey] = thoughtSigVal;
-        }
-        modelParts.add(part);
-      }
-
-      convo.add({'role': 'model', 'parts': modelParts});
+      // Gemini 3: preserve the original model parts order exactly.
+      convo.add({'role': 'model', 'parts': roundModelParts});
 
       // 4. All functionResponses in one user turn
       final responseParts = <Map<String, dynamic>>[];

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -834,33 +834,47 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     // Collect any function calls in this round
     final List<Map<String, dynamic>> calls =
         <Map<String, dynamic>>[]; // {id,name,args,res}
+    final List<Map<String, dynamic>> pendingThoughtSignatureTargets =
+        <Map<String, dynamic>>[];
     // Preserve the model turn parts in the exact order they were received.
     final List<Map<String, dynamic>> roundModelParts = <Map<String, dynamic>>[];
     // Counter for server-side code execution tool cards
     int codeExecCounter = 0;
 
-    void assignThoughtSignatureToFirstUnassignedCall(
-      String key,
-      dynamic value,
-    ) {
-      for (final call in calls) {
-        if (call['thoughtSigKey'] == null && call['thoughtSigVal'] == null) {
-          call['thoughtSigKey'] = key;
-          call['thoughtSigVal'] = value;
-          final part = call['part'];
-          if (part is Map<String, dynamic>) {
-            part[key] = value;
-          }
-          return;
-        }
-      }
+    bool partHasNonFunctionPayload(Map<dynamic, dynamic> part) {
+      return part.containsKey('toolCall') ||
+          part.containsKey('toolResponse') ||
+          part.containsKey('inlineData') ||
+          part.containsKey('inline_data') ||
+          part.containsKey('fileData') ||
+          part.containsKey('file_data') ||
+          part.containsKey('executableCode') ||
+          part.containsKey('executable_code') ||
+          part.containsKey('codeExecutionResult') ||
+          part.containsKey('code_execution_result');
     }
 
-    bool hasAnyCallThoughtSignature() {
-      return calls.any(
-        (call) =>
-            call['thoughtSigKey'] != null && call['thoughtSigVal'] != null,
-      );
+    bool assignThoughtSignatureToFirstPendingTarget(String key, dynamic value) {
+      while (pendingThoughtSignatureTargets.isNotEmpty) {
+        final target = pendingThoughtSignatureTargets.removeAt(0);
+        final part = target['part'];
+        if (part is! Map<String, dynamic>) {
+          continue;
+        }
+        if (part.containsKey('thoughtSignature') ||
+            part.containsKey('thought_signature')) {
+          continue;
+        }
+        part[key] = value;
+        final call = target['call'];
+        if (call is Map<String, dynamic>) {
+          call['thoughtSigKey'] = key;
+          call['thoughtSigVal'] = value;
+          return true;
+        }
+        return false;
+      }
+      return false;
     }
 
     // Capture thought signatures for history (Gemini 3 image/editing)
@@ -990,36 +1004,37 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 final thought = p['thought'] as bool? ?? false;
                 final fc = p['functionCall'];
                 final rawPart = Map<String, dynamic>.from(p);
-                bool backfilledThoughtSignatureToCall = false;
-                if (partThoughtSigKey != null &&
+                final hasNonFunctionPayload = partHasNonFunctionPayload(p);
+                final isDetachedThoughtSignatureCarrier =
+                    partThoughtSigKey != null &&
                     partThoughtSigVal != null &&
+                    !thought &&
+                    t.isEmpty &&
                     fc is! Map &&
-                    calls.isNotEmpty &&
-                    !hasAnyCallThoughtSignature()) {
-                  assignThoughtSignatureToFirstUnassignedCall(
-                    partThoughtSigKey,
-                    partThoughtSigVal,
-                  );
-                  backfilledThoughtSignatureToCall = true;
+                    !hasNonFunctionPayload;
+                bool backfilledThoughtSignatureToCall = false;
+                if (isDetachedThoughtSignatureCarrier &&
+                    pendingThoughtSignatureTargets.isNotEmpty) {
+                  backfilledThoughtSignatureToCall =
+                      assignThoughtSignatureToFirstPendingTarget(
+                        partThoughtSigKey,
+                        partThoughtSigVal,
+                      );
                 }
 
                 final hasRelevantPayload =
                     t.isNotEmpty ||
                     partThoughtSigKey != null ||
                     fc is Map ||
-                    p.containsKey('toolCall') ||
-                    p.containsKey('toolResponse') ||
-                    p.containsKey('inlineData') ||
-                    p.containsKey('inline_data') ||
-                    p.containsKey('fileData') ||
-                    p.containsKey('file_data') ||
-                    p.containsKey('executableCode') ||
-                    p.containsKey('executable_code') ||
-                    p.containsKey('codeExecutionResult') ||
-                    p.containsKey('code_execution_result');
+                    hasNonFunctionPayload;
 
                 if (isGemini3 && !thought && hasRelevantPayload) {
                   roundModelParts.add(rawPart);
+                }
+
+                if (hasNonFunctionPayload &&
+                    (partThoughtSigKey == null || partThoughtSigVal == null)) {
+                  pendingThoughtSignatureTargets.add({'part': rawPart});
                 }
 
                 // Capture thought signature for text part (Gemini 3 image/editing)
@@ -1217,7 +1232,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                       ],
                     );
                   }
-                  calls.add({
+                  final call = <String, dynamic>{
                     'id': id,
                     'apiId': apiId,
                     'name': name,
@@ -1226,7 +1241,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                     'thoughtSigKey': thoughtSigKey,
                     'thoughtSigVal': thoughtSigVal,
                     'part': rawPart,
-                  });
+                  };
+                  calls.add(call);
+                  if (thoughtSigKey == null || thoughtSigVal == null) {
+                    pendingThoughtSignatureTargets.add({
+                      'part': rawPart,
+                      'call': call,
+                    });
+                  }
                 }
               }
               // Capture explicit finish reason if present

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -834,48 +834,10 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     // Collect any function calls in this round
     final List<Map<String, dynamic>> calls =
         <Map<String, dynamic>>[]; // {id,name,args,res}
-    final List<Map<String, dynamic>> pendingThoughtSignatureTargets =
-        <Map<String, dynamic>>[];
     // Preserve the model turn parts in the exact order they were received.
     final List<Map<String, dynamic>> roundModelParts = <Map<String, dynamic>>[];
     // Counter for server-side code execution tool cards
     int codeExecCounter = 0;
-
-    bool partHasNonFunctionPayload(Map<dynamic, dynamic> part) {
-      return part.containsKey('toolCall') ||
-          part.containsKey('toolResponse') ||
-          part.containsKey('inlineData') ||
-          part.containsKey('inline_data') ||
-          part.containsKey('fileData') ||
-          part.containsKey('file_data') ||
-          part.containsKey('executableCode') ||
-          part.containsKey('executable_code') ||
-          part.containsKey('codeExecutionResult') ||
-          part.containsKey('code_execution_result');
-    }
-
-    bool assignThoughtSignatureToFirstPendingTarget(String key, dynamic value) {
-      while (pendingThoughtSignatureTargets.isNotEmpty) {
-        final target = pendingThoughtSignatureTargets.removeAt(0);
-        final part = target['part'];
-        if (part is! Map<String, dynamic>) {
-          continue;
-        }
-        if (part.containsKey('thoughtSignature') ||
-            part.containsKey('thought_signature')) {
-          continue;
-        }
-        part[key] = value;
-        final call = target['call'];
-        if (call is Map<String, dynamic>) {
-          call['thoughtSigKey'] = key;
-          call['thoughtSigVal'] = value;
-          return true;
-        }
-        return false;
-      }
-      return false;
-    }
 
     // Capture thought signatures for history (Gemini 3 image/editing)
     String? responseTextThoughtSigKey;
@@ -1004,45 +966,16 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 final thought = p['thought'] as bool? ?? false;
                 final fc = p['functionCall'];
                 final rawPart = Map<String, dynamic>.from(p);
-                final hasNonFunctionPayload = partHasNonFunctionPayload(p);
-                final isDetachedThoughtSignatureCarrier =
-                    partThoughtSigKey != null &&
-                    partThoughtSigVal != null &&
-                    !thought &&
-                    t.isEmpty &&
-                    fc is! Map &&
-                    !hasNonFunctionPayload;
-                bool backfilledThoughtSignatureToCall = false;
-                if (isDetachedThoughtSignatureCarrier &&
-                    pendingThoughtSignatureTargets.isNotEmpty) {
-                  backfilledThoughtSignatureToCall =
-                      assignThoughtSignatureToFirstPendingTarget(
-                        partThoughtSigKey,
-                        partThoughtSigVal,
-                      );
-                }
 
-                final hasRelevantPayload =
-                    t.isNotEmpty ||
-                    partThoughtSigKey != null ||
-                    fc is Map ||
-                    hasNonFunctionPayload;
-
-                if (isGemini3 && !thought && hasRelevantPayload) {
+                if (isGemini3 && !thought && rawPart.isNotEmpty) {
                   roundModelParts.add(rawPart);
-                }
-
-                if (hasNonFunctionPayload &&
-                    (partThoughtSigKey == null || partThoughtSigVal == null)) {
-                  pendingThoughtSignatureTargets.add({'part': rawPart});
                 }
 
                 // Capture thought signature for text part (Gemini 3 image/editing)
                 if (persistGeminiThoughtSigs &&
                     !thought &&
                     partThoughtSigKey != null &&
-                    partThoughtSigVal != null &&
-                    !backfilledThoughtSignatureToCall) {
+                    partThoughtSigVal != null) {
                   if (t.isNotEmpty && responseTextThoughtSigKey == null) {
                     responseTextThoughtSigKey = partThoughtSigKey;
                     responseTextThoughtSigVal = partThoughtSigVal;
@@ -1243,12 +1176,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                     'part': rawPart,
                   };
                   calls.add(call);
-                  if (thoughtSigKey == null || thoughtSigVal == null) {
-                    pendingThoughtSignatureTargets.add({
-                      'part': rawPart,
-                      'call': call,
-                    });
-                  }
                 }
               }
               // Capture explicit finish reason if present

--- a/test/gemini_thought_signature_repro_test.dart
+++ b/test/gemini_thought_signature_repro_test.dart
@@ -1,0 +1,379 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiTest',
+    enabled: true,
+    name: 'GeminiTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+Map<String, dynamic> _streamChunk(
+  List<Map<String, dynamic>> parts, {
+  String? finishReason,
+}) {
+  return {
+    'candidates': [
+      {
+        'content': {'parts': parts},
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+    'usageMetadata': {
+      'promptTokenCount': 1,
+      'candidatesTokenCount': 1,
+      'totalTokenCount': 2,
+    },
+  };
+}
+
+Map<String, dynamic> _functionCallPart({
+  required String name,
+  required Map<String, dynamic> args,
+  String? thoughtSignature,
+}) {
+  return {
+    'functionCall': {'name': name, 'args': args},
+    if (thoughtSignature != null) 'thoughtSignature': thoughtSignature,
+  };
+}
+
+Map<String, dynamic> _toolCallPart({
+  required String toolType,
+  required Map<String, dynamic> args,
+  required String id,
+  String? thoughtSignature,
+}) {
+  return {
+    'toolCall': {'toolType': toolType, 'args': args, 'id': id},
+    if (thoughtSignature != null) 'thoughtSignature': thoughtSignature,
+  };
+}
+
+Map<String, dynamic> _textPart({
+  required String text,
+  String? thoughtSignature,
+}) {
+  return {
+    'text': text,
+    if (thoughtSignature != null) 'thoughtSignature': thoughtSignature,
+  };
+}
+
+void main() {
+  group('Gemini mixed tool thought signature repro', () {
+    test('preserves a late thought signature on the functionCall part', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        final bodyText = await utf8.decoder.bind(request).join();
+
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([
+              _functionCallPart(name: 'google_search', args: {'query': 'Kelivo fetch'}),
+            ]))}\n\n',
+          );
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-google-search')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        if (requestCount == 2) {
+          final body = jsonDecode(bodyText) as Map<String, dynamic>;
+          final contents = (body['contents'] as List).cast<Map>();
+          final modelParts = (contents[1]['parts'] as List).cast<Map>();
+          final firstCall = modelParts.firstWhere(
+            (p) => p.containsKey('functionCall'),
+          );
+          final hasSignature =
+              firstCall.containsKey('thoughtSignature') ||
+              firstCall.containsKey('thought_signature');
+
+          if (!hasSignature) {
+            request.response.statusCode = HttpStatus.badRequest;
+            request.response.headers.contentType = ContentType.json;
+            request.response.write(
+              jsonEncode({
+                'error': {
+                  'code': 400,
+                  'message':
+                      'Function call is missing a thought_signature in functionCall parts. Additional data, function call `google:search`, position 6.',
+                  'status': 'INVALID_ARGUMENT',
+                },
+              }),
+            );
+            await request.response.close();
+            return;
+          }
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        fail('Unexpected request count: $requestCount');
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {
+            'role': 'user',
+            'content':
+                'Search the web for the Kelivo fetch server docs, then summarize them.',
+          },
+        ],
+        tools: const [
+          {'google_search': {}},
+          {
+            'function_declarations': [
+              {
+                'name': 'fetch_markdown',
+                'description': 'Fetch a page as markdown',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'url': {'type': 'string'},
+                  },
+                  'required': ['url'],
+                },
+              },
+            ],
+          },
+        ],
+      ).toList();
+
+      expect(requestCount, 2);
+      expect(chunks.last.isDone, isTrue);
+    });
+
+    test(
+      'succeeds when the signature is attached to the functionCall chunk',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        var requestCount = 0;
+        server.listen((request) async {
+          requestCount++;
+          await utf8.decoder.bind(request).join();
+
+          if (requestCount == 1) {
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.contentType = ContentType(
+              'text',
+              'event-stream',
+            );
+            request.response.headers.set('Transfer-Encoding', 'chunked');
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([
+                _functionCallPart(name: 'google_search', args: {'query': 'Kelivo fetch'}, thoughtSignature: 'sig-google-search'),
+              ]))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          if (requestCount == 2) {
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.contentType = ContentType(
+              'text',
+              'event-stream',
+            );
+            request.response.headers.set('Transfer-Encoding', 'chunked');
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          fail('Unexpected request count: $requestCount');
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-3.1-pro-preview',
+          messages: const [
+            {
+              'role': 'user',
+              'content':
+                  'Search the web for the Kelivo fetch server docs, then summarize them.',
+            },
+          ],
+          tools: const [
+            {'google_search': {}},
+            {
+              'function_declarations': [
+                {
+                  'name': 'fetch_markdown',
+                  'description': 'Fetch a page as markdown',
+                  'parameters': {
+                    'type': 'object',
+                    'properties': {
+                      'url': {'type': 'string'},
+                    },
+                    'required': ['url'],
+                  },
+                },
+              ],
+            },
+          ],
+        ).toList();
+
+        expect(chunks.last.isDone, isTrue);
+      },
+    );
+
+    test('preserves signed toolCall and functionCall parts in order', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        final bodyText = await utf8.decoder.bind(request).join();
+
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([
+              _toolCallPart(toolType: 'GOOGLE_SEARCH_WEB', args: {
+                'queries': ['"Vagal blood volume receptors"'],
+              }, id: 'wne1uqtz', thoughtSignature: 'sig-google-search'),
+              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}, thoughtSignature: 'sig-fetch-markdown'),
+            ]))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        if (requestCount == 2) {
+          final body = jsonDecode(bodyText) as Map<String, dynamic>;
+          final contents = (body['contents'] as List).cast<Map>();
+          final modelParts = (contents[1]['parts'] as List).cast<Map>();
+          final toolCallIndex = modelParts.indexWhere(
+            (p) => p.containsKey('toolCall'),
+          );
+          final functionCallIndex = modelParts.indexWhere(
+            (p) => p.containsKey('functionCall'),
+          );
+
+          expect(toolCallIndex, isNonNegative);
+          expect(functionCallIndex, isNonNegative);
+          expect(toolCallIndex, lessThan(functionCallIndex));
+          expect(
+            modelParts[toolCallIndex].containsKey('thoughtSignature') ||
+                modelParts[toolCallIndex].containsKey('thought_signature'),
+            isTrue,
+          );
+          expect(
+            modelParts[functionCallIndex].containsKey('thoughtSignature') ||
+                modelParts[functionCallIndex].containsKey('thought_signature'),
+            isTrue,
+          );
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        fail('Unexpected request count: $requestCount');
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {
+            'role': 'user',
+            'content':
+                'Search the web for the latest paper, then fetch it and summarize it.',
+          },
+        ],
+        tools: const [
+          {'google_search': {}},
+          {
+            'function_declarations': [
+              {
+                'name': 'fetch_markdown',
+                'description': 'Fetch a page as markdown',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'url': {'type': 'string'},
+                  },
+                  'required': ['url'],
+                },
+              },
+            ],
+          },
+        ],
+      ).toList();
+
+      expect(requestCount, 2);
+      expect(chunks.last.isDone, isTrue);
+    });
+  });
+}

--- a/test/gemini_thought_signature_repro_test.dart
+++ b/test/gemini_thought_signature_repro_test.dart
@@ -80,7 +80,7 @@ String? _thoughtSignatureOf(Map<dynamic, dynamic> part) {
 
 void main() {
   group('Gemini mixed tool thought signature repro', () {
-    test('preserves a late thought signature on the functionCall part', () async {
+    test('does not move a detached signature onto an unsigned functionCall', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
         await server.close(force: true);
@@ -118,37 +118,27 @@ void main() {
           final firstCall = modelParts.firstWhere(
             (p) => p.containsKey('functionCall'),
           );
-          final hasSignature =
-              firstCall.containsKey('thoughtSignature') ||
-              firstCall.containsKey('thought_signature');
-
-          if (!hasSignature) {
-            request.response.statusCode = HttpStatus.badRequest;
-            request.response.headers.contentType = ContentType.json;
-            request.response.write(
-              jsonEncode({
-                'error': {
-                  'code': 400,
-                  'message':
-                      'Function call is missing a thought_signature in functionCall parts. Additional data, function call `google:search`, position 6.',
-                  'status': 'INVALID_ARGUMENT',
-                },
-              }),
-            );
-            await request.response.close();
-            return;
-          }
-
-          request.response.statusCode = HttpStatus.ok;
-          request.response.headers.contentType = ContentType(
-            'text',
-            'event-stream',
+          final detachedSignature = modelParts.firstWhere(
+            (p) =>
+                p['text'] == '' &&
+                _thoughtSignatureOf(p) == 'sig-google-search',
           );
-          request.response.headers.set('Transfer-Encoding', 'chunked');
+
+          expect(_hasThoughtSignature(firstCall), isFalse);
+          expect(_thoughtSignatureOf(detachedSignature), 'sig-google-search');
+
+          request.response.statusCode = HttpStatus.badRequest;
+          request.response.headers.contentType = ContentType.json;
           request.response.write(
-            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+            jsonEncode({
+              'error': {
+                'code': 400,
+                'message':
+                    'Function call is missing a thought_signature in functionCall parts. Additional data, function call `google:search`, position 6.',
+                'status': 'INVALID_ARGUMENT',
+              },
+            }),
           );
-          request.response.write('data: [DONE]');
           await request.response.close();
           return;
         }
@@ -156,40 +146,42 @@ void main() {
         fail('Unexpected request count: $requestCount');
       });
 
-      final chunks = await ChatApiService.sendMessageStream(
-        config: _geminiConfig(
-          'http://${server.address.address}:${server.port}/v1beta',
-        ),
-        modelId: 'gemini-3.1-pro-preview',
-        messages: const [
-          {
-            'role': 'user',
-            'content':
-                'Search the web for the Kelivo fetch server docs, then summarize them.',
-          },
-        ],
-        tools: const [
-          {'google_search': {}},
-          {
-            'function_declarations': [
-              {
-                'name': 'fetch_markdown',
-                'description': 'Fetch a page as markdown',
-                'parameters': {
-                  'type': 'object',
-                  'properties': {
-                    'url': {'type': 'string'},
+      await expectLater(
+        ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-3.1-pro-preview',
+          messages: const [
+            {
+              'role': 'user',
+              'content':
+                  'Search the web for the Kelivo fetch server docs, then summarize them.',
+            },
+          ],
+          tools: const [
+            {'google_search': {}},
+            {
+              'function_declarations': [
+                {
+                  'name': 'fetch_markdown',
+                  'description': 'Fetch a page as markdown',
+                  'parameters': {
+                    'type': 'object',
+                    'properties': {
+                      'url': {'type': 'string'},
+                    },
+                    'required': ['url'],
                   },
-                  'required': ['url'],
                 },
-              },
-            ],
-          },
-        ],
-      ).toList();
+              ],
+            },
+          ],
+        ).toList(),
+        throwsA(isA<HttpException>()),
+      );
 
       expect(requestCount, 2);
-      expect(chunks.last.isDone, isTrue);
     });
 
     test(
@@ -276,7 +268,7 @@ void main() {
       },
     );
 
-    test('backfills a later signature onto the next unsigned functionCall', () async {
+    test('preserves parallel function calls without inventing signatures', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
         await server.close(force: true);
@@ -298,10 +290,7 @@ void main() {
             'data: ${jsonEncode(_streamChunk([
               _functionCallPart(name: 'search_docs', args: {'query': 'Kelivo fetch'}, thoughtSignature: 'sig-search-docs'),
               _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}),
-            ]))}\n\n',
-          );
-          request.response.write(
-            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-fetch-markdown')], finishReason: 'STOP'))}\n\n',
+            ], finishReason: 'STOP'))}\n\n',
           );
           request.response.write('data: [DONE]');
           await request.response.close();
@@ -318,7 +307,7 @@ void main() {
 
           expect(functionCalls, hasLength(2));
           expect(_thoughtSignatureOf(functionCalls[0]), 'sig-search-docs');
-          expect(_thoughtSignatureOf(functionCalls[1]), 'sig-fetch-markdown');
+          expect(_hasThoughtSignature(functionCalls[1]), isFalse);
 
           request.response.statusCode = HttpStatus.ok;
           request.response.headers.contentType = ContentType(
@@ -382,7 +371,7 @@ void main() {
       expect(chunks.last.isDone, isTrue);
     });
 
-    test('does not attach a late tool signature to a later functionCall', () async {
+    test('keeps a detached signature part instead of moving it', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
         await server.close(force: true);
@@ -402,14 +391,11 @@ void main() {
           request.response.headers.set('Transfer-Encoding', 'chunked');
           request.response.write(
             'data: ${jsonEncode(_streamChunk([
-              _toolCallPart(toolType: 'GOOGLE_SEARCH_WEB', args: {
-                'queries': ['Kelivo fetch docs'],
-              }, id: 'tool-call-1'),
-              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}),
+              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}, thoughtSignature: 'sig-fetch-markdown'),
             ]))}\n\n',
           );
           request.response.write(
-            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-tool-call')], finishReason: 'STOP'))}\n\n',
+            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-detached')], finishReason: 'STOP'))}\n\n',
           );
           request.response.write('data: [DONE]');
           await request.response.close();
@@ -420,28 +406,26 @@ void main() {
           final body = jsonDecode(bodyText) as Map<String, dynamic>;
           final contents = (body['contents'] as List).cast<Map>();
           final modelParts = (contents[1]['parts'] as List).cast<Map>();
-          final toolCall = modelParts.firstWhere(
-            (p) => p.containsKey('toolCall'),
-          );
           final functionCall = modelParts.firstWhere(
             (p) => p.containsKey('functionCall'),
           );
-
-          expect(_thoughtSignatureOf(toolCall), 'sig-tool-call');
-          expect(_hasThoughtSignature(functionCall), isFalse);
-
-          request.response.statusCode = HttpStatus.badRequest;
-          request.response.headers.contentType = ContentType.json;
-          request.response.write(
-            jsonEncode({
-              'error': {
-                'code': 400,
-                'message':
-                    'Function call is missing a thought_signature in functionCall parts after a built-in tool signature arrived late.',
-                'status': 'INVALID_ARGUMENT',
-              },
-            }),
+          final detachedSignature = modelParts.firstWhere(
+            (p) => p['text'] == '' && _thoughtSignatureOf(p) == 'sig-detached',
           );
+
+          expect(_thoughtSignatureOf(functionCall), 'sig-fetch-markdown');
+          expect(_thoughtSignatureOf(detachedSignature), 'sig-detached');
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
           await request.response.close();
           return;
         }
@@ -449,41 +433,132 @@ void main() {
         fail('Unexpected request count: $requestCount');
       });
 
-      await expectLater(
-        ChatApiService.sendMessageStream(
-          config: _geminiConfig(
-            'http://${server.address.address}:${server.port}/v1beta',
-          ),
-          modelId: 'gemini-3.1-pro-preview',
-          messages: const [
-            {
-              'role': 'user',
-              'content': 'Search first, then fetch the top result.',
-            },
-          ],
-          tools: const [
-            {'google_search': {}},
-            {
-              'function_declarations': [
-                {
-                  'name': 'fetch_markdown',
-                  'description': 'Fetch a page as markdown',
-                  'parameters': {
-                    'type': 'object',
-                    'properties': {
-                      'url': {'type': 'string'},
-                    },
-                    'required': ['url'],
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {'role': 'user', 'content': 'Fetch the page content.'},
+        ],
+        tools: const [
+          {
+            'function_declarations': [
+              {
+                'name': 'fetch_markdown',
+                'description': 'Fetch a page as markdown',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'url': {'type': 'string'},
                   },
+                  'required': ['url'],
                 },
-              ],
-            },
-          ],
-        ).toList(),
-        throwsA(isA<HttpException>()),
-      );
+              },
+            ],
+          },
+        ],
+      ).toList();
 
       expect(requestCount, 2);
+      expect(chunks.last.isDone, isTrue);
+    });
+
+    test('preserves unknown non-thought model parts in replay', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        final bodyText = await utf8.decoder.bind(request).join();
+
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([
+              {
+                'futureToolPart': {'id': 'future-tool-1', 'payload': 'preserve me'},
+              },
+              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}, thoughtSignature: 'sig-fetch-markdown'),
+            ], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        if (requestCount == 2) {
+          final body = jsonDecode(bodyText) as Map<String, dynamic>;
+          final contents = (body['contents'] as List).cast<Map>();
+          final modelParts = (contents[1]['parts'] as List).cast<Map>();
+          final futurePartIndex = modelParts.indexWhere(
+            (p) => p.containsKey('futureToolPart'),
+          );
+          final functionCallIndex = modelParts.indexWhere(
+            (p) => p.containsKey('functionCall'),
+          );
+
+          expect(futurePartIndex, isNonNegative);
+          expect(functionCallIndex, isNonNegative);
+          expect(futurePartIndex, lessThan(functionCallIndex));
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        fail('Unexpected request count: $requestCount');
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {
+            'role': 'user',
+            'content': 'Fetch the page content after processing the tool part.',
+          },
+        ],
+        tools: const [
+          {
+            'function_declarations': [
+              {
+                'name': 'fetch_markdown',
+                'description': 'Fetch a page as markdown',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'url': {'type': 'string'},
+                  },
+                  'required': ['url'],
+                },
+              },
+            ],
+          },
+        ],
+      ).toList();
+
+      expect(requestCount, 2);
+      expect(chunks.last.isDone, isTrue);
     });
 
     test('preserves signed toolCall and functionCall parts in order', () async {

--- a/test/gemini_thought_signature_repro_test.dart
+++ b/test/gemini_thought_signature_repro_test.dart
@@ -69,6 +69,15 @@ Map<String, dynamic> _textPart({
   };
 }
 
+bool _hasThoughtSignature(Map<dynamic, dynamic> part) {
+  return part.containsKey('thoughtSignature') ||
+      part.containsKey('thought_signature');
+}
+
+String? _thoughtSignatureOf(Map<dynamic, dynamic> part) {
+  return (part['thoughtSignature'] ?? part['thought_signature'])?.toString();
+}
+
 void main() {
   group('Gemini mixed tool thought signature repro', () {
     test('preserves a late thought signature on the functionCall part', () async {
@@ -267,6 +276,216 @@ void main() {
       },
     );
 
+    test('backfills a later signature onto the next unsigned functionCall', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        final bodyText = await utf8.decoder.bind(request).join();
+
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([
+              _functionCallPart(name: 'search_docs', args: {'query': 'Kelivo fetch'}, thoughtSignature: 'sig-search-docs'),
+              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}),
+            ]))}\n\n',
+          );
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-fetch-markdown')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        if (requestCount == 2) {
+          final body = jsonDecode(bodyText) as Map<String, dynamic>;
+          final contents = (body['contents'] as List).cast<Map>();
+          final modelParts = (contents[1]['parts'] as List).cast<Map>();
+          final functionCalls = modelParts
+              .where((p) => p.containsKey('functionCall'))
+              .toList();
+
+          expect(functionCalls, hasLength(2));
+          expect(_thoughtSignatureOf(functionCalls[0]), 'sig-search-docs');
+          expect(_thoughtSignatureOf(functionCalls[1]), 'sig-fetch-markdown');
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        fail('Unexpected request count: $requestCount');
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {
+            'role': 'user',
+            'content': 'Look up the docs first, then fetch the page content.',
+          },
+        ],
+        tools: const [
+          {
+            'function_declarations': [
+              {
+                'name': 'search_docs',
+                'description': 'Search for matching docs',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'query': {'type': 'string'},
+                  },
+                  'required': ['query'],
+                },
+              },
+              {
+                'name': 'fetch_markdown',
+                'description': 'Fetch a page as markdown',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'url': {'type': 'string'},
+                  },
+                  'required': ['url'],
+                },
+              },
+            ],
+          },
+        ],
+      ).toList();
+
+      expect(requestCount, 2);
+      expect(chunks.last.isDone, isTrue);
+    });
+
+    test('does not attach a late tool signature to a later functionCall', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        final bodyText = await utf8.decoder.bind(request).join();
+
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([
+              _toolCallPart(toolType: 'GOOGLE_SEARCH_WEB', args: {
+                'queries': ['Kelivo fetch docs'],
+              }, id: 'tool-call-1'),
+              _functionCallPart(name: 'fetch_markdown', args: {'url': 'https://example.com'}),
+            ]))}\n\n',
+          );
+          request.response.write(
+            'data: ${jsonEncode(_streamChunk([_textPart(text: '', thoughtSignature: 'sig-tool-call')], finishReason: 'STOP'))}\n\n',
+          );
+          request.response.write('data: [DONE]');
+          await request.response.close();
+          return;
+        }
+
+        if (requestCount == 2) {
+          final body = jsonDecode(bodyText) as Map<String, dynamic>;
+          final contents = (body['contents'] as List).cast<Map>();
+          final modelParts = (contents[1]['parts'] as List).cast<Map>();
+          final toolCall = modelParts.firstWhere(
+            (p) => p.containsKey('toolCall'),
+          );
+          final functionCall = modelParts.firstWhere(
+            (p) => p.containsKey('functionCall'),
+          );
+
+          expect(_thoughtSignatureOf(toolCall), 'sig-tool-call');
+          expect(_hasThoughtSignature(functionCall), isFalse);
+
+          request.response.statusCode = HttpStatus.badRequest;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'error': {
+                'code': 400,
+                'message':
+                    'Function call is missing a thought_signature in functionCall parts after a built-in tool signature arrived late.',
+                'status': 'INVALID_ARGUMENT',
+              },
+            }),
+          );
+          await request.response.close();
+          return;
+        }
+
+        fail('Unexpected request count: $requestCount');
+      });
+
+      await expectLater(
+        ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-3.1-pro-preview',
+          messages: const [
+            {
+              'role': 'user',
+              'content': 'Search first, then fetch the top result.',
+            },
+          ],
+          tools: const [
+            {'google_search': {}},
+            {
+              'function_declarations': [
+                {
+                  'name': 'fetch_markdown',
+                  'description': 'Fetch a page as markdown',
+                  'parameters': {
+                    'type': 'object',
+                    'properties': {
+                      'url': {'type': 'string'},
+                    },
+                    'required': ['url'],
+                  },
+                },
+              ],
+            },
+          ],
+        ).toList(),
+        throwsA(isA<HttpException>()),
+      );
+
+      expect(requestCount, 2);
+    });
+
     test('preserves signed toolCall and functionCall parts in order', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
@@ -312,16 +531,8 @@ void main() {
           expect(toolCallIndex, isNonNegative);
           expect(functionCallIndex, isNonNegative);
           expect(toolCallIndex, lessThan(functionCallIndex));
-          expect(
-            modelParts[toolCallIndex].containsKey('thoughtSignature') ||
-                modelParts[toolCallIndex].containsKey('thought_signature'),
-            isTrue,
-          );
-          expect(
-            modelParts[functionCallIndex].containsKey('thoughtSignature') ||
-                modelParts[functionCallIndex].containsKey('thought_signature'),
-            isTrue,
-          );
+          expect(_hasThoughtSignature(modelParts[toolCallIndex]), isTrue);
+          expect(_hasThoughtSignature(modelParts[functionCallIndex]), isTrue);
 
           request.response.statusCode = HttpStatus.ok;
           request.response.headers.contentType = ContentType(


### PR DESCRIPTION
## Summary
- Preserve Gemini 3 model turns in their original part order when mixed tool outputs are present.
- Keep `thoughtSignature` attached to the original `toolCall` / `functionCall` part instead of rebuilding tool history by buckets.
- Add a regression test covering mixed `google_search` + custom function tool turns.
## Testing
- `flutter analyze lib/core/services/api/providers/google_common.dart test/gemini_thought_signature_repro_test.dart`
- `flutter test test/gemini_thought_signature_repro_test.dart`
## Notes
- The fix targets the Gemini replay path in `lib/core/services/api/providers/google_common.dart`.
- The regression test reproduces the failure deterministically with a local HTTP server.

Closes #487