### PR TITLE
feat(openai): support Images API generations and edits

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 import '../../providers/settings_provider.dart';
 import '../../providers/model_provider.dart';
 import '../../models/token_usage.dart';

--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -26,6 +26,7 @@ import '../../utils/multimodal_input_utils.dart';
 part 'chat_api_service_shims.dart';
 part 'providers/openai_common.dart';
 part 'providers/openai_chat_completions.dart';
+part 'providers/openai_images.dart';
 part 'providers/openai_responses.dart';
 part 'providers/google_common.dart';
 part 'providers/google_gemini.dart';
@@ -400,7 +401,17 @@ class ChatApiService {
 
     try {
       if (kind == ProviderKind.openai) {
-        if (config.useResponseApi == true) {
+        if (_shouldUseOpenAIImagesApi(config, modelId)) {
+          yield* _sendOpenAIImagesStream(
+            client,
+            config,
+            modelId,
+            safeMessages,
+            userImagePaths: userImagePaths,
+            extraHeaders: extraHeaders,
+            extraBody: extraBody,
+          );
+        } else if (config.useResponseApi == true) {
           yield* _sendOpenAIResponsesStream(
             client,
             config,

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -1,0 +1,315 @@
+part of '../chat_api_service.dart';
+
+bool _shouldUseOpenAIImagesApi(ProviderConfig config, String modelId) {
+  if (config.useResponseApi == true) return false;
+  final upstreamModelId = _apiModelId(config, modelId).toLowerCase();
+  return upstreamModelId.startsWith('gpt-image-') ||
+      upstreamModelId.startsWith('dall-e-') ||
+      upstreamModelId.startsWith('chatgpt-image-');
+}
+
+Uri _openAIImagesUrl(ProviderConfig config, String path) {
+  final rawBase = config.baseUrl.endsWith('/')
+      ? config.baseUrl.substring(0, config.baseUrl.length - 1)
+      : config.baseUrl;
+  return Uri.parse('$rawBase$path');
+}
+
+Stream<ChatStreamChunk> _sendOpenAIImagesStream(
+  http.Client client,
+  ProviderConfig config,
+  String modelId,
+  List<Map<String, dynamic>> messages, {
+  List<String>? userImagePaths,
+  Map<String, String>? extraHeaders,
+  Map<String, dynamic>? extraBody,
+}) async* {
+  final prompt = await _lastOpenAIImagePrompt(messages);
+  final imageRefs = await _openAIImageEditRefs(messages, userImagePaths);
+  final response = imageRefs.isEmpty
+      ? await _sendOpenAIImageGeneration(
+          client,
+          config,
+          modelId,
+          prompt,
+          extraHeaders: extraHeaders,
+          extraBody: extraBody,
+        )
+      : await _sendOpenAIImageEdit(
+          client,
+          config,
+          modelId,
+          prompt,
+          imageRefs,
+          extraHeaders: extraHeaders,
+          extraBody: extraBody,
+        );
+  final markdown = await _openAIImagesResponseToMarkdown(response);
+  final usage = _openAIImagesUsage(response);
+  yield ChatStreamChunk(
+    content: markdown,
+    isDone: true,
+    totalTokens: usage?.totalTokens ?? 0,
+    usage: usage,
+  );
+}
+
+Future<Map<String, dynamic>> _sendOpenAIImageGeneration(
+  http.Client client,
+  ProviderConfig config,
+  String modelId,
+  String prompt, {
+  Map<String, String>? extraHeaders,
+  Map<String, dynamic>? extraBody,
+}) async {
+  final body = <String, dynamic>{
+    'model': _apiModelId(config, modelId),
+    'prompt': prompt,
+  };
+  _applyOpenAIImagesExtraBody(body, config, modelId, extraBody);
+  final response = await client.post(
+    _openAIImagesUrl(config, '/images/generations'),
+    headers: _openAIImagesJsonHeaders(
+      config,
+      modelId,
+      extraHeaders: extraHeaders,
+    ),
+    body: jsonEncode(body),
+  );
+  return _decodeOpenAIImagesResponse(response);
+}
+
+Future<Map<String, dynamic>> _sendOpenAIImageEdit(
+  http.Client client,
+  ProviderConfig config,
+  String modelId,
+  String prompt,
+  List<_ImageRef> imageRefs, {
+  Map<String, String>? extraHeaders,
+  Map<String, dynamic>? extraBody,
+}) async {
+  final allRemote = imageRefs.every((ref) => ref.kind == 'url');
+  if (allRemote) {
+    final body = <String, dynamic>{
+      'model': _apiModelId(config, modelId),
+      'prompt': prompt,
+      'images': [
+        for (final ref in imageRefs) {'image_url': ref.src},
+      ],
+    };
+    _applyOpenAIImagesExtraBody(body, config, modelId, extraBody);
+    final response = await client.post(
+      _openAIImagesUrl(config, '/images/edits'),
+      headers: _openAIImagesJsonHeaders(
+        config,
+        modelId,
+        extraHeaders: extraHeaders,
+      ),
+      body: jsonEncode(body),
+    );
+    return _decodeOpenAIImagesResponse(response);
+  }
+
+  if (imageRefs.any((ref) => ref.kind == 'url')) {
+    throw const FormatException(
+      'OpenAI image edits cannot mix remote image URLs with local image files.',
+    );
+  }
+
+  final request = http.MultipartRequest(
+    'POST',
+    _openAIImagesUrl(config, '/images/edits'),
+  );
+  request.headers.addAll(
+    _openAIImagesMultipartHeaders(config, modelId, extraHeaders: extraHeaders),
+  );
+  request.fields['model'] = _apiModelId(config, modelId);
+  request.fields['prompt'] = prompt;
+  final body = <String, dynamic>{};
+  _applyOpenAIImagesExtraBody(body, config, modelId, extraBody);
+  for (final entry in body.entries) {
+    if (entry.value == null) continue;
+    request.fields[entry.key] = entry.value.toString();
+  }
+  for (final ref in imageRefs) {
+    request.files.add(await _openAIImageMultipartFile(ref));
+  }
+  final streamed = await client.send(request);
+  final response = await http.Response.fromStream(streamed);
+  return _decodeOpenAIImagesResponse(response);
+}
+
+Future<String> _lastOpenAIImagePrompt(
+  List<Map<String, dynamic>> messages,
+) async {
+  for (int i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i]['role'] ?? '').toString() != 'user') continue;
+    final content = messages[i]['content'];
+    if (content is List) {
+      final buffer = StringBuffer();
+      for (final part in content) {
+        if (part is! Map) continue;
+        final type = (part['type'] ?? '').toString();
+        if (type == 'text' || type == 'input_text') {
+          final text = (part['text'] ?? part['content'] ?? '').toString();
+          if (text.trim().isNotEmpty) {
+            if (buffer.isNotEmpty) buffer.writeln();
+            buffer.write(text.trim());
+          }
+        }
+      }
+      final prompt = buffer.toString().trim();
+      if (prompt.isNotEmpty) return prompt;
+      continue;
+    }
+    final parsed = await _parseTextAndImages(
+      (content ?? '').toString(),
+      allowRemoteImages: true,
+      allowLocalImages: true,
+      keepRemoteMarkdownText: false,
+    );
+    final prompt = parsed.text.trim();
+    if (prompt.isNotEmpty) return prompt;
+  }
+  return '';
+}
+
+Future<List<_ImageRef>> _openAIImageEditRefs(
+  List<Map<String, dynamic>> messages,
+  List<String>? userImagePaths,
+) async {
+  final explicitPaths = (userImagePaths ?? const <String>[])
+      .map((path) => path.trim())
+      .where((path) => path.isNotEmpty)
+      .toList(growable: false);
+  if (explicitPaths.isNotEmpty) {
+    return [for (final path in explicitPaths) _imageRefFromSource(path)];
+  }
+
+  for (int i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i]['role'] ?? '').toString() != 'user') continue;
+    final parsed = await _parseTextAndImages(
+      (messages[i]['content'] ?? '').toString(),
+      allowRemoteImages: true,
+      allowLocalImages: true,
+      keepRemoteMarkdownText: false,
+    );
+    return parsed.images;
+  }
+  return const <_ImageRef>[];
+}
+
+_ImageRef _imageRefFromSource(String source) {
+  if (source.startsWith('data:')) return _ImageRef('data', source);
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    return _ImageRef('url', source);
+  }
+  return _ImageRef('path', source);
+}
+
+Future<http.MultipartFile> _openAIImageMultipartFile(_ImageRef ref) async {
+  if (ref.kind == 'data') {
+    final commaIndex = ref.src.indexOf(',');
+    final payload = commaIndex >= 0
+        ? ref.src.substring(commaIndex + 1)
+        : ref.src;
+    return http.MultipartFile.fromBytes(
+      'image[]',
+      base64Decode(payload.replaceAll(RegExp(r'\s'), '')),
+      filename:
+          'image.${AppDirectories.extFromMime(_mimeFromDataUrl(ref.src))}',
+    );
+  }
+  final fixed = SandboxPathResolver.fix(ref.src);
+  return http.MultipartFile.fromPath('image[]', fixed);
+}
+
+Map<String, String> _openAIImagesJsonHeaders(
+  ProviderConfig config,
+  String modelId, {
+  Map<String, String>? extraHeaders,
+}) {
+  return <String, String>{
+    'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+    'Content-Type': 'application/json',
+    ..._customHeaders(config, modelId),
+    if (extraHeaders != null) ...extraHeaders,
+  };
+}
+
+Map<String, String> _openAIImagesMultipartHeaders(
+  ProviderConfig config,
+  String modelId, {
+  Map<String, String>? extraHeaders,
+}) {
+  final headers = <String, String>{
+    'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+    ..._customHeaders(config, modelId),
+    if (extraHeaders != null) ...extraHeaders,
+  };
+  headers.removeWhere((key, _) => key.toLowerCase() == 'content-type');
+  return headers;
+}
+
+void _applyOpenAIImagesExtraBody(
+  Map<String, dynamic> body,
+  ProviderConfig config,
+  String modelId,
+  Map<String, dynamic>? extraBody,
+) {
+  final custom = _customBody(config, modelId);
+  if (custom.isNotEmpty) body.addAll(custom);
+  if (extraBody != null && extraBody.isNotEmpty) {
+    extraBody.forEach((key, value) {
+      body[key] = value is String ? _parseOverrideValue(value) : value;
+    });
+  }
+}
+
+Map<String, dynamic> _decodeOpenAIImagesResponse(http.Response response) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw HttpException('HTTP ${response.statusCode}: ${response.body}');
+  }
+  final decoded = jsonDecode(response.body);
+  if (decoded is! Map) {
+    throw const FormatException(
+      'OpenAI Images API returned a non-object body.',
+    );
+  }
+  return decoded.cast<String, dynamic>();
+}
+
+Future<String> _openAIImagesResponseToMarkdown(
+  Map<String, dynamic> response,
+) async {
+  final data = response['data'];
+  if (data is! List || data.isEmpty) return '';
+  final lines = <String>[];
+  for (final item in data) {
+    if (item is! Map) continue;
+    final url = (item['url'] ?? '').toString().trim();
+    if (url.isNotEmpty) {
+      lines.add('![image]($url)');
+      continue;
+    }
+    final b64 = (item['b64_json'] ?? '').toString().trim();
+    if (b64.isEmpty) continue;
+    final path = await AppDirectories.saveBase64Image('image/png', b64);
+    lines.add('![image]($path)');
+  }
+  return lines.join('\n\n');
+}
+
+TokenUsage? _openAIImagesUsage(Map<String, dynamic> response) {
+  final usage = response['usage'];
+  if (usage is! Map) return null;
+  final input =
+      (usage['input_tokens'] ?? usage['prompt_tokens'] ?? 0) as int? ?? 0;
+  final output =
+      (usage['output_tokens'] ?? usage['completion_tokens'] ?? 0) as int? ?? 0;
+  return TokenUsage(
+    promptTokens: input,
+    completionTokens: output,
+    totalTokens: input + output,
+  );
+}

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -271,6 +271,7 @@ _ImageRef _imageRefFromSource(String source) {
 
 Future<http.MultipartFile> _openAIImageMultipartFile(_ImageRef ref) async {
   if (ref.kind == 'data') {
+    final mime = _mimeFromDataUrl(ref.src);
     final commaIndex = ref.src.indexOf(',');
     final payload = commaIndex >= 0
         ? ref.src.substring(commaIndex + 1)
@@ -278,12 +279,29 @@ Future<http.MultipartFile> _openAIImageMultipartFile(_ImageRef ref) async {
     return http.MultipartFile.fromBytes(
       'image[]',
       base64Decode(payload.replaceAll(RegExp(r'\s'), '')),
-      filename:
-          'image.${AppDirectories.extFromMime(_mimeFromDataUrl(ref.src))}',
+      filename: 'image.${AppDirectories.extFromMime(mime)}',
+      contentType: _openAIImageMediaType(mime),
     );
   }
   final fixed = SandboxPathResolver.fix(ref.src);
-  return http.MultipartFile.fromPath('image[]', fixed);
+  final mime = _mimeFromPath(fixed);
+  return http.MultipartFile.fromPath(
+    'image[]',
+    fixed,
+    contentType: _openAIImageMediaType(mime),
+  );
+}
+
+MediaType _openAIImageMediaType(String mime) {
+  final normalized = mime.trim().toLowerCase();
+  if (normalized == 'image/jpeg' ||
+      normalized == 'image/png' ||
+      normalized == 'image/webp') {
+    return MediaType.parse(normalized);
+  }
+  throw FormatException(
+    'OpenAI image edits only support image/jpeg, image/png, and image/webp; got $mime.',
+  );
 }
 
 Map<String, String> _openAIImagesJsonHeaders(

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -2,9 +2,22 @@ part of '../chat_api_service.dart';
 
 bool _shouldUseOpenAIImagesApi(ProviderConfig config, String modelId) {
   final upstreamModelId = _apiModelId(config, modelId).toLowerCase();
-  return upstreamModelId.startsWith('gpt-image-') ||
-      upstreamModelId.startsWith('dall-e-') ||
-      upstreamModelId.startsWith('chatgpt-image-');
+  return _supportsOpenAIImageGenerations(upstreamModelId);
+}
+
+bool _supportsOpenAIImageGenerations(String modelId) {
+  final normalized = modelId.toLowerCase();
+  return normalized.startsWith('gpt-image-') ||
+      normalized.startsWith('chatgpt-image-') ||
+      normalized == 'dall-e-2' ||
+      normalized == 'dall-e-3';
+}
+
+bool _supportsOpenAIImageEdits(String modelId) {
+  final normalized = modelId.toLowerCase();
+  return normalized.startsWith('gpt-image-') ||
+      normalized.startsWith('chatgpt-image-') ||
+      normalized == 'dall-e-2';
 }
 
 Uri _openAIImagesUrl(ProviderConfig config, String path) {
@@ -24,6 +37,14 @@ Stream<ChatStreamChunk> _sendOpenAIImagesStream(
   Map<String, dynamic>? extraBody,
 }) async* {
   final input = await _openAIImagesInput(messages, userImagePaths);
+  final outputMime = _openAIImagesOutputMime(config, modelId, extraBody);
+  final upstreamModelId = _apiModelId(config, modelId);
+  if (input.imageRefs.isNotEmpty &&
+      !_supportsOpenAIImageEdits(upstreamModelId)) {
+    throw UnsupportedError(
+      'OpenAI Images API model $upstreamModelId does not support image edits with input images.',
+    );
+  }
   final response = input.imageRefs.isEmpty
       ? await _sendOpenAIImageGeneration(
           client,
@@ -42,7 +63,10 @@ Stream<ChatStreamChunk> _sendOpenAIImagesStream(
           extraHeaders: extraHeaders,
           extraBody: extraBody,
         );
-  final markdown = await _openAIImagesResponseToMarkdown(response);
+  final markdown = await _openAIImagesResponseToMarkdown(
+    response,
+    outputMime: outputMime,
+  );
   final usage = _openAIImagesUsage(response);
   yield ChatStreamChunk(
     content: markdown,
@@ -190,8 +214,16 @@ Future<_OpenAIImagesInput> _openAIImagesInput(
 
   for (int i = messages.length - 1; i >= 0; i--) {
     if ((messages[i]['role'] ?? '').toString() != 'user') continue;
+    final content = messages[i]['content'];
+    if (content is List) {
+      final structuredImages = _extractOpenAIImageRefs(content);
+      if (structuredImages.isNotEmpty) {
+        return _OpenAIImagesInput(prompt: prompt, imageRefs: structuredImages);
+      }
+    }
+
     final parsed = await _parseTextAndImages(
-      (messages[i]['content'] ?? '').toString(),
+      (content ?? '').toString(),
       allowRemoteImages: true,
       allowLocalImages: true,
       keepRemoteMarkdownText: false,
@@ -232,14 +264,10 @@ List<_ImageRef> _extractOpenAIImageRefs(dynamic content) {
       if (part is! Map) continue;
       final type = (part['type'] ?? '').toString();
       if (type == 'image_url') {
-        final imageUrl = part['image_url'];
-        final source = imageUrl is Map
-            ? (imageUrl['url'] ?? '').toString().trim()
-            : imageUrl.toString().trim();
-        if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
-      } else if (type == 'input_image') {
-        final source = (part['image_url'] ?? '').toString().trim();
-        if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+        _addOpenAIStructuredImageRefs(refs, part['image_url']);
+      } else if (type == 'input_image' || type == 'image') {
+        _addOpenAIStructuredImageRefs(refs, part['image_url']);
+        _addOpenAIStructuredImageRefs(refs, part['input_image']);
       }
     }
     return refs;
@@ -259,6 +287,55 @@ List<_ImageRef> _extractOpenAIImageRefs(dynamic content) {
     if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
   }
   return refs;
+}
+
+void _addOpenAIStructuredImageRefs(List<_ImageRef> refs, dynamic value) {
+  if (value == null) return;
+  if (value is List) {
+    for (final item in value) {
+      _addOpenAIStructuredImageRefs(refs, item);
+    }
+    return;
+  }
+  if (value is Map) {
+    _addOpenAIStructuredImageRefs(refs, value['url'] ?? value['image_url']);
+    final data = value['data'];
+    if (data != null) {
+      final type = (value['type'] ?? '').toString().trim().toLowerCase();
+      final mime = (value['mime_type'] ?? value['media_type'] ?? 'image/png')
+          .toString()
+          .trim();
+      _addOpenAIStructuredImageData(
+        refs,
+        data,
+        isBase64: type == 'base64',
+        mime: mime.isEmpty ? 'image/png' : mime,
+      );
+    }
+    return;
+  }
+  final source = value.toString().trim();
+  if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+}
+
+void _addOpenAIStructuredImageData(
+  List<_ImageRef> refs,
+  dynamic data, {
+  required bool isBase64,
+  required String mime,
+}) {
+  if (data is List) {
+    for (final item in data) {
+      _addOpenAIStructuredImageData(refs, item, isBase64: isBase64, mime: mime);
+    }
+    return;
+  }
+  var source = data.toString().trim();
+  if (source.isEmpty) return;
+  if (isBase64 && !source.startsWith('data:')) {
+    source = 'data:$mime;base64,$source';
+  }
+  refs.add(_imageRefFromSource(source));
 }
 
 _ImageRef _imageRefFromSource(String source) {
@@ -346,6 +423,30 @@ void _applyOpenAIImagesExtraBody(
   }
 }
 
+String _openAIImagesOutputMime(
+  ProviderConfig config,
+  String modelId,
+  Map<String, dynamic>? extraBody,
+) {
+  final body = <String, dynamic>{};
+  _applyOpenAIImagesExtraBody(body, config, modelId, extraBody);
+  final format = (body['output_format'] ?? '').toString().trim().toLowerCase();
+  switch (format) {
+    case '':
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'webp':
+      return 'image/webp';
+    default:
+      throw FormatException(
+        'OpenAI Images API output_format must be png, jpeg, or webp; got $format.',
+      );
+  }
+}
+
 Map<String, dynamic> _decodeOpenAIImagesResponse(http.Response response) {
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw HttpException('HTTP ${response.statusCode}: ${response.body}');
@@ -360,8 +461,9 @@ Map<String, dynamic> _decodeOpenAIImagesResponse(http.Response response) {
 }
 
 Future<String> _openAIImagesResponseToMarkdown(
-  Map<String, dynamic> response,
-) async {
+  Map<String, dynamic> response, {
+  required String outputMime,
+}) async {
   final data = response['data'];
   if (data is! List || data.isEmpty) return '';
   final lines = <String>[];
@@ -374,7 +476,12 @@ Future<String> _openAIImagesResponseToMarkdown(
     }
     final b64 = (item['b64_json'] ?? '').toString().trim();
     if (b64.isEmpty) continue;
-    final path = await AppDirectories.saveBase64Image('image/png', b64);
+    final path = await AppDirectories.saveBase64Image(outputMime, b64);
+    if (path == null || path.isEmpty) {
+      throw const FileSystemException(
+        'Failed to save OpenAI Images API base64 image.',
+      );
+    }
     lines.add('![image]($path)');
   }
   return lines.join('\n\n');

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -1,7 +1,6 @@
 part of '../chat_api_service.dart';
 
 bool _shouldUseOpenAIImagesApi(ProviderConfig config, String modelId) {
-  if (config.useResponseApi == true) return false;
   final upstreamModelId = _apiModelId(config, modelId).toLowerCase();
   return upstreamModelId.startsWith('gpt-image-') ||
       upstreamModelId.startsWith('dall-e-') ||

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -23,14 +23,13 @@ Stream<ChatStreamChunk> _sendOpenAIImagesStream(
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
 }) async* {
-  final prompt = await _lastOpenAIImagePrompt(messages);
-  final imageRefs = await _openAIImageEditRefs(messages, userImagePaths);
-  final response = imageRefs.isEmpty
+  final input = await _openAIImagesInput(messages, userImagePaths);
+  final response = input.imageRefs.isEmpty
       ? await _sendOpenAIImageGeneration(
           client,
           config,
           modelId,
-          prompt,
+          input.prompt,
           extraHeaders: extraHeaders,
           extraBody: extraBody,
         )
@@ -38,8 +37,8 @@ Stream<ChatStreamChunk> _sendOpenAIImagesStream(
           client,
           config,
           modelId,
-          prompt,
-          imageRefs,
+          input.prompt,
+          input.imageRefs,
           extraHeaders: extraHeaders,
           extraBody: extraBody,
         );
@@ -173,16 +172,20 @@ Future<String> _lastOpenAIImagePrompt(
   return '';
 }
 
-Future<List<_ImageRef>> _openAIImageEditRefs(
+Future<_OpenAIImagesInput> _openAIImagesInput(
   List<Map<String, dynamic>> messages,
   List<String>? userImagePaths,
 ) async {
+  final prompt = await _lastOpenAIImagePrompt(messages);
   final explicitPaths = (userImagePaths ?? const <String>[])
       .map((path) => path.trim())
       .where((path) => path.isNotEmpty)
       .toList(growable: false);
   if (explicitPaths.isNotEmpty) {
-    return [for (final path in explicitPaths) _imageRefFromSource(path)];
+    return _OpenAIImagesInput(
+      prompt: prompt,
+      imageRefs: [for (final path in explicitPaths) _imageRefFromSource(path)],
+    );
   }
 
   for (int i = messages.length - 1; i >= 0; i--) {
@@ -193,9 +196,69 @@ Future<List<_ImageRef>> _openAIImageEditRefs(
       allowLocalImages: true,
       keepRemoteMarkdownText: false,
     );
-    return parsed.images;
+    if (parsed.images.isNotEmpty) {
+      return _OpenAIImagesInput(prompt: prompt, imageRefs: parsed.images);
+    }
+
+    final previousAssistantImage = _lastAssistantImageBefore(messages, i);
+    if (previousAssistantImage == null) {
+      return _OpenAIImagesInput(prompt: prompt);
+    }
+
+    return _OpenAIImagesInput(
+      prompt: prompt,
+      imageRefs: [previousAssistantImage],
+    );
   }
-  return const <_ImageRef>[];
+  return _OpenAIImagesInput(prompt: prompt);
+}
+
+_ImageRef? _lastAssistantImageBefore(
+  List<Map<String, dynamic>> messages,
+  int beforeIndex,
+) {
+  for (int i = beforeIndex - 1; i >= 0; i--) {
+    if ((messages[i]['role'] ?? '').toString() != 'assistant') continue;
+    final images = _extractOpenAIImageRefs(messages[i]['content']);
+    if (images.isNotEmpty) return images.last;
+  }
+  return null;
+}
+
+List<_ImageRef> _extractOpenAIImageRefs(dynamic content) {
+  if (content is List) {
+    final refs = <_ImageRef>[];
+    for (final part in content) {
+      if (part is! Map) continue;
+      final type = (part['type'] ?? '').toString();
+      if (type == 'image_url') {
+        final imageUrl = part['image_url'];
+        final source = imageUrl is Map
+            ? (imageUrl['url'] ?? '').toString().trim()
+            : imageUrl.toString().trim();
+        if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+      } else if (type == 'input_image') {
+        final source = (part['image_url'] ?? '').toString().trim();
+        if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+      }
+    }
+    return refs;
+  }
+
+  final raw = (content ?? '').toString();
+  if (raw.isEmpty) return const <_ImageRef>[];
+  final refs = <_ImageRef>[];
+  final markdownImage = RegExp(r'!\[[^\]]*\]\(([^)]+)\)');
+  final customImage = RegExp(r'\[image:(.+?)\]');
+  for (final match in markdownImage.allMatches(raw)) {
+    final source = (match.group(1) ?? '').trim();
+    if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+  }
+  for (final match in customImage.allMatches(raw)) {
+    final source = (match.group(1) ?? '').trim();
+    if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+  }
+  return refs;
 }
 
 _ImageRef _imageRefFromSource(String source) {
@@ -311,4 +374,11 @@ TokenUsage? _openAIImagesUsage(Map<String, dynamic> response) {
     completionTokens: output,
     totalTokens: input + output,
   );
+}
+
+class _OpenAIImagesInput {
+  const _OpenAIImagesInput({required this.prompt, this.imageRefs = const []});
+
+  final String prompt;
+  final List<_ImageRef> imageRefs;
 }

--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -159,13 +159,13 @@ class DioHttpClient extends http.BaseClient {
     final uri = request.url;
     final method = request.method.toUpperCase();
 
-    final reqHeaders = Map<String, String>.from(request.headers);
-    reqHeaders.putIfAbsent('User-Agent', () => 'Kelivo');
-
     List<int> bodyBytes = const <int>[];
     try {
       bodyBytes = await request.finalize().toBytes();
     } catch (_) {}
+
+    final reqHeaders = Map<String, String>.from(request.headers);
+    reqHeaders.putIfAbsent('User-Agent', () => 'Kelivo');
 
     if (RequestLogger.enabled) {
       RequestLogger.logLine('[REQ $reqId] $method $uri');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,6 +84,7 @@ dependencies:
   audioplayers: ^6.5.1
   html: ^0.15.6
   html2md: ^1.2.10
+  http_parser: ^4.1.2
   animations: ^2.0.11
   flutter_animate: ^4.5.2
   webview_flutter: ^4.7.0

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _openAiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'OpenAITest',
+    enabled: true,
+    name: 'OpenAITest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    useResponseApi: false,
+  );
+}
+
+String _baseUrl(HttpServer server) {
+  return 'http://${server.address.address}:${server.port}/v1';
+}
+
+Future<List<int>> _readBytes(HttpRequest request) async {
+  final chunks = <int>[];
+  await for (final chunk in request) {
+    chunks.addAll(chunk);
+  }
+  return chunks;
+}
+
+void main() {
+  group('OpenAI Images API', () {
+    test('routes image model without input images to generations', () async {
+      late Uri requestUri;
+      late Map<String, dynamic> requestBody;
+      late String? authorization;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestUri = request.uri;
+        authorization = request.headers.value(HttpHeaders.authorizationHeader);
+        requestBody =
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {'url': 'https://example.com/generated.png'},
+            ],
+            'usage': {'input_tokens': 3, 'output_tokens': 5},
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {'role': 'user', 'content': 'draw a tabby cat'},
+        ],
+      ).toList();
+
+      expect(requestUri.path, '/v1/images/generations');
+      expect(authorization, 'Bearer test-key');
+      expect(requestBody['model'], 'gpt-image-2');
+      expect(requestBody['prompt'], 'draw a tabby cat');
+      expect(chunks, hasLength(1));
+      expect(
+        chunks.single.content,
+        '![image](https://example.com/generated.png)',
+      );
+      expect(chunks.single.usage?.totalTokens, 8);
+    });
+
+    test('routes image model with input image to edits multipart', () async {
+      late Uri requestUri;
+      late String contentType;
+      late String requestBody;
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_openai_image_edit_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final inputImage = File('${tempDir.path}/source.png');
+      await inputImage.writeAsBytes(const [1, 2, 3, 4]);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestUri = request.uri;
+        contentType = request.headers.contentType?.mimeType ?? '';
+        requestBody = latin1.decode(await _readBytes(request));
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {'url': 'https://example.com/edited.png'},
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {'role': 'user', 'content': 'make the background blue'},
+        ],
+        userImagePaths: [inputImage.path],
+      ).toList();
+
+      expect(requestUri.path, '/v1/images/edits');
+      expect(contentType, 'multipart/form-data');
+      expect(requestBody, contains('name="model"'));
+      expect(requestBody, contains('gpt-image-2'));
+      expect(requestBody, contains('name="prompt"'));
+      expect(requestBody, contains('make the background blue'));
+      expect(requestBody, contains('name="image[]"'));
+      expect(requestBody, contains('filename="source.png"'));
+      expect(chunks.single.content, '![image](https://example.com/edited.png)');
+    });
+
+    test(
+      'throws useful exception on non-success Images API response',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          await request.drain<void>();
+          request.response.statusCode = HttpStatus.badRequest;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(jsonEncode({'error': 'bad image request'}));
+          await request.response.close();
+        });
+
+        expect(
+          ChatApiService.sendMessageStream(
+            config: _openAiConfig(_baseUrl(server)),
+            modelId: 'gpt-image-2',
+            messages: const [
+              {'role': 'user', 'content': 'draw'},
+            ],
+          ).toList(),
+          throwsA(
+            isA<HttpException>().having(
+              (error) => error.message,
+              'message',
+              contains('HTTP 400'),
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -174,8 +174,54 @@ void main() {
       expect(requestBody, contains('name="prompt"'));
       expect(requestBody, contains('make the background blue'));
       expect(requestBody, contains('name="image[]"'));
+      expect(requestBody, contains('content-type: image/png'));
       expect(requestBody, contains('filename="source.png"'));
       expect(chunks.single.content, '![image](https://example.com/edited.png)');
+    });
+
+    test('sets jpeg content type for jpg image edit uploads', () async {
+      late String requestBody;
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_openai_jpeg_edit_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final inputImage = File('${tempDir.path}/source.jpg');
+      await inputImage.writeAsBytes(const [1, 2, 3, 4]);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody = latin1.decode(await _readBytes(request));
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {'url': 'https://example.com/edited.jpg'},
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {'role': 'user', 'content': 'make it cinematic'},
+        ],
+        userImagePaths: [inputImage.path],
+      ).toList();
+
+      expect(requestBody, contains('filename="source.jpg"'));
+      expect(requestBody, contains('content-type: image/jpeg'));
     });
 
     test(

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 import 'package:Kelivo/core/providers/settings_provider.dart';
 import 'package:Kelivo/core/services/api/chat_api_service.dart';
@@ -28,6 +30,24 @@ Future<List<int>> _readBytes(HttpRequest request) async {
     chunks.addAll(chunk);
   }
   return chunks;
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$path/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$path/tmp';
 }
 
 void main() {
@@ -223,6 +243,187 @@ void main() {
       expect(requestBody, contains('filename="source.jpg"'));
       expect(requestBody, contains('content-type: image/jpeg'));
     });
+
+    test('routes structured user input images to edits multipart', () async {
+      late Uri requestUri;
+      late String contentType;
+      late String requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestUri = request.uri;
+        contentType = request.headers.contentType?.mimeType ?? '';
+        requestBody = latin1.decode(await _readBytes(request));
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {'url': 'https://example.com/structured-edit.png'},
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {
+            'role': 'user',
+            'content': [
+              {'type': 'input_text', 'text': 'make the background blue'},
+              {
+                'type': 'input_image',
+                'input_image': {
+                  'type': 'base64',
+                  'media_type': 'image/png',
+                  'data': ['AQIDBA=='],
+                },
+              },
+            ],
+          },
+        ],
+      ).toList();
+
+      expect(requestUri.path, '/v1/images/edits');
+      expect(contentType, 'multipart/form-data');
+      expect(requestBody, contains('name="prompt"'));
+      expect(requestBody, contains('make the background blue'));
+      expect(requestBody, contains('name="image[]"'));
+      expect(requestBody, contains('content-type: image/png'));
+    });
+
+    test('rejects dall-e-3 edits before sending a request', () async {
+      await expectLater(
+        ChatApiService.sendMessageStream(
+          config: _openAiConfig('http://127.0.0.1:9/v1'),
+          modelId: 'dall-e-3',
+          messages: const [
+            {'role': 'user', 'content': 'edit this image'},
+          ],
+          userImagePaths: const ['/tmp/source.png'],
+        ).toList(),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (error) => error.message,
+            'message',
+            contains('does not support image edits'),
+          ),
+        ),
+      );
+    });
+
+    test('saves base64 image responses with requested output format', () async {
+      late Map<String, dynamic> requestBody;
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_openai_b64_output_',
+      );
+      final previousPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+      addTearDown(() async {
+        PathProviderPlatform.instance = previousPathProvider;
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody =
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {
+                'b64_json': base64Encode(const [1, 2, 3, 4]),
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {'role': 'user', 'content': 'draw a tabby cat'},
+        ],
+        extraBody: const {'output_format': 'webp'},
+      ).toList();
+
+      final imagePath = RegExp(
+        r'!\[image\]\(([^)]+)\)',
+      ).firstMatch(chunks.single.content)!.group(1)!;
+      expect(requestBody['output_format'], 'webp');
+      expect(imagePath.endsWith('.webp'), isTrue);
+      expect(await File(imagePath).readAsBytes(), const [1, 2, 3, 4]);
+    });
+
+    test(
+      'throws instead of rendering null when base64 image save fails',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'kelivo_openai_b64_failure_',
+        );
+        final previousPathProvider = PathProviderPlatform.instance;
+        PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+        addTearDown(() async {
+          PathProviderPlatform.instance = previousPathProvider;
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          await request.drain<void>();
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'data': [
+                {'b64_json': 'not valid base64'},
+              ],
+            }),
+          );
+          await request.response.close();
+        });
+
+        await expectLater(
+          ChatApiService.sendMessageStream(
+            config: _openAiConfig(_baseUrl(server)),
+            modelId: 'gpt-image-2',
+            messages: const [
+              {'role': 'user', 'content': 'draw a tabby cat'},
+            ],
+          ).toList(),
+          throwsA(
+            isA<FileSystemException>().having(
+              (error) => error.message,
+              'message',
+              contains('Failed to save OpenAI Images API base64 image'),
+            ),
+          ),
+        );
+      },
+    );
 
     test(
       'uses the latest assistant image as edit input for follow-up turns',

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -179,6 +179,60 @@ void main() {
     });
 
     test(
+      'uses the latest assistant image as edit input for follow-up turns',
+      () async {
+        late Uri requestUri;
+        late String contentType;
+        late String requestBody;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          requestUri = request.uri;
+          contentType = request.headers.contentType?.mimeType ?? '';
+          requestBody = latin1.decode(await _readBytes(request));
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'data': [
+                {'url': 'https://example.com/follow-up-edit.png'},
+              ],
+            }),
+          );
+          await request.response.close();
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _openAiConfig(_baseUrl(server)),
+          modelId: 'gpt-image-2',
+          messages: const [
+            {'role': 'user', 'content': 'draw a tabby cat'},
+            {
+              'role': 'assistant',
+              'content': '![image](data:image/png;base64,AQIDBA==)',
+            },
+            {'role': 'user', 'content': 'make it realistic'},
+          ],
+        ).toList();
+
+        expect(requestUri.path, '/v1/images/edits');
+        expect(contentType, 'multipart/form-data');
+        expect(requestBody, contains('name="image[]"'));
+        expect(requestBody, contains('make it realistic'));
+        expect(requestBody, isNot(contains('draw a tabby cat')));
+        expect(requestBody, isNot(contains('Original image request:')));
+        expect(requestBody, isNot(contains('Edit request:')));
+        expect(
+          chunks.single.content,
+          '![image](https://example.com/follow-up-edit.png)',
+        );
+      },
+    );
+
+    test(
       'throws useful exception on non-success Images API response',
       () async {
         final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Kelivo/core/providers/settings_provider.dart';
 import 'package:Kelivo/core/services/api/chat_api_service.dart';
 
-ProviderConfig _openAiConfig(String baseUrl) {
+ProviderConfig _openAiConfig(String baseUrl, {bool useResponseApi = false}) {
   return ProviderConfig(
     id: 'OpenAITest',
     enabled: true,
@@ -14,7 +14,7 @@ ProviderConfig _openAiConfig(String baseUrl) {
     apiKey: 'test-key',
     baseUrl: baseUrl,
     providerType: ProviderKind.openai,
-    useResponseApi: false,
+    useResponseApi: useResponseApi,
   );
 }
 
@@ -79,6 +79,48 @@ void main() {
       );
       expect(chunks.single.usage?.totalTokens, 8);
     });
+
+    test(
+      'routes image models to Images API even when Responses is enabled',
+      () async {
+        late Uri requestUri;
+        late Map<String, dynamic> requestBody;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          requestUri = request.uri;
+          requestBody =
+              jsonDecode(await utf8.decoder.bind(request).join())
+                  as Map<String, dynamic>;
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'data': [
+                {'url': 'https://example.com/generated.png'},
+              ],
+            }),
+          );
+          await request.response.close();
+        });
+
+        await ChatApiService.sendMessageStream(
+          config: _openAiConfig(_baseUrl(server), useResponseApi: true),
+          modelId: 'gpt-image-2',
+          messages: const [
+            {'role': 'user', 'content': 'generate an empty image'},
+          ],
+        ).toList();
+
+        expect(requestUri.path, '/v1/images/generations');
+        expect(requestBody['model'], 'gpt-image-2');
+        expect(requestBody.containsKey('input'), isFalse);
+        expect(requestBody.containsKey('stream'), isFalse);
+      },
+    );
 
     test('routes image model with input image to edits multipart', () async {
       late Uri requestUri;


### PR DESCRIPTION
## 总结
Closes #502.
- 为 `gpt-image-2` 等 OpenAI 图片模型接入 Images API。
- 纯文本生图请求走 `/v1/images/generations`。
- 带图片输入的生成/编辑请求走 `/v1/images/edits`。
- 修复 multipart 图片上传 MIME，确保 jpg/png/webp 能被 OpenAI 正确识别。
## 功能边界
本实现严格按当前 OpenAI Images API 的能力边界处理。Images API 不是 Chat API，不支持完整多轮 messages 上下文。
当前支持两种模式：
1. **Zero-shot 文本生图**
   - 输入：一条文字 prompt。
   - API：`POST /v1/images/generations`。
   - 例：用户输入“生成一张空白图片”。
   - 模型只会收到这一条 prompt。
2. **One-shot / few-shot 图片条件生成或编辑**
   - 输入：一条文字 prompt + 一张或多张图片。
   - API：`POST /v1/images/edits`。
   - 例：用户上传图片后输入“把背景改成蓝色”。
   - 模型会收到最新 prompt 和这些图片输入。
3. **后续继续修改**
- 如果用户在 assistant 生成图片后继续输入修改指令，且本轮没有重新上传图片，应用会把“最近一张 assistant 返回的图片”作为 `/images/edits` 的图片输入。
- 这里的“最近一张图片”指当前可见聊天历史中，assistant 最近一次 Images API 返回后保存/渲染成 markdown 图片的那张图。
- 续改请求只会发送：
  - 最近一张 assistant 图片
  - 最新一条用户 prompt
- 不会把更早的 prompt 或完整聊天历史一起发送给 Images API。
## API 无法做到的事情
当前 OpenAI Images API 对 `gpt-image-2` 这类图片模型没有完整 chat context 能力：
- `/v1/images/generations` 不接受 messages 历史。
- `/v1/images/edits` 不接受 messages 历史。
- 后续编辑必须显式提供图片输入。
- Images API 不会自动记住前面的任意对话轮次。
- 不能直接把 `gpt-image-2` 作为 `/v1/responses` 的主模型来获得多轮上下文。
因此，如果用户想切换回更早的一张图继续修改，或者从更早的指令分支重新生成，需要在聊天中回到对应位置处理，例如编辑那条用户 prompt 并从该位置重新生成。当前实现不会在后续编辑时自动选择任意历史图片，也不会自动携带完整 prompt 链路。
## 实现说明
- OpenAI 图片模型会优先走 Images API 分流，不再落入 Chat Completions 或 Responses API。
- 用户本轮显式上传的图片优先级最高。
- 当前用户消息里包含的图片引用优先于历史 assistant 图片。
- 如果本轮没有图片输入，则复用最近一张 assistant 图片走 `/images/edits`。
- multipart 上传会显式设置图片 MIME：
  - `image/jpeg`
  - `image/png`
  - `image/webp`
## 验证
- `flutter pub get`
- `dart format`
- `flutter analyze`
- `flutter test test/openai_images_api_test.dart`
- `flutter test`