### PR TITLE
fix(windows): resolve MCP stdio server crash on Windows

### DIFF
--- a/dependencies/mcp_client/lib/src/transport/stdio_launch.dart
+++ b/dependencies/mcp_client/lib/src/transport/stdio_launch.dart
@@ -1,0 +1,32 @@
+import 'dart:io' show Platform;
+
+bool needsWindowsCmdWrapper(String command, {bool? isWindows}) {
+  final resolvedIsWindows = isWindows ?? Platform.isWindows;
+  if (!resolvedIsWindows) return false;
+
+  final lower = command.toLowerCase();
+  return lower.endsWith('.cmd') ||
+      lower.endsWith('.bat') ||
+      lower == 'npx' ||
+      lower == 'npm' ||
+      lower == 'uv' ||
+      lower == 'uvx';
+}
+
+({String executableCommand, List<String> effectiveArgs}) resolveStdioLaunch(
+  String command,
+  List<String> arguments, {
+  bool? isWindows,
+}) {
+  if (needsWindowsCmdWrapper(command, isWindows: isWindows)) {
+    return (
+      executableCommand: 'cmd.exe',
+      effectiveArgs: ['/c', command, ...arguments],
+    );
+  }
+
+  return (
+    executableCommand: command,
+    effectiveArgs: [...arguments],
+  );
+}

--- a/dependencies/mcp_client/lib/src/transport/transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/transport.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io' show Platform, Process, HttpClient, ContentType;
+import 'dart:io' show Process, HttpClient, ContentType;
 
 import '../../logger.dart';
 import '../models/models.dart';
 import 'event_source.dart';
+import 'stdio_launch.dart';
 
 final Logger _logger = Logger('mcp_client.transport');
 
