### PR TITLE
fix(google): strip internal Gemini part ids before send

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -99,6 +99,28 @@ Map<String, dynamic> _googleFunctionResponsePartFromToolMessage(
   return part;
 }
 
+List<Map<String, dynamic>> _googleApiContents(
+  List<Map<String, dynamic>> contents,
+) {
+  return [
+    for (final content in contents)
+      {
+        ...content,
+        if (content['parts'] is List)
+          'parts': [
+            for (final part in content['parts'] as List)
+              part is Map ? _googleApiPart(part) : part,
+          ],
+      },
+  ];
+}
+
+Map<String, dynamic> _googleApiPart(Map part) {
+  final out = Map<String, dynamic>.from(part);
+  out.remove('id');
+  return out;
+}
+
 Stream<ChatStreamChunk> _sendGoogleStream(
   http.Client client,
   ProviderConfig config,
@@ -384,7 +406,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       final req = http.Request('POST', Uri.parse(url));
       req.headers.addAll(headers);
       final body = Map<String, dynamic>.from(baseBody);
-      body['contents'] = currentContents;
+      body['contents'] = _googleApiContents(currentContents);
       req.body = jsonEncode(body);
       final resp = await client.send(req);
       if (resp.statusCode < 200 || resp.statusCode >= 300) {
@@ -921,6 +943,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         body[k] = (v is String) ? _parseOverrideValue(v) : v;
       });
     }
+    body['contents'] = _googleApiContents(convo);
     request.body = jsonEncode(body);
 
     final resp = await client.send(request);

--- a/test/gemini_part_id_payload_test.dart
+++ b/test/gemini_part_id_payload_test.dart
@@ -1,0 +1,232 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiPartIdTest',
+    enabled: true,
+    name: 'GeminiPartIdTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+Map<String, dynamic> _streamChunk(
+  List<Map<String, dynamic>> parts, {
+  String? finishReason,
+}) {
+  return {
+    'candidates': [
+      {
+        'content': {'parts': parts},
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+    'usageMetadata': {
+      'promptTokenCount': 1,
+      'candidatesTokenCount': 1,
+      'totalTokenCount': 2,
+    },
+  };
+}
+
+void _expectNoGooglePartIds(Map<String, dynamic> body) {
+  final contents = (body['contents'] as List).cast<Map>();
+  for (final content in contents) {
+    final parts = (content['parts'] as List?)?.cast<Map>() ?? const <Map>[];
+    for (final part in parts) {
+      expect(part.containsKey('id'), isFalse, reason: jsonEncode(part));
+    }
+  }
+}
+
+void main() {
+  group('Gemini API part ids', () {
+    test('strips internal ids from historical function parts', () async {
+      Map<String, dynamic>? requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody =
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: const [
+          {'role': 'user', 'content': 'Fetch the page.'},
+          {
+            'role': 'assistant',
+            'content': '\n\n',
+            'tool_calls': [
+              {
+                'id': 'call_1',
+                'type': 'function',
+                'function': {
+                  'name': 'fetch_markdown',
+                  'arguments': '{"url":"https://example.com"}',
+                },
+                'metadata': {
+                  'google': {
+                    'part': {
+                      'id': 'api_call_1',
+                      'functionCall': {
+                        'name': 'fetch_markdown',
+                        'args': {'url': 'https://example.com'},
+                      },
+                      'thoughtSignature': 'sig-call',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
+            'role': 'tool',
+            'name': 'fetch_markdown',
+            'tool_call_id': 'call_1',
+            'content': '{"result":"ok"}',
+            'metadata': {
+              'google': {
+                'part': {'id': 'api_call_1'},
+              },
+            },
+          },
+          {'role': 'user', 'content': 'Continue.'},
+        ],
+        stream: false,
+      ).toList();
+
+      expect(requestBody, isNotNull);
+      _expectNoGooglePartIds(requestBody!);
+      final contents = (requestBody!['contents'] as List).cast<Map>();
+      final modelParts = (contents[1]['parts'] as List).cast<Map>();
+      expect(modelParts.single['thoughtSignature'], 'sig-call');
+    });
+
+    test(
+      'strips internal ids from live tool-call continuation parts',
+      () async {
+        final requestBodies = <Map<String, dynamic>>[];
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        var requestCount = 0;
+        server.listen((request) async {
+          requestCount++;
+          requestBodies.add(
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>,
+          );
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.headers.set('Transfer-Encoding', 'chunked');
+
+          if (requestCount == 1) {
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([
+                {
+                  'id': 'api_call_live',
+                  'functionCall': {
+                    'name': 'fetch_markdown',
+                    'args': {'url': 'https://example.com'},
+                  },
+                  'thoughtSignature': 'sig-live',
+                },
+              ], finishReason: 'STOP'))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          if (requestCount == 2) {
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([
+                {'text': 'done'},
+              ], finishReason: 'STOP'))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          fail('Unexpected request count: $requestCount');
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-3.1-pro-preview',
+          messages: const [
+            {'role': 'user', 'content': 'Fetch the page.'},
+          ],
+          tools: const [
+            {
+              'function_declarations': [
+                {
+                  'name': 'fetch_markdown',
+                  'description': 'Fetch markdown',
+                  'parameters': {
+                    'type': 'object',
+                    'properties': {
+                      'url': {'type': 'string'},
+                    },
+                    'required': ['url'],
+                  },
+                },
+              ],
+            },
+          ],
+          onToolCall: (name, args) async => '{"result":"ok"}',
+        ).toList();
+
+        expect(chunks.last.isDone, isTrue);
+        expect(requestCount, 2);
+        expect(requestBodies, hasLength(2));
+        _expectNoGooglePartIds(requestBodies[1]);
+        final contents = (requestBodies[1]['contents'] as List).cast<Map>();
+        final modelParts = (contents[1]['parts'] as List).cast<Map>();
+        final userParts = (contents[2]['parts'] as List).cast<Map>();
+        expect(modelParts.single['thoughtSignature'], 'sig-live');
+        expect(modelParts.single.containsKey('functionCall'), isTrue);
+        expect(userParts.single.containsKey('functionResponse'), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 摘要

  Closes #543.

  修复 Gemini 工具调用回放时，把 Kelivo 内部 tool id 泄漏到 Google API `contents[].parts[]` 的问题。Gemini `Part` 不接受顶层 `id` 字段，因此包含工具调用历史或
  streaming tool continuation 的对话可能触发 HTTP 400。

  本次修复只在发送 Google/Gemini 请求前移除 part 顶层的内部 `id` 字段，同时保留 `thoughtSignature`、`functionCall` 和 `functionResponse`。

## 变更

  - 在 Gemini 请求 JSON encode 前清理 `contents[].parts[].id`
  - 覆盖历史 tool call replay payload 中包含内部 part id 的情况
  - 覆盖 streaming tool call continuation payload 中包含内部 part id 的情况
  - 验证 `thoughtSignature` 不会被误删

## 验证

  ```bash
  flutter test test/gemini_part_id_payload_test.dart
  flutter analyze lib/core/services/api/providers/google_common.dart test/gemini_part_id_payload_test.dart