### PR TITLE
fix(stats): resolve timezone and DST drift in StatsHeatmap

### DIFF
--- a/lib/features/stats/widgets/stats_heatmap.dart
+++ b/lib/features/stats/widgets/stats_heatmap.dart
@@ -215,20 +215,28 @@ class _StatsHeatmapState extends State<StatsHeatmap> {
     final byDate = {for (final day in days) _dateOnly(day.date): day};
     final first = _dateOnly(days.first.date);
     final last = _dateOnly(days.last.date);
-    final start = first.subtract(Duration(days: first.weekday % 7));
+    final start = DateTime(
+      first.year,
+      first.month,
+      first.day - (first.weekday % 7),
+    );
     final weeks = <List<StatsHeatmapDay>>[];
     for (
       var weekStart = start;
       !weekStart.isAfter(last);
-      weekStart = weekStart.add(const Duration(days: 7))
+      weekStart = DateTime(weekStart.year, weekStart.month, weekStart.day + 7)
     ) {
-      final weekEnd = weekStart.add(const Duration(days: 6));
+      final weekEnd = DateTime(
+        weekStart.year,
+        weekStart.month,
+        weekStart.day + 6,
+      );
       final visibleEnd = weekEnd.isAfter(last) ? last : weekEnd;
       weeks.add([
         for (
           var date = weekStart;
           !date.isAfter(visibleEnd);
-          date = date.add(const Duration(days: 1))
+          date = DateTime(date.year, date.month, date.day + 1)
         )
           _dayForDate(byDate, date),
       ]);

--- a/test/features/stats/pages/stats_page_smoke_test.dart
+++ b/test/features/stats/pages/stats_page_smoke_test.dart
@@ -161,10 +161,13 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final latest = DateTime(2026, 5, 3);
-    final earliest = latest.subtract(const Duration(days: 179));
+    final earliest = DateTime(latest.year, latest.month, latest.day - 179);
     final days = [
       for (var i = 179; i >= 0; i--)
-        StatsHeatmapDay(date: latest.subtract(Duration(days: i)), count: 1),
+        StatsHeatmapDay(
+          date: DateTime(latest.year, latest.month, latest.day - i),
+          count: 1,
+        ),
     ];
 
     await tester.pumpWidget(


### PR DESCRIPTION
### 描述
本 PR 修复了 `StatsHeatmap` 在计算日历周数时因夏令时/时区漂移导致的渲染缺失问题。

### 根本原因
在 `lib/features/stats/widgets/stats_heatmap.dart` 的 `_calendarWeeks` 方法中，先前使用 `Duration(days: n)` (即固定的 `n * 24` 小时) 进行日期递增和递减。
当用户或测试套件在启用夏令时（DST）的时区运行且时间跨度较长（如 narrow viewport 测试中的 180 天）时，多次累加 `Duration(days: 7)` 会由于夏令时时间拨快/拨慢导致小时值偏离 `00:00:00` 漂移至 `01:00:00`。
这导致最后一周的 `weekStart` 变为了 `2026-05-03 01:00:00`，而 `last` 归一化为 `2026-05-03 00:00:00`。在循环判定中 `weekStart.isAfter(last)` 成立，导致循环提前终止，热力图最后一周无法进入渲染树，抛出找不着 Key 的异常。

### 解决方案
将所有基于 `Duration` 的日期算术修改为基于 `DateTime(year, month, day + offset)` 的安全日期构造器。Flutter 的构造函数能自动处理天/月/年溢出，且能够抵抗时区与夏令时漂移。

### 验证情况
- 运行 `dart format` 完成了格式化。
- 在启用了夏令时的本地环境下运行 `flutter test`，全部 449 项测试通过，`heatmap initially shows latest date on narrow viewport` 测试通过。