@@ -48,29 +49,9 @@ class StdioClientTransport implements ClientTransport {
   }) async {
     _logger.debug('Starting process: $command ${arguments.join(' ')}');
 
-    // On Windows, handle .cmd/.bat files specially
-    List<String> effectiveArgs;
-    String executableCommand;
-    Map<String, String>? effectiveEnv = environment;
-
-    if (Platform.isWindows) {
-      final cmdLower = command.toLowerCase();
-      // Check if this is a .cmd or .bat file, or a known npm command
-      if (cmdLower.endsWith('.cmd') ||
-          cmdLower.endsWith('.bat') ||
-          command == 'npx' ||
-          command == 'npm') {
-        // Use cmd.exe to execute .cmd/.bat files, or for npx/npm
-        executableCommand = 'cmd.exe';
-        effectiveArgs = ['/c', command, ...arguments];
-      } else {
-        executableCommand = command;
-        effectiveArgs = arguments;
-      }
-    } else {
-      executableCommand = command;
-      effectiveArgs = arguments;
-    }
+    final launchPlan = resolveStdioLaunch(command, arguments);
+    final effectiveArgs = launchPlan.effectiveArgs;
+    final executableCommand = launchPlan.executableCommand;
 
     _logger.debug(
       'Effective command: $executableCommand, args: $effectiveArgs',
@@ -80,7 +61,7 @@ class StdioClientTransport implements ClientTransport {
       executableCommand,
       effectiveArgs,
       workingDirectory: workingDirectory,
-      environment: effectiveEnv,
+      environment: environment,
     );
 
     return StdioClientTransport._internal(process);

--- a/dependencies/mcp_client/lib/src/transport/transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/transport.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io' show Process, HttpClient, ContentType;
+import 'dart:io' show Platform, Process, HttpClient, ContentType;
 
 import '../../logger.dart';
 import '../models/models.dart';
@@ -48,11 +48,39 @@ class StdioClientTransport implements ClientTransport {
   }) async {
     _logger.debug('Starting process: $command ${arguments.join(' ')}');
 
+    // On Windows, handle .cmd/.bat files specially
+    List<String> effectiveArgs;
+    String executableCommand;
+    Map<String, String>? effectiveEnv = environment;
+
+    if (Platform.isWindows) {
+      final cmdLower = command.toLowerCase();
+      // Check if this is a .cmd or .bat file, or a known npm command
+      if (cmdLower.endsWith('.cmd') ||
+          cmdLower.endsWith('.bat') ||
+          command == 'npx' ||
+          command == 'npm') {
+        // Use cmd.exe to execute .cmd/.bat files, or for npx/npm
+        executableCommand = 'cmd.exe';
+        effectiveArgs = ['/c', command, ...arguments];
+      } else {
+        executableCommand = command;
+        effectiveArgs = arguments;
+      }
+    } else {
+      executableCommand = command;
+      effectiveArgs = arguments;
+    }
+
+    _logger.debug(
+      'Effective command: $executableCommand, args: $effectiveArgs',
+    );
+
     final process = await Process.start(
-      command,
-      arguments,
+      executableCommand,
+      effectiveArgs,
       workingDirectory: workingDirectory,
-      environment: environment,
+      environment: effectiveEnv,
     );
 
     return StdioClientTransport._internal(process);

--- a/dependencies/mcp_client/test/stdio_launch_test.dart
+++ b/dependencies/mcp_client/test/stdio_launch_test.dart
@@ -1,0 +1,44 @@
+import 'package:mcp_client/src/transport/stdio_launch.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('needsWindowsCmdWrapper', () {
+    test('returns false when not running on Windows', () {
+      expect(needsWindowsCmdWrapper('npx', isWindows: false), isFalse);
+      expect(needsWindowsCmdWrapper('tool.cmd', isWindows: false), isFalse);
+    });
+
+    test('matches Windows shim commands case-insensitively', () {
+      expect(needsWindowsCmdWrapper('npx', isWindows: true), isTrue);
+      expect(needsWindowsCmdWrapper('Npm', isWindows: true), isTrue);
+      expect(needsWindowsCmdWrapper('UV', isWindows: true), isTrue);
+      expect(needsWindowsCmdWrapper('UvX', isWindows: true), isTrue);
+    });
+
+    test('matches batch file extensions case-insensitively', () {
+      expect(needsWindowsCmdWrapper('server.CMD', isWindows: true), isTrue);
+      expect(needsWindowsCmdWrapper('server.Bat', isWindows: true), isTrue);
+      expect(needsWindowsCmdWrapper('server.exe', isWindows: true), isFalse);
+    });
+  });
+
+  group('resolveStdioLaunch', () {
+    test('wraps Windows shim commands with cmd.exe', () {
+      final plan = resolveStdioLaunch('NPX', ['-y', 'pkg'], isWindows: true);
+
+      expect(plan.executableCommand, 'cmd.exe');
+      expect(plan.effectiveArgs, ['/c', 'NPX', '-y', 'pkg']);
+    });
+
+    test('leaves regular commands unchanged', () {
+      final plan = resolveStdioLaunch(
+        'python',
+        ['-m', 'module'],
+        isWindows: true,
+      );
+
+      expect(plan.executableCommand, 'python');
+      expect(plan.effectiveArgs, ['-m', 'module']);
+    });
+  });
+}

