### PR TITLE
fix(network): redact secrets from request logs

### DIFF
--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -9,6 +9,8 @@ import 'package:socks5_proxy/socks_client.dart' as socks;
 
 import 'request_logger.dart';
 
+const int _maxLoggedResponseBodyBytes = 1024 * 1024;
+
 Future<InternetAddress?> _resolveProxyAddress(String host) async {
   final parsed = InternetAddress.tryParse(host);
   if (parsed != null) return parsed;
@@ -168,10 +170,12 @@ class DioHttpClient extends http.BaseClient {
     reqHeaders.putIfAbsent('User-Agent', () => 'Kelivo');
 
     if (RequestLogger.enabled) {
-      RequestLogger.logLine('[REQ $reqId] $method $uri');
+      RequestLogger.logLine(
+        '[REQ $reqId] $method ${RequestLogger.sanitizeUrlForLogging(uri)}',
+      );
       if (reqHeaders.isNotEmpty) {
         RequestLogger.logLine(
-          '[REQ $reqId] headers=${RequestLogger.encodeObject(reqHeaders)}',
+          '[REQ $reqId] headers=${RequestLogger.encodeObject(reqHeaders, redactSecrets: true)}',
         );
       }
       if (bodyBytes.isNotEmpty) {
@@ -180,7 +184,7 @@ class DioHttpClient extends http.BaseClient {
             ? decoded
             : 'base64:${base64Encode(bodyBytes)}';
         RequestLogger.logLine(
-          '[REQ $reqId] body=${RequestLogger.escape(bodyText)}',
+          '[REQ $reqId] body=${RequestLogger.escape(RequestLogger.sanitizeBodyForLogging(bodyText))}',
         );
       }
     }
@@ -211,7 +215,7 @@ class DioHttpClient extends http.BaseClient {
         RequestLogger.logLine('[RES $reqId] status=$statusCode');
         if (headers.isNotEmpty) {
           RequestLogger.logLine(
-            '[RES $reqId] headers=${RequestLogger.encodeObject(headers)}',
+            '[RES $reqId] headers=${RequestLogger.encodeObject(headers, redactSecrets: true)}',
           );
         }
       }
@@ -221,29 +225,80 @@ class DioHttpClient extends http.BaseClient {
           ? body.contentLength
           : null;
       final controller = StreamController<List<int>>(sync: true);
+      var responseLogBytes = 0;
+      var responseLogPending = '';
+      var responseLogTruncated = false;
+      var responseLogFinished = false;
+
+      void writeResponseLogText(String text) {
+        if (text.isEmpty) return;
+        RequestLogger.logLine(
+          '[RES $reqId] chunk=${RequestLogger.escape(RequestLogger.sanitizeBodyForLogging(text))}',
+        );
+      }
+
+      void flushCompleteResponseLogLines() {
+        final end = responseLogPending.lastIndexOf('\n');
+        if (end < 0) return;
+        final text = responseLogPending.substring(0, end + 1);
+        responseLogPending = responseLogPending.substring(end + 1);
+        writeResponseLogText(text);
+      }
+
+      void captureResponseLogChunk(List<int> chunk) {
+        if (!RequestLogger.enabled || !RequestLogger.saveOutput) return;
+        final remaining = _maxLoggedResponseBodyBytes - responseLogBytes;
+        if (remaining <= 0) {
+          responseLogTruncated = true;
+          return;
+        }
+        final bytes = remaining >= chunk.length
+            ? chunk
+            : chunk.sublist(0, remaining);
+        responseLogBytes += bytes.length;
+        if (bytes.length < chunk.length) {
+          responseLogTruncated = true;
+        }
+        final s = RequestLogger.safeDecodeUtf8(bytes);
+        if (s.isEmpty) return;
+        responseLogPending += s;
+        flushCompleteResponseLogLines();
+      }
+
+      void finishResponseLogBody() {
+        if (responseLogFinished ||
+            !RequestLogger.enabled ||
+            !RequestLogger.saveOutput) {
+          return;
+        }
+        responseLogFinished = true;
+        writeResponseLogText(responseLogPending);
+        responseLogPending = '';
+        if (responseLogTruncated) {
+          writeResponseLogText(
+            '[response log truncated after $_maxLoggedResponseBodyBytes bytes]',
+          );
+        }
+      }
+
       controller.onListen = () {
         body.stream.listen(
           (chunk) {
             controller.add(chunk);
-            if (RequestLogger.enabled && RequestLogger.saveOutput) {
-              final s = RequestLogger.safeDecodeUtf8(chunk);
-              if (s.isNotEmpty) {
-                RequestLogger.logLine(
-                  '[RES $reqId] chunk=${RequestLogger.escape(s)}',
-                );
-              }
-            }
+            captureResponseLogChunk(chunk);
           },
           onError: (e, st) {
+            finishResponseLogBody();
             if (RequestLogger.enabled) {
               RequestLogger.logLine(
-                '[RES $reqId] error=${RequestLogger.escape(e.toString())}',
+                '[RES $reqId] error=${RequestLogger.escape(RequestLogger.sanitizeBodyForLogging(e.toString()))}',
               );
             }
             controller.addError(e, st);
             controller.close();
           },
           onDone: () {
+            finishResponseLogBody();
             if (RequestLogger.enabled) {
               RequestLogger.logLine('[RES $reqId] done');
             }
@@ -277,14 +332,14 @@ class DioHttpClient extends http.BaseClient {
     } on DioException catch (e) {
       if (RequestLogger.enabled) {
         RequestLogger.logLine(
-          '[RES $reqId] dio_error=${RequestLogger.escape(e.toString())}',
+          '[RES $reqId] dio_error=${RequestLogger.escape(RequestLogger.sanitizeBodyForLogging(e.toString()))}',
         );
       }
       throw http.ClientException(e.toString(), uri);
     } catch (e) {
       if (RequestLogger.enabled) {
         RequestLogger.logLine(
-          '[RES $reqId] error=${RequestLogger.escape(e.toString())}',
+          '[RES $reqId] error=${RequestLogger.escape(RequestLogger.sanitizeBodyForLogging(e.toString()))}',
         );
       }
       throw http.ClientException(e.toString(), uri);

--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -9,8 +9,6 @@ import 'package:socks5_proxy/socks_client.dart' as socks;
 
 import 'request_logger.dart';
 
-const int _maxLoggedResponseBodyBytes = 1024 * 1024;
-
 Future<InternetAddress?> _resolveProxyAddress(String host) async {
   final parsed = InternetAddress.tryParse(host);
   if (parsed != null) return parsed;
@@ -225,9 +223,7 @@ class DioHttpClient extends http.BaseClient {
           ? body.contentLength
           : null;
       final controller = StreamController<List<int>>(sync: true);
-      var responseLogBytes = 0;
       var responseLogPending = '';
-      var responseLogTruncated = false;
       var responseLogFinished = false;
 
       void writeResponseLogText(String text) {
@@ -256,19 +252,7 @@ class DioHttpClient extends http.BaseClient {
 
       void captureResponseLogChunk(List<int> chunk) {
         if (!RequestLogger.enabled || !RequestLogger.saveOutput) return;
-        final remaining = _maxLoggedResponseBodyBytes - responseLogBytes;
-        if (remaining <= 0) {
-          responseLogTruncated = true;
-          return;
-        }
-        final bytes = remaining >= chunk.length
-            ? chunk
-            : chunk.sublist(0, remaining);
-        responseLogBytes += bytes.length;
-        if (bytes.length < chunk.length) {
-          responseLogTruncated = true;
-        }
-        final s = RequestLogger.safeDecodeUtf8(bytes);
+        final s = RequestLogger.safeDecodeUtf8(chunk);
         if (s.isEmpty) return;
         responseLogPending += s;
         flushCompleteResponseLogLines();
@@ -283,11 +267,6 @@ class DioHttpClient extends http.BaseClient {
         responseLogFinished = true;
         writeResponseLogText(responseLogPending);
         responseLogPending = '';
-        if (responseLogTruncated) {
-          writeResponseLogText(
-            '[response log truncated after $_maxLoggedResponseBodyBytes bytes]',
-          );
-        }
       }
 
       controller.onListen = () {

--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -240,8 +240,17 @@ class DioHttpClient extends http.BaseClient {
       void flushCompleteResponseLogLines() {
         final end = responseLogPending.lastIndexOf('\n');
         if (end < 0) return;
-        final text = responseLogPending.substring(0, end + 1);
-        responseLogPending = responseLogPending.substring(end + 1);
+        final completeText = responseLogPending.substring(0, end + 1);
+        var flushEnd = completeText.length;
+        if (RequestLogger.hasDanglingSensitiveValue(completeText)) {
+          flushEnd =
+              completeText.lastIndexOf('\n', completeText.length - 2) + 1;
+        }
+        if (flushEnd <= 0) return;
+        final text = completeText.substring(0, flushEnd);
+        responseLogPending =
+            completeText.substring(flushEnd) +
+            responseLogPending.substring(end + 1);
         writeResponseLogText(text);
       }
 

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -7,6 +7,8 @@ import '../../../utils/app_directories.dart';
 class RequestLogger {
   RequestLogger._();
 
+  static const String _redactedValue = '<redacted>';
+
   static bool _enabled = false;
   static bool get enabled => _enabled;
   static bool _writeErrorReported = false;
@@ -122,12 +124,28 @@ class RequestLogger {
     });
   }
 
-  static String encodeObject(Object? obj) {
+  static String encodeObject(Object? obj, {bool redactSecrets = false}) {
+    final value = redactSecrets ? _redactSecrets(obj) : obj;
     try {
-      return const JsonEncoder.withIndent('  ').convert(obj);
+      return const JsonEncoder.withIndent('  ').convert(value);
     } catch (_) {
-      return obj?.toString() ?? '';
+      final text = value?.toString() ?? '';
+      return redactSecrets ? _redactTextSecrets(text) : text;
     }
+  }
+
+  static String sanitizeBodyForLogging(String bodyText) {
+    try {
+      final decoded = jsonDecode(bodyText);
+      return jsonEncode(_redactSecrets(decoded));
+    } catch (_) {
+      return _redactTextSecrets(bodyText);
+    }
+  }
+
+  static String sanitizeUrlForLogging(Uri uri) {
+    final redactedUserInfo = _redactUrlUserInfo(uri.toString());
+    return _redactUrlQuerySecrets(redactedUserInfo);
   }
 
   static String safeDecodeUtf8(List<int> bytes) {
@@ -145,6 +163,169 @@ class RequestLogger {
         .replaceAll('\n', r'\n')
         .replaceAll('\t', r'\t');
   }
+
+  static Object? _redactSecrets(Object? value, {String? key}) {
+    final normalizedKey = key == null ? null : _normalizeKey(key);
+    if (normalizedKey != null && _isSensitiveKey(normalizedKey)) {
+      return _redactValueForKey(normalizedKey, value);
+    }
+
+    if (value is Map) {
+      return value.map<String, Object?>(
+        (k, v) => MapEntry(k.toString(), _redactSecrets(v, key: k.toString())),
+      );
+    }
+    if (value is Iterable) {
+      return value.map((v) => _redactSecrets(v)).toList();
+    }
+    if (value is String) {
+      return _redactTextSecrets(value);
+    }
+    return value;
+  }
+
+  static String _normalizeKey(String key) {
+    return key.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+  }
+
+  static bool _isSensitiveKey(String normalizedKey) {
+    if (_sensitiveExactKeys.contains(normalizedKey)) return true;
+    if (normalizedKey.contains('apikey')) return true;
+    if (normalizedKey.endsWith('token')) return true;
+    if (normalizedKey.endsWith('secret')) return true;
+    return false;
+  }
+
+  static Object _redactValueForKey(String normalizedKey, Object? value) {
+    if ((normalizedKey == 'authorization' ||
+            normalizedKey == 'proxyauthorization') &&
+        value is String) {
+      return _redactAuthorizationValue(value);
+    }
+    return _redactedValue;
+  }
+
+  static String _redactTextSecrets(String text) {
+    return _redactUrlQuerySecrets(
+      _redactUrlUserInfo(
+        _redactInlineSecretPairs(
+          _redactBearerTokens(_redactAuthorizationPairs(text)),
+        ),
+      ),
+    );
+  }
+
+  static String _redactAuthorizationValue(String text) {
+    final match = _authorizationValueRe.firstMatch(text.trim());
+    if (match == null) return _redactedValue;
+    return '${match.group(1)} $_redactedValue';
+  }
+
+  static String _redactAuthorizationPairs(String text) {
+    return text.replaceAllMapped(_authorizationPairRe, (m) {
+      final prefix = m.group(1) ?? '';
+      final keyQuote = m.group(2) ?? '';
+      final key = m.group(3) ?? '';
+      final separator = m.group(4) ?? '';
+      final valueQuote = m.group(5) ?? '';
+      final scheme = m.group(6) ?? m.group(8);
+      final value = scheme == null ? _redactedValue : '$scheme $_redactedValue';
+      return '$prefix$keyQuote$key$keyQuote$separator$valueQuote$value$valueQuote';
+    });
+  }
+
+  static String _redactBearerTokens(String text) {
+    return text.replaceAllMapped(_bearerTokenRe, (m) {
+      return '${m.group(1)} $_redactedValue';
+    });
+  }
+
+  static String _redactInlineSecretPairs(String text) {
+    return text.replaceAllMapped(_inlineSecretPairRe, (m) {
+      final prefix = m.group(1) ?? '';
+      final keyQuote = m.group(2) ?? '';
+      final key = m.group(3) ?? '';
+      final separator = m.group(4) ?? '';
+      final valueQuote = m.group(5) ?? '';
+      return '$prefix$keyQuote$key$keyQuote$separator$valueQuote$_redactedValue$valueQuote';
+    });
+  }
+
+  static String _redactUrlUserInfo(String text) {
+    return text.replaceAllMapped(_urlUserInfoRe, (m) {
+      return '${m.group(1)}${Uri.encodeComponent(_redactedValue)}@';
+    });
+  }
+
+  static String _redactUrlQuerySecrets(String text) {
+    return text.replaceAllMapped(_urlQueryParamRe, (m) {
+      final prefix = m.group(1) ?? '';
+      final rawKey = m.group(2) ?? '';
+      final normalizedKey = _normalizeKey(Uri.decodeQueryComponent(rawKey));
+      if (!_isSensitiveQueryKey(normalizedKey)) return m.group(0) ?? '';
+      return '$prefix$rawKey=${Uri.encodeQueryComponent(_redactedValue)}';
+    });
+  }
+
+  static bool _isSensitiveQueryKey(String normalizedKey) {
+    return _isSensitiveKey(normalizedKey) ||
+        _sensitiveQueryExactKeys.contains(normalizedKey) ||
+        normalizedKey.endsWith('signature') ||
+        normalizedKey.endsWith('credential');
+  }
+
+  static const Set<String> _sensitiveExactKeys = <String>{
+    'authorization',
+    'proxyauthorization',
+    'apikey',
+    'accesstoken',
+    'refreshtoken',
+    'idtoken',
+    'authtoken',
+    'token',
+    'clientsecret',
+    'secret',
+    'cookie',
+    'setcookie',
+  };
+
+  static const Set<String> _sensitiveQueryExactKeys = <String>{
+    'key',
+    'sig',
+    'signature',
+    'xamzsignature',
+    'xamzcredential',
+    'xamzsecuritytoken',
+  };
+
+  static final RegExp _authorizationValueRe = RegExp(
+    r'''^([A-Za-z]+)\s+(.+)$''',
+    caseSensitive: false,
+  );
+
+  static final RegExp _authorizationPairRe = RegExp(
+    r'''(^|[\s,{])(["']?)(authorization|proxy-authorization)\2(\s*[:=]\s*)(?:(["'])(?:([A-Za-z]+)\s+)?([^"'\r\n]*)\5?|(?:([A-Za-z]+)\s+)?([^"'\s&,}\]\r\n]+))''',
+    caseSensitive: false,
+  );
+
+  static final RegExp _bearerTokenRe = RegExp(
+    r'''\b(Bearer)\s+([^\s,;"'&}\]<]+)''',
+    caseSensitive: false,
+  );
+
+  static final RegExp _inlineSecretPairRe = RegExp(
+    r'''(^|[\s,{])(["']?)([A-Za-z0-9_-]*(?:api[_-]?key|token|secret|cookie))\2(\s*[:=]\s*)(?:(["'])([^"'\r\n]*)\5?|([^"'\s&,}\]\r\n]+))''',
+    caseSensitive: false,
+  );
+
+  static final RegExp _urlUserInfoRe = RegExp(
+    r'''([A-Za-z][A-Za-z0-9+.-]*://)([^/?#@\s]+)@''',
+  );
+
+  static final RegExp _urlQueryParamRe = RegExp(
+    r'''([?&])([^=&#]+)=([^&#]*)''',
+    caseSensitive: false,
+  );
 
   static Future<void> cleanupLogs({
     required int autoDeleteDays,

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -261,10 +261,18 @@ class RequestLogger {
     return text.replaceAllMapped(_urlQueryParamRe, (m) {
       final prefix = m.group(1) ?? '';
       final rawKey = m.group(2) ?? '';
-      final normalizedKey = _normalizeKey(Uri.decodeQueryComponent(rawKey));
+      final normalizedKey = _normalizeQueryKey(rawKey);
       if (!_isSensitiveQueryKey(normalizedKey)) return m.group(0) ?? '';
       return '$prefix$rawKey=${Uri.encodeQueryComponent(_redactedValue)}';
     });
+  }
+
+  static String _normalizeQueryKey(String rawKey) {
+    try {
+      return _normalizeKey(Uri.decodeQueryComponent(rawKey));
+    } catch (_) {
+      return _normalizeKey(rawKey);
+    }
   }
 
   static bool _isSensitiveQueryKey(String normalizedKey) {

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -191,9 +191,14 @@ class RequestLogger {
   static bool _isSensitiveKey(String normalizedKey) {
     if (_sensitiveExactKeys.contains(normalizedKey)) return true;
     if (normalizedKey.contains('apikey')) return true;
+    if (normalizedKey.contains('secretkey')) return true;
     if (normalizedKey.endsWith('token')) return true;
     if (normalizedKey.endsWith('secret')) return true;
     return false;
+  }
+
+  static bool hasDanglingSensitiveValue(String text) {
+    return _danglingSensitiveValueRe.hasMatch(text);
   }
 
   static Object _redactValueForKey(String normalizedKey, Object? value) {
@@ -322,7 +327,12 @@ class RequestLogger {
   );
 
   static final RegExp _inlineSecretPairRe = RegExp(
-    r'''(^|[\s,{])(["']?)([A-Za-z0-9_-]*(?:api[_-]?key|token|secret|cookie))\2(\s*[:=]\s*)(?:(["'])([^"'\r\n]*)\5?|([^"'\s&,}\]\r\n]+))''',
+    r'''(^|[\s,{])(["']?)([A-Za-z0-9_-]*(?:api[_-]?key|secret[_-]?key|token|secret|cookie))\2(\s*[:=]\s*)(?:(["'])([^"'\r\n]*)\5?|([^"'\s&,}\]\r\n]+))''',
+    caseSensitive: false,
+  );
+
+  static final RegExp _danglingSensitiveValueRe = RegExp(
+    r'''(^|[\s,{])(["']?)(authorization|proxy-authorization|[A-Za-z0-9_-]*(?:api[_-]?key|secret[_-]?key|token|secret|cookie))\2\s*[:=]\s*$''',
     caseSensitive: false,
   );
 

--- a/test/core/services/network/request_logger_redaction_test.dart
+++ b/test/core/services/network/request_logger_redaction_test.dart
@@ -1,0 +1,372 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:Kelivo/core/services/network/dio_http_client.dart';
+import 'package:Kelivo/core/services/network/request_logger.dart';
+
+void main() {
+  group('RequestLogger secret redaction', () {
+    test('keeps normal headers readable while redacting sensitive headers', () {
+      final encoded = RequestLogger.encodeObject(const <String, String>{
+        'Content-Type': 'application/json',
+        'X-Request-Id': 'request-123',
+        'Authorization': 'Bearer bearer-header-secret',
+        'x-api-key': 'api-key-secret',
+        'xi-api-key': 'elevenlabs-secret',
+      }, redactSecrets: true);
+
+      expect(encoded, contains('Content-Type'));
+      expect(encoded, contains('application/json'));
+      expect(encoded, contains('X-Request-Id'));
+      expect(encoded, contains('request-123'));
+      expect(encoded, contains('Bearer <redacted>'));
+      expect(encoded, isNot(contains('bearer-header-secret')));
+      expect(encoded, isNot(contains('api-key-secret')));
+      expect(encoded, isNot(contains('elevenlabs-secret')));
+    });
+
+    test('redacts mixed-case sensitive header names', () {
+      final encoded = RequestLogger.encodeObject(const <String, String>{
+        'AUTHORIZATION': 'Bearer mixed-case-secret',
+        'X-GoOg-Api-Key': 'google-secret',
+      }, redactSecrets: true);
+
+      expect(encoded, contains('Bearer <redacted>'));
+      expect(encoded, isNot(contains('mixed-case-secret')));
+      expect(encoded, isNot(contains('google-secret')));
+    });
+
+    test('redacts sensitive JSON request body fields recursively', () {
+      final body = jsonEncode(<String, Object?>{
+        'model': 'test-model',
+        'max_tokens': 128,
+        'api_key': 'body-api-key-secret',
+        'apiKey': 'body-camel-secret',
+        'nested': <String, Object?>{
+          'access_token': 'access-secret',
+          'Authorization': 'Bearer body-bearer-secret',
+        },
+        'items': <Object?>[
+          <String, Object?>{'refresh_token': 'refresh-secret'},
+        ],
+      });
+
+      final sanitized = RequestLogger.sanitizeBodyForLogging(body);
+      final decoded = jsonDecode(sanitized) as Map<String, dynamic>;
+
+      expect(decoded['model'], 'test-model');
+      expect(decoded['max_tokens'], 128);
+      expect(decoded['api_key'], '<redacted>');
+      expect(decoded['apiKey'], '<redacted>');
+      expect(
+        (decoded['nested'] as Map<String, dynamic>)['access_token'],
+        '<redacted>',
+      );
+      expect(
+        (decoded['nested'] as Map<String, dynamic>)['Authorization'],
+        'Bearer <redacted>',
+      );
+      expect(
+        ((decoded['items'] as List<dynamic>).single
+            as Map<String, dynamic>)['refresh_token'],
+        '<redacted>',
+      );
+      expect(sanitized, isNot(contains('body-api-key-secret')));
+      expect(sanitized, isNot(contains('body-camel-secret')));
+      expect(sanitized, isNot(contains('access-secret')));
+      expect(sanitized, isNot(contains('body-bearer-secret')));
+      expect(sanitized, isNot(contains('refresh-secret')));
+    });
+
+    test('redacts bearer tokens in malformed or non-JSON bodies', () {
+      final sanitized = RequestLogger.sanitizeBodyForLogging(
+        'raw body with Authorization: Bearer non-json-secret and standalone Bearer standalone-bearer-secret',
+      );
+
+      expect(sanitized, contains('Bearer <redacted>'));
+      expect(sanitized, isNot(contains('non-json-secret')));
+      expect(sanitized, isNot(contains('standalone-bearer-secret')));
+      expect(sanitized, contains('standalone'));
+    });
+
+    test('redacts non-bearer authorization values in text fragments', () {
+      final sanitized = RequestLogger.sanitizeBodyForLogging(
+        'Authorization: Basic basic-auth-secret and Proxy-Authorization: Token proxy-token-secret',
+      );
+
+      expect(sanitized, contains('Authorization: Basic <redacted>'));
+      expect(sanitized, contains('Proxy-Authorization: Token <redacted>'));
+      expect(sanitized, isNot(contains('basic-auth-secret')));
+      expect(sanitized, isNot(contains('proxy-token-secret')));
+    });
+
+    test('redacts URL query credentials and user info', () {
+      final sanitized = RequestLogger.sanitizeUrlForLogging(
+        Uri.parse(
+          'https://user:password@example.com/v1/models?api_key=url-api-secret&key=url-key-secret&access_token=url-access-secret&model=visible-model',
+        ),
+      );
+
+      expect(sanitized, contains('model=visible-model'));
+      expect(sanitized, contains('api_key=%3Credacted%3E'));
+      expect(sanitized, contains('key=%3Credacted%3E'));
+      expect(sanitized, contains('access_token=%3Credacted%3E'));
+      expect(sanitized, isNot(contains('user:password')));
+      expect(sanitized, isNot(contains('url-api-secret')));
+      expect(sanitized, isNot(contains('url-key-secret')));
+      expect(sanitized, isNot(contains('url-access-secret')));
+    });
+
+    test('redacts URL secrets inside plain text fragments', () {
+      final sanitized = RequestLogger.sanitizeBodyForLogging(
+        'DioException for https://user:password@example.com/v1/models?api_key=text-api-secret&key=text-key-secret&model=visible-model',
+      );
+
+      expect(sanitized, contains('model=visible-model'));
+      expect(sanitized, contains('api_key=%3Credacted%3E'));
+      expect(sanitized, contains('key=%3Credacted%3E'));
+      expect(sanitized, isNot(contains('user:password')));
+      expect(sanitized, isNot(contains('text-api-secret')));
+      expect(sanitized, isNot(contains('text-key-secret')));
+    });
+
+    test('redacts quoted sensitive keys in non-JSON fragments', () {
+      final sanitized = RequestLogger.sanitizeBodyForLogging(
+        'data: {"access_token":"fragment-access-secret","api_key":"fragment-api-secret"}',
+      );
+
+      expect(sanitized, contains('"access_token":"<redacted>"'));
+      expect(sanitized, contains('"api_key":"<redacted>"'));
+      expect(sanitized, isNot(contains('fragment-access-secret')));
+      expect(sanitized, isNot(contains('fragment-api-secret')));
+    });
+
+    test('redacts malformed sensitive values without closing quotes', () {
+      final sanitized = RequestLogger.sanitizeBodyForLogging(
+        '{"access_token":"malformed-access-secret, "Authorization":"Bearer malformed-bearer-secret',
+      );
+
+      expect(sanitized, contains('"access_token":"<redacted>"'));
+      expect(sanitized, contains('"Authorization":"Bearer <redacted>"'));
+      expect(sanitized, isNot(contains('malformed-access-secret')));
+      expect(sanitized, isNot(contains('malformed-bearer-secret')));
+    });
+
+    test('redacts response log secrets split across stream chunks', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_request_logger_test_',
+      );
+      final previousPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      unawaited(
+        server.first.then((request) async {
+          request.response.headers.contentType = ContentType.text;
+          request.response.write('data: {"access_');
+          await request.response.flush();
+          request.response.write('token":"stream-access-secret"}\n');
+          await request.response.flush();
+          request.response.write('Authorization: Bearer ');
+          await request.response.flush();
+          request.response.write('stream-bearer-secret\n');
+          await request.response.close();
+        }),
+      );
+
+      RequestLogger.saveOutput = true;
+      await RequestLogger.setEnabled(true);
+
+      try {
+        final client = DioHttpClient();
+        try {
+          final request = http.Request(
+            'GET',
+            Uri.parse('http://${server.address.host}:${server.port}/stream'),
+          );
+          final response = await client.send(request);
+          await response.stream.toBytes();
+        } finally {
+          client.close();
+        }
+
+        final logText = await _readLogUntil(
+          tempDir,
+          (content) => content.contains('[RES') && content.contains('done'),
+        );
+
+        expect(logText, contains('"access_token":"<redacted>"'));
+        expect(logText, contains('Bearer <redacted>'));
+        expect(logText, isNot(contains('stream-access-secret')));
+        expect(logText, isNot(contains('stream-bearer-secret')));
+      } finally {
+        await RequestLogger.setEnabled(false);
+        RequestLogger.saveOutput = true;
+        await server.close(force: true);
+        PathProviderPlatform.instance = previousPathProvider;
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'writes response logs incrementally without waiting for done',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'kelivo_request_logger_incremental_test_',
+        );
+        final previousPathProvider = PathProviderPlatform.instance;
+        PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+
+        final allowFinish = Completer<void>();
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        unawaited(
+          server.first.then((request) async {
+            request.response.bufferOutput = false;
+            request.response.headers.contentType = ContentType.text;
+            request.response.write('data: {"message":"first-visible"}\n');
+            await request.response.flush();
+            await allowFinish.future;
+            request.response.write(
+              'data: {"access_token":"incremental-access-secret"}\n',
+            );
+            await request.response.close();
+          }),
+        );
+
+        RequestLogger.saveOutput = true;
+        await RequestLogger.setEnabled(true);
+
+        try {
+          final client = DioHttpClient();
+          try {
+            final request = http.Request(
+              'GET',
+              Uri.parse('http://${server.address.host}:${server.port}/stream'),
+            );
+            final response = await client.send(request);
+            final drainFuture = response.stream.drain<void>();
+
+            final partialLogText = await _readLogUntil(
+              tempDir,
+              (content) =>
+                  content.contains('first-visible') &&
+                  !content.contains('done'),
+            );
+
+            expect(partialLogText, contains('first-visible'));
+            expect(partialLogText, isNot(contains('done')));
+
+            allowFinish.complete();
+            await drainFuture;
+          } finally {
+            client.close();
+          }
+
+          final logText = await _readLogUntil(
+            tempDir,
+            (content) => content.contains('[RES') && content.contains('done'),
+          );
+
+          expect(logText, contains('"access_token":"<redacted>"'));
+          expect(logText, isNot(contains('incremental-access-secret')));
+        } finally {
+          if (!allowFinish.isCompleted) allowFinish.complete();
+          await RequestLogger.setEnabled(false);
+          RequestLogger.saveOutput = true;
+          await server.close(force: true);
+          PathProviderPlatform.instance = previousPathProvider;
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test('redacts URL secrets in actual request log lines', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_request_logger_url_test_',
+      );
+      final previousPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      unawaited(
+        server.first.then((request) async {
+          request.response.statusCode = 204;
+          await request.response.close();
+        }),
+      );
+
+      await RequestLogger.setEnabled(true);
+
+      try {
+        final client = DioHttpClient();
+        try {
+          final request = http.Request(
+            'GET',
+            Uri.parse(
+              'http://${server.address.host}:${server.port}/models?api_key=request-url-api-secret&key=request-url-key-secret&model=visible-model',
+            ),
+          );
+          final response = await client.send(request);
+          await response.stream.toBytes();
+        } finally {
+          client.close();
+        }
+
+        final logText = await _readLogUntil(
+          tempDir,
+          (content) => content.contains('[RES') && content.contains('done'),
+        );
+
+        expect(logText, contains('model=visible-model'));
+        expect(logText, contains('api_key=%3Credacted%3E'));
+        expect(logText, contains('key=%3Credacted%3E'));
+        expect(logText, isNot(contains('request-url-api-secret')));
+        expect(logText, isNot(contains('request-url-key-secret')));
+      } finally {
+        await RequestLogger.setEnabled(false);
+        await server.close(force: true);
+        PathProviderPlatform.instance = previousPathProvider;
+        await tempDir.delete(recursive: true);
+      }
+    });
+  });
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$path/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$path/tmp';
+}
+
+Future<String> _readLogUntil(
+  Directory root,
+  bool Function(String content) predicate,
+) async {
+  final file = File('${root.path}/logs/logs.txt');
+  for (var i = 0; i < 50; i++) {
+    if (await file.exists()) {
+      final content = await file.readAsString();
+      if (predicate(content)) return content;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  return await file.exists() ? file.readAsString() : '';
+}

--- a/test/core/services/network/request_logger_redaction_test.dart
+++ b/test/core/services/network/request_logger_redaction_test.dart
@@ -136,6 +136,65 @@ void main() {
       expect(sanitized, isNot(contains('text-key-secret')));
     });
 
+    test('handles malformed percent encoding while redacting query secrets', () {
+      const cases = <({String body, List<String> contains, List<String> absent})>[
+        (
+          body: 'multipart fragment ?bad%=value&api_key=bad-percent-api-secret',
+          contains: ['bad%=value', 'api_key=%3Credacted%3E'],
+          absent: ['bad-percent-api-secret'],
+        ),
+        (
+          body:
+              'stream error https://example.com/path?bad%2=value&key=incomplete-percent-key-secret',
+          contains: ['bad%2=value', 'key=%3Credacted%3E'],
+          absent: ['incomplete-percent-key-secret'],
+        ),
+        (
+          body:
+              'plain text https://example.com/path?bad%zz=value&access_token=invalid-hex-token-secret',
+          contains: ['bad%zz=value', 'access_token=%3Credacted%3E'],
+          absent: ['invalid-hex-token-secret'],
+        ),
+        (
+          body:
+              'binary-ish text ?model=100%broken&api_key=invalid-percent-value-secret',
+          contains: ['model=100%broken', 'api_key=%3Credacted%3E'],
+          absent: ['invalid-percent-value-secret'],
+        ),
+        (
+          body:
+              'malformed sensitive key ?api%_key=malformed-sensitive-key-secret&model=visible-model',
+          contains: ['api%_key=%3Credacted%3E', 'model=visible-model'],
+          absent: ['malformed-sensitive-key-secret'],
+        ),
+        (
+          body:
+              'encoded sensitive key ?api%5Fkey=encoded-sensitive-key-secret&model=visible-model',
+          contains: ['api%5Fkey=%3Credacted%3E', 'model=visible-model'],
+          absent: ['encoded-sensitive-key-secret'],
+        ),
+        (
+          body:
+              'userinfo https://user%:password@example.com/path?api_key=userinfo-secret',
+          contains: [
+            'https://%3Credacted%3E@example.com/path',
+            'api_key=%3Credacted%3E',
+          ],
+          absent: ['user%:password', 'userinfo-secret'],
+        ),
+      ];
+
+      for (final c in cases) {
+        final sanitized = RequestLogger.sanitizeBodyForLogging(c.body);
+        for (final expected in c.contains) {
+          expect(sanitized, contains(expected), reason: c.body);
+        }
+        for (final forbidden in c.absent) {
+          expect(sanitized, isNot(contains(forbidden)), reason: c.body);
+        }
+      }
+    });
+
     test('redacts quoted sensitive keys in non-JSON fragments', () {
       final sanitized = RequestLogger.sanitizeBodyForLogging(
         'data: {"access_token":"fragment-access-secret","api_key":"fragment-api-secret"}',

--- a/test/core/services/network/request_logger_redaction_test.dart
+++ b/test/core/services/network/request_logger_redaction_test.dart
@@ -19,6 +19,7 @@ void main() {
         'Authorization': 'Bearer bearer-header-secret',
         'x-api-key': 'api-key-secret',
         'xi-api-key': 'elevenlabs-secret',
+        'X-Secret-Key': 'header-secret-key-secret',
       }, redactSecrets: true);
 
       expect(encoded, contains('Content-Type'));
@@ -29,6 +30,7 @@ void main() {
       expect(encoded, isNot(contains('bearer-header-secret')));
       expect(encoded, isNot(contains('api-key-secret')));
       expect(encoded, isNot(contains('elevenlabs-secret')));
+      expect(encoded, isNot(contains('header-secret-key-secret')));
     });
 
     test('redacts mixed-case sensitive header names', () {
@@ -48,12 +50,16 @@ void main() {
         'max_tokens': 128,
         'api_key': 'body-api-key-secret',
         'apiKey': 'body-camel-secret',
+        'secret_key': 'body-secret-key-secret',
+        'secretKey': 'body-secret-key-camel-secret',
         'nested': <String, Object?>{
           'access_token': 'access-secret',
           'Authorization': 'Bearer body-bearer-secret',
+          'x-secret-key': 'nested-secret-key-secret',
         },
         'items': <Object?>[
           <String, Object?>{'refresh_token': 'refresh-secret'},
+          <String, Object?>{'api_secret_key': 'api-secret-key-secret'},
         ],
       });
 
@@ -64,6 +70,8 @@ void main() {
       expect(decoded['max_tokens'], 128);
       expect(decoded['api_key'], '<redacted>');
       expect(decoded['apiKey'], '<redacted>');
+      expect(decoded['secret_key'], '<redacted>');
+      expect(decoded['secretKey'], '<redacted>');
       expect(
         (decoded['nested'] as Map<String, dynamic>)['access_token'],
         '<redacted>',
@@ -73,15 +81,28 @@ void main() {
         'Bearer <redacted>',
       );
       expect(
-        ((decoded['items'] as List<dynamic>).single
+        (decoded['nested'] as Map<String, dynamic>)['x-secret-key'],
+        '<redacted>',
+      );
+      expect(
+        ((decoded['items'] as List<dynamic>)[0]
             as Map<String, dynamic>)['refresh_token'],
+        '<redacted>',
+      );
+      expect(
+        ((decoded['items'] as List<dynamic>)[1]
+            as Map<String, dynamic>)['api_secret_key'],
         '<redacted>',
       );
       expect(sanitized, isNot(contains('body-api-key-secret')));
       expect(sanitized, isNot(contains('body-camel-secret')));
+      expect(sanitized, isNot(contains('body-secret-key-secret')));
+      expect(sanitized, isNot(contains('body-secret-key-camel-secret')));
       expect(sanitized, isNot(contains('access-secret')));
       expect(sanitized, isNot(contains('body-bearer-secret')));
+      expect(sanitized, isNot(contains('nested-secret-key-secret')));
       expect(sanitized, isNot(contains('refresh-secret')));
+      expect(sanitized, isNot(contains('api-secret-key-secret')));
     });
 
     test('redacts bearer tokens in malformed or non-JSON bodies', () {
@@ -109,7 +130,7 @@ void main() {
     test('redacts URL query credentials and user info', () {
       final sanitized = RequestLogger.sanitizeUrlForLogging(
         Uri.parse(
-          'https://user:password@example.com/v1/models?api_key=url-api-secret&key=url-key-secret&access_token=url-access-secret&model=visible-model',
+          'https://user:password@example.com/v1/models?api_key=url-api-secret&key=url-key-secret&access_token=url-access-secret&secret_key=url-secret-key-secret&model=visible-model',
         ),
       );
 
@@ -117,10 +138,12 @@ void main() {
       expect(sanitized, contains('api_key=%3Credacted%3E'));
       expect(sanitized, contains('key=%3Credacted%3E'));
       expect(sanitized, contains('access_token=%3Credacted%3E'));
+      expect(sanitized, contains('secret_key=%3Credacted%3E'));
       expect(sanitized, isNot(contains('user:password')));
       expect(sanitized, isNot(contains('url-api-secret')));
       expect(sanitized, isNot(contains('url-key-secret')));
       expect(sanitized, isNot(contains('url-access-secret')));
+      expect(sanitized, isNot(contains('url-secret-key-secret')));
     });
 
     test('redacts URL secrets inside plain text fragments', () {
@@ -197,13 +220,17 @@ void main() {
 
     test('redacts quoted sensitive keys in non-JSON fragments', () {
       final sanitized = RequestLogger.sanitizeBodyForLogging(
-        'data: {"access_token":"fragment-access-secret","api_key":"fragment-api-secret"}',
+        'data: {"access_token":"fragment-access-secret","api_key":"fragment-api-secret","secret_key":"fragment-secret-key-secret","secretKey":"fragment-secret-key-camel-secret"}',
       );
 
       expect(sanitized, contains('"access_token":"<redacted>"'));
       expect(sanitized, contains('"api_key":"<redacted>"'));
+      expect(sanitized, contains('"secret_key":"<redacted>"'));
+      expect(sanitized, contains('"secretKey":"<redacted>"'));
       expect(sanitized, isNot(contains('fragment-access-secret')));
       expect(sanitized, isNot(contains('fragment-api-secret')));
+      expect(sanitized, isNot(contains('fragment-secret-key-secret')));
+      expect(sanitized, isNot(contains('fragment-secret-key-camel-secret')));
     });
 
     test('redacts malformed sensitive values without closing quotes', () {
@@ -272,6 +299,65 @@ void main() {
         await tempDir.delete(recursive: true);
       }
     });
+
+    test(
+      'redacts response log secrets split across pretty JSON lines',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'kelivo_request_logger_pretty_json_test_',
+        );
+        final previousPathProvider = PathProviderPlatform.instance;
+        PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        unawaited(
+          server.first.then((request) async {
+            request.response.bufferOutput = false;
+            request.response.headers.contentType = ContentType.json;
+            request.response.write(
+              '{\n  "message": "visible-before-secret",\n',
+            );
+            await request.response.flush();
+            request.response.write('  "access_token":\n');
+            await request.response.flush();
+            request.response.write('  "pretty-secret-token"\n}\n');
+            await request.response.close();
+          }),
+        );
+
+        RequestLogger.saveOutput = true;
+        await RequestLogger.setEnabled(true);
+
+        try {
+          final client = DioHttpClient();
+          try {
+            final request = http.Request(
+              'GET',
+              Uri.parse('http://${server.address.host}:${server.port}/stream'),
+            );
+            final response = await client.send(request);
+            await response.stream.toBytes();
+          } finally {
+            client.close();
+          }
+
+          final logText = await _readLogUntil(
+            tempDir,
+            (content) => content.contains('[RES') && content.contains('done'),
+          );
+
+          expect(logText, contains('visible-before-secret'));
+          expect(logText, contains('"access_token":\\n  "<redacted>"'));
+          expect(logText, isNot(contains('pretty-secret-token')));
+        } finally {
+          await RequestLogger.setEnabled(false);
+          RequestLogger.saveOutput = true;
+          await server.close(force: true);
+          PathProviderPlatform.instance = previousPathProvider;
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
 
     test(
       'writes response logs incrementally without waiting for done',
@@ -368,7 +454,7 @@ void main() {
           final request = http.Request(
             'GET',
             Uri.parse(
-              'http://${server.address.host}:${server.port}/models?api_key=request-url-api-secret&key=request-url-key-secret&model=visible-model',
+              'http://${server.address.host}:${server.port}/models?api_key=request-url-api-secret&key=request-url-key-secret&secret_key=request-url-secret-key-secret&model=visible-model',
             ),
           );
           final response = await client.send(request);
@@ -385,8 +471,10 @@ void main() {
         expect(logText, contains('model=visible-model'));
         expect(logText, contains('api_key=%3Credacted%3E'));
         expect(logText, contains('key=%3Credacted%3E'));
+        expect(logText, contains('secret_key=%3Credacted%3E'));
         expect(logText, isNot(contains('request-url-api-secret')));
         expect(logText, isNot(contains('request-url-key-secret')));
+        expect(logText, isNot(contains('request-url-secret-key-secret')));
       } finally {
         await RequestLogger.setEnabled(false);
         await server.close(force: true);


### PR DESCRIPTION
## Summary
这个 PR 修复请求日志中可能泄漏 API key、Authorization token、URL 凭据和响应内容敏感字段的问题。
脱敏逻辑集中在 `DioHttpClient` / `RequestLogger` 的日志边界执行，不修改真实请求 URL、请求头、请求体、响应流或异常传播行为。
Fixes #526
## 脱敏范围
以下日志内容现在会被脱敏：
- 请求 URL：
  - URL query 中的凭据参数，例如 `api_key`、`key`、`access_token`、`sig`、`signature`、`credential`，以及 AWS 风格的 `X-Amz-*` credential 参数。
  - URL user info，例如 `https://user:password@example.com/...`。
- 请求头：
  - `Authorization`
  - `Proxy-Authorization`
  - API key 风格 header，例如 `x-api-key`、`xi-api-key`，包括大小写混合写法。
  - token / secret / cookie 风格敏感 key。
- 请求体：
  - JSON 字段，例如 `api_key`、`apiKey`、`access_token`、`refresh_token`、`id_token`、`auth_token`、`client_secret`、`secret`、`cookie`、`set-cookie`。
  - 嵌套 JSON object 和 array 会递归脱敏。
  - Authorization 值会尽量保留 scheme，例如 `Bearer <redacted>`。
- 非 JSON / malformed 文本：
  - `Authorization: Bearer ...`
  - `Authorization: Basic ...`
  - `Proxy-Authorization: Token ...`
  - 独立出现的 `Bearer ...`
  - 非 JSON 片段中的 quoted sensitive key/value。
  - 缺少闭合引号的 malformed sensitive value。
- 响应日志：
  - 响应 header 走同一套 object 脱敏逻辑。
  - 响应 body chunk 写入日志前会先脱敏。
  - 普通 error 字符串和 Dio exception 字符串写入日志前会先脱敏。
  - 对跨 streamed response chunk 拆开的 secret，通过按完整行缓冲后脱敏写入，避免 secret 被 chunk 边界绕过。
## 日志行为变化
- 保留原有日志行结构，只把敏感值替换为 `<redacted>`。
- 响应 body 日志仍按完整行增量写入，流式输出不需要等 response 完全结束才可见。
- 真实 HTTP 请求 URL、headers、body、response stream 和抛出的 client exception 不会被改写。
## 测试覆盖
新增聚焦回归测试：`test/core/services/network/request_logger_redaction_test.dart`。
已覆盖的边界情况：
- 普通 header 保持可读，敏感 header 被脱敏。
- mixed-case 敏感 header 名称被脱敏。
- JSON 请求体中的敏感字段递归脱敏。
- 嵌套 map 和 list item 中的敏感字段被脱敏。
- malformed / non-JSON body 中的 Bearer token 被脱敏。
- 非 Bearer Authorization 值被脱敏，例如 Basic auth 和 Token auth。
- URL query secret 和 URL user info 被脱敏。
- 普通文本异常片段中嵌入的 URL secret 被脱敏。
- 非 JSON 片段中的 quoted sensitive key 被脱敏。
- 缺少闭合引号的 malformed sensitive value 被脱敏。
- streamed response 中跨 chunk 拆开的 secret 被脱敏。
- response log 仍会在 response done 前增量写入。
- 实际 request log line 中的 URL query secret 被脱敏，同时保留非敏感 query 参数。
## 验证
已通过：
- `dart analyze --fatal-infos "lib/core/services/network/request_logger.dart" "lib/core/services/network/dio_http_client.dart" "test/core/services/network/request_logger_redaction_test.dart"`
- `flutter test "test/core/services/network/request_logger_redaction_test.dart"`
- `git diff --check`
## 注
这个 PR 有意把范围控制在已知 API key、token、Authorization、secret、cookie、URL query credential 和 URL user info 模式上。它不会尝试脱敏任意 path 或普通文本中所有 password-like 内容，除非这些内容匹配本次覆盖的敏感 key 模式。