--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -256,6 +256,7 @@ class McpProvider extends ChangeNotifier {
   final Map<String, Timer> _heartbeats = <String, Timer>{};
   Duration _requestTimeout = const Duration(seconds: 30);
   String? _cachedSystemPath;
+  Future<String?>? _systemPathFuture;
 
   McpProvider() {
     _load();
@@ -1395,46 +1396,54 @@ class McpProvider extends ChangeNotifier {
     super.dispose();
   }
 
-  Future<String?> _getSystemPath() async {
-    if (_cachedSystemPath != null) return _cachedSystemPath;
-    // macOS: use launchctl to get system PATH
-    if (Platform.isMacOS) {
-      try {
-        final result = await Process.run('launchctl', ['getenv', 'PATH']);
-        if (result.exitCode == 0) {
-          _cachedSystemPath = (result.stdout as String).trim();
-          return _cachedSystemPath;
-        }
-      } catch (_) {}
-    }
-    // Windows: get user PATH from registry if not in current environment
-    if (Platform.isWindows) {
-      try {
-        // Try to get PATH from the user environment via PowerShell
-        final result = await Process.run('powershell', [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          r'[Environment]::GetEnvironmentVariable("PATH", "User")',
-        ]);
-        if (result.exitCode == 0) {
-          final userPath = (result.stdout as String).trim();
-          if (userPath.isNotEmpty) {
-            // Merge with current PATH
-            final currentPath = Platform.environment['PATH'] ?? '';
-            if (currentPath.isNotEmpty && userPath.isNotEmpty) {
-              _cachedSystemPath = '$currentPath;$userPath';
-            } else {
-              _cachedSystemPath = currentPath.isNotEmpty
-                  ? currentPath
-                  : userPath;
-            }
+  Future<String?> _getSystemPath() {
+    final cachedFuture = _systemPathFuture;
+    if (cachedFuture != null) return cachedFuture;
+
+    final systemPathFuture = () async {
+      if (_cachedSystemPath != null) return _cachedSystemPath;
+      // macOS: use launchctl to get system PATH
+      if (Platform.isMacOS) {
+        try {
+          final result = await Process.run('launchctl', ['getenv', 'PATH']);
+          if (result.exitCode == 0) {
+            _cachedSystemPath = (result.stdout as String).trim();
             return _cachedSystemPath;
           }
-        }
-      } catch (_) {}
-    }
-    return null;
+        } catch (_) {}
+      }
+      // Windows: get user PATH from registry if not in current environment
+      if (Platform.isWindows) {
+        try {
+          // Try to get PATH from the user environment via PowerShell
+          final result = await Process.run('powershell', [
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            r'[Environment]::GetEnvironmentVariable("PATH", "User")',
+          ]);
+          if (result.exitCode == 0) {
+            final userPath = (result.stdout as String).trim();
+            if (userPath.isNotEmpty) {
+              // Merge with current PATH
+              final currentPath = Platform.environment['PATH'] ?? '';
+              if (currentPath.isNotEmpty && userPath.isNotEmpty) {
+                _cachedSystemPath = '$currentPath;$userPath';
+              } else {
+                _cachedSystemPath = currentPath.isNotEmpty
+                    ? currentPath
+                    : userPath;
+              }
+              return _cachedSystemPath;
+            }
+          }
+        } catch (_) {}
+      }
+      return null;
+    }();
+
+    _systemPathFuture = systemPathFuture;
+    return systemPathFuture;
   }
 
   Future<Map<String, String>> _resolveEnvironmentWithPath(
@@ -1455,45 +1464,15 @@ class McpProvider extends ChangeNotifier {
     Map<String, String> environment,
   ) async {
     try {
-      // On Windows, we need special handling:
-      // 1. npm packages install as .cmd files (e.g., npx.cmd)
-      // 2. The 'where' command finds them, but execution needs cmd.exe
-      // 3. Try direct execution first, then fallback to 'where'
       if (Platform.isWindows) {
-        // First, try to find the command with 'where'
         final whereResult = await Process.run(
           'where',
           [command],
           environment: environment,
           runInShell: true,
         );
-        if (whereResult.exitCode != 0) {
-          return false;
-        }
-        // If found, verify it can actually run
-        // For .cmd/.bat files, use cmd.exe explicitly
-        final testCommand = command.toLowerCase();
-        if (testCommand.endsWith('.cmd') || testCommand.endsWith('.bat')) {
-          final testResult = await Process.run(
-            'cmd.exe',
-            ['/c', command, '--version'],
-            environment: environment,
-            runInShell: true,
-          );
-          //command might not have --version, but if it runs without error, it's valid
-          return testResult.exitCode == 0 || testResult.exitCode == 1;
-        } else {
-          // Try running with --help or --version to verify
-          final testResult = await Process.run(
-            'cmd.exe',
-            ['/c', command],
-            environment: environment,
-            runInShell: true,
-          );
-          return testResult.exitCode == 0 || testResult.exitCode == 1;
-        }
+        return whereResult.exitCode == 0;
       } else {
-        // Unix-like: use which
         final whichCmd = 'which';
         final result = await Process.run(
           whichCmd,

--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -49,6 +49,7 @@ class McpToolConfig {
   final List<McpParamSpec> params;
   // Raw JSON schema for parameters, if provided by the server
   final Map<String, dynamic>? schema;
+
   /// Whether this tool requires user approval before execution.
   final bool needsApproval;
 
@@ -712,8 +713,10 @@ class McpProvider extends ChangeNotifier {
     if (idx < 0) return;
     final server = _servers[idx];
     final tools = server.tools
-        .map((t) =>
-            t.name == toolName ? t.copyWith(needsApproval: needsApproval) : t)
+        .map(
+          (t) =>
+              t.name == toolName ? t.copyWith(needsApproval: needsApproval) : t,
+        )
         .toList();
     _servers[idx] = server.copyWith(tools: tools);
     await _persist();
@@ -1394,14 +1397,43 @@ class McpProvider extends ChangeNotifier {
 
   Future<String?> _getSystemPath() async {
     if (_cachedSystemPath != null) return _cachedSystemPath;
-    if (!Platform.isMacOS) return null;
-    try {
-      final result = await Process.run('launchctl', ['getenv', 'PATH']);
-      if (result.exitCode == 0) {
-        _cachedSystemPath = (result.stdout as String).trim();
-        return _cachedSystemPath;
-      }
-    } catch (_) {}
+    // macOS: use launchctl to get system PATH
+    if (Platform.isMacOS) {
+      try {
+        final result = await Process.run('launchctl', ['getenv', 'PATH']);
+        if (result.exitCode == 0) {
+          _cachedSystemPath = (result.stdout as String).trim();
+          return _cachedSystemPath;
+        }
+      } catch (_) {}
+    }
+    // Windows: get user PATH from registry if not in current environment
+    if (Platform.isWindows) {
+      try {
+        // Try to get PATH from the user environment via PowerShell
+        final result = await Process.run('powershell', [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          r'[Environment]::GetEnvironmentVariable("PATH", "User")',
+        ]);
+        if (result.exitCode == 0) {
+          final userPath = (result.stdout as String).trim();
+          if (userPath.isNotEmpty) {
+            // Merge with current PATH
+            final currentPath = Platform.environment['PATH'] ?? '';
+            if (currentPath.isNotEmpty && userPath.isNotEmpty) {
+              _cachedSystemPath = '$currentPath;$userPath';
+            } else {
+              _cachedSystemPath = currentPath.isNotEmpty
+                  ? currentPath
+                  : userPath;
+            }
+            return _cachedSystemPath;
+          }
+        }
+      } catch (_) {}
+    }
     return null;
   }
 
@@ -1423,14 +1455,54 @@ class McpProvider extends ChangeNotifier {
     Map<String, String> environment,
   ) async {
     try {
-      final whichCmd = Platform.isWindows ? 'where' : 'which';
-      final result = await Process.run(
-        whichCmd,
-        [command],
-        environment: environment,
-        runInShell: true,
-      );
-      return result.exitCode == 0;
+      // On Windows, we need special handling:
+      // 1. npm packages install as .cmd files (e.g., npx.cmd)
+      // 2. The 'where' command finds them, but execution needs cmd.exe
+      // 3. Try direct execution first, then fallback to 'where'
+      if (Platform.isWindows) {
+        // First, try to find the command with 'where'
+        final whereResult = await Process.run(
+          'where',
+          [command],
+          environment: environment,
+          runInShell: true,
+        );
+        if (whereResult.exitCode != 0) {
+          return false;
+        }
+        // If found, verify it can actually run
+        // For .cmd/.bat files, use cmd.exe explicitly
+        final testCommand = command.toLowerCase();
+        if (testCommand.endsWith('.cmd') || testCommand.endsWith('.bat')) {
+          final testResult = await Process.run(
+            'cmd.exe',
+            ['/c', command, '--version'],
+            environment: environment,
+            runInShell: true,
+          );
+          //command might not have --version, but if it runs without error, it's valid
+          return testResult.exitCode == 0 || testResult.exitCode == 1;
+        } else {
+          // Try running with --help or --version to verify
+          final testResult = await Process.run(
+            'cmd.exe',
+            ['/c', command],
+            environment: environment,
+            runInShell: true,
+          );
+          return testResult.exitCode == 0 || testResult.exitCode == 1;
+        }
+      } else {
+        // Unix-like: use which
+        final whichCmd = 'which';
+        final result = await Process.run(
+          whichCmd,
+          [command],
+          environment: environment,
+          runInShell: true,
+        );
+        return result.exitCode == 0;
+      }
     } catch (_) {
       return false;
     }

--- a/lib/icons/lucide_adapter.dart
+++ b/lib/icons/lucide_adapter.dart
@@ -70,7 +70,7 @@ class Lucide {
   static const IconData MessageCircle = lucide.LucideIcons.messageCircle;
   static const IconData NotebookTabs = lucide.LucideIcons.notebookTabs;
   static const IconData Vibrate = lucide.LucideIcons.vibrate;
-  static const IconData TextSelect = lucide.LucideIcons.lassoSelect;
+  static const IconData TextSelect = lucide.LucideIcons.textSelect;
   static const IconData BookOpenText = lucide.LucideIcons.bookOpenText;
   static const IconData Pencil = lucide.LucideIcons.pencil;
   static const IconData GitFork = lucide.LucideIcons.gitFork;

--- a/lib/icons/lucide_adapter.dart
+++ b/lib/icons/lucide_adapter.dart
@@ -70,7 +70,7 @@ class Lucide {
   static const IconData MessageCircle = lucide.LucideIcons.messageCircle;
   static const IconData NotebookTabs = lucide.LucideIcons.notebookTabs;
   static const IconData Vibrate = lucide.LucideIcons.vibrate;
-  static const IconData TextSelect = lucide.LucideIcons.textSelect;
+  static const IconData TextSelect = lucide.LucideIcons.lassoSelect;
   static const IconData BookOpenText = lucide.LucideIcons.bookOpenText;
   static const IconData Pencil = lucide.LucideIcons.pencil;
   static const IconData GitFork = lucide.LucideIcons.gitFork;


### PR DESCRIPTION
## 概述

修复在 Windows 平台上添加 MCP stdio 服务器时应用程序崩溃的问题（BEX64 异常）。

Closes #490

## 问题描述

在 Windows 上添加 MCP stdio 服务器（如 `npx -y @e2b/mcp-server`）并保存后，应用程序会立即崩溃退出。

**崩溃特征：**
- Event Type: BEX64  
- Exception Code: `c0000409` (STATUS_STACK_BUFFER_OVERRUN / C++ Fast-Fail)
- Faulting Module: `flutter_windows.dll`

## 原因分析

问题由两个层面的原因导致：

### 1. 命令执行方式问题

Windows 上 npm 全局包（如 `npx`）安装为 `.cmd` 批处理文件。Dart 的 `Process.start()` 无法直接执行这些文件，导致进程启动失败并触发底层异常。

### 2. PATH 环境变量问题

Windows GUI 应用程序无法获取完整的用户 PATH 环境变量（相比于终端启动的应用）。当用户通过 npm 安装了 MCP 服务器命令后，Flutter 应用可能无法找到该命令。

## 修复方案

### Commit 1: mcp_client 传输层修复

在 `StdioClientTransport.create()` 中增加 Windows 特殊处理：

```dart
if (Platform.isWindows) {
  final cmdLower = command.toLowerCase();
  if (cmdLower.endsWith('.cmd') ||
      cmdLower.endsWith('.bat') ||
      command == 'npx' ||
      command == 'npm') {
    executableCommand = 'cmd.exe';
    effectiveArgs = ['/c', command, ...arguments];
  }
}
```

### Commit 2: Provider 层 PATH 解析与命令验证

- `_getSystemPath()`: 通过 PowerShell 获取用户 PATH 并合并，解决 GUI 应用缺少 PATH 的问题
- `_validateCommand()`: 改进 Windows 命令验证逻辑，正确处理 `.cmd/.bat` 文件

### Commit 3: 图标兼容性修复

`lucide_icons_flutter` 3.1.x 中不存在 `textSelect` 图标，替换为 `lassoSelect`。

## 修改文件

| 文件 | 变更说明 |
|------|---------|
| `dependencies/mcp_client/lib/src/transport/transport.dart` | Windows 上使用 cmd.exe 包装 .cmd/.bat 文件和 npm 命令 |
| `lib/core/providers/mcp_provider.dart` | Windows PATH 解析与命令验证改进 |
| `lib/icons/lucide_adapter.dart` | 替换缺失的 textSelect 图标 |

## 测试环境

- Windows Server 2025 (Build 26100)
- Flutter 3.38.7
- Kelivo 1.1.11+29

## 测试计划

- [x] Windows 上添加 `npx -y @e2b/mcp-server` MCP stdio 服务器，验证不再崩溃
- [x] Flutter analyze 通过
- [x] Windows release 构建成功
- [ ] macOS/Linux 平台验证 MCP stdio 功能无回归

## 验证步骤

1. 构建并运行 Windows 版本
2. 进入 MCP 设置页面
3. 添加新的 MCP stdio 服务器：
   - 命令: `npx`
   - 参数: `-y @e2b/mcp-server`
   - 环境变量: `E2B_API_KEY=<your_key>`
4. 保存配置，验证应用正常响应且服务器连接成功