### PR TITLE
feat: 在导出导入过程中保留文件修改时间戳 - Preserve file modification timestamps during backup/restore

### DIFF
--- a/lib/core/services/backup/cherry_importer.dart
+++ b/lib/core/services/backup/cherry_importer.dart
@@ -795,12 +795,14 @@ class CherryImporter {
               final entry = filesIndexByRel[key]!;
               final bytes = entry.content as List<int>;
               await File(outPath).writeAsBytes(bytes);
-              final dt = _decodeDosDateTime(entry.lastModTime);
-              if (dt != null) {
-                await File(outPath).setLastModified(dt);
-              }
               result[id] = outPath;
               done = true;
+              final dt = _decodeDosDateTime(entry.lastModTime);
+              if (dt != null) {
+                try {
+                  await File(outPath).setLastModified(dt);
+                } catch (_) {}
+              }
             }
             if (!done &&
                 diskFilesIndexByRel != null &&
@@ -808,9 +810,13 @@ class CherryImporter {
               final src = diskFilesIndexByRel[key]!;
               final bytes = await File(src).readAsBytes();
               await File(outPath).writeAsBytes(bytes);
-              await File(outPath).setLastModified(await File(src).lastModified());
               result[id] = outPath;
               done = true;
+              try {
+                await File(
+                  outPath,
+                ).setLastModified(await File(src).lastModified());
+              } catch (_) {}
             }
             if (done) break;
           }
@@ -836,12 +842,14 @@ class CherryImporter {
             final entry = filesIndexByBase[base]!;
             final bytes = entry.content as List<int>;
             await File(outPath).writeAsBytes(bytes);
-            final dt = _decodeDosDateTime(entry.lastModTime);
-            if (dt != null) {
-              await File(outPath).setLastModified(dt);
-            }
             result[id] = outPath;
             done = true;
+            final dt = _decodeDosDateTime(entry.lastModTime);
+            if (dt != null) {
+              try {
+                await File(outPath).setLastModified(dt);
+              } catch (_) {}
+            }
           }
           if (!done &&
               diskFilesIndexByBase != null &&
@@ -849,9 +857,13 @@ class CherryImporter {
             final src = diskFilesIndexByBase[base]!;
             final bytes = await File(src).readAsBytes();
             await File(outPath).writeAsBytes(bytes);
-            await File(outPath).setLastModified(await File(src).lastModified());
             result[id] = outPath;
             done = true;
+            try {
+              await File(
+                outPath,
+              ).setLastModified(await File(src).lastModified());
+            } catch (_) {}
           }
           if (done) break;
         }
@@ -872,30 +884,36 @@ class CherryImporter {
           final entry = filesIndexById[id]!;
           final bytes = entry.content as List<int>;
           await File(outPath).writeAsBytes(bytes);
+          result[id] = outPath;
           final dt = _decodeDosDateTime(entry.lastModTime);
           if (dt != null) {
-            await File(outPath).setLastModified(dt);
+            try {
+              await File(outPath).setLastModified(dt);
+            } catch (_) {}
           }
-          result[id] = outPath;
           continue;
         }
         if (filesIndexByBase != null && filesIndexByBase.containsKey(idPlus)) {
           final entry = filesIndexByBase[idPlus]!;
           final bytes = entry.content as List<int>;
           await File(outPath).writeAsBytes(bytes);
+          result[id] = outPath;
           final dt = _decodeDosDateTime(entry.lastModTime);
           if (dt != null) {
-            await File(outPath).setLastModified(dt);
+            try {
+              await File(outPath).setLastModified(dt);
+            } catch (_) {}
           }
-          result[id] = outPath;
           continue;
         }
         if (diskFilesIndexById != null && diskFilesIndexById.containsKey(id)) {
           final src = diskFilesIndexById[id]!;
           final bytes = await File(src).readAsBytes();
           await File(outPath).writeAsBytes(bytes);
-          await File(outPath).setLastModified(await File(src).lastModified());
           result[id] = outPath;
+          try {
+            await File(outPath).setLastModified(await File(src).lastModified());
+          } catch (_) {}
           continue;
         }
         if (diskFilesIndexByBase != null &&
@@ -903,8 +921,10 @@ class CherryImporter {
           final src = diskFilesIndexByBase[idPlus]!;
           final bytes = await File(src).readAsBytes();
           await File(outPath).writeAsBytes(bytes);
-          await File(outPath).setLastModified(await File(src).lastModified());
           result[id] = outPath;
+          try {
+            await File(outPath).setLastModified(await File(src).lastModified());
+          } catch (_) {}
           continue;
         }
       } catch (_) {}

--- a/lib/core/services/backup/cherry_importer.dart
+++ b/lib/core/services/backup/cherry_importer.dart
@@ -606,6 +606,25 @@ class CherryImporter {
     return out.length;
   }
 
+  /// Decode a DOS date/time packed value (from ZIP entry's lastModTime) into
+  /// a [DateTime]. Returns null when the date portion is zero (unset).
+  static DateTime? _decodeDosDateTime(int packed) {
+    final dosDate = packed >> 16;
+    final dosTime = packed & 0xFFFF;
+    if (dosDate == 0) return null;
+    final year = ((dosDate >> 9) & 0x7f) + 1980;
+    final month = (dosDate >> 5) & 0x0f;
+    final day = dosDate & 0x1f;
+    final hour = (dosTime >> 11) & 0x1f;
+    final minute = (dosTime >> 5) & 0x3f;
+    final second = (dosTime & 0x1f) * 2;
+    try {
+      return DateTime(year, month, day, hour, minute, second);
+    } catch (_) {
+      return null;
+    }
+  }
+
   static Future<Map<String, String>> _materializeFiles(
     Map<String, Map<String, dynamic>> filesById,
     Set<String> usedIds, {
@@ -776,6 +795,10 @@ class CherryImporter {
               final entry = filesIndexByRel[key]!;
               final bytes = entry.content as List<int>;
               await File(outPath).writeAsBytes(bytes);
+              final dt = _decodeDosDateTime(entry.lastModTime);
+              if (dt != null) {
+                await File(outPath).setLastModified(dt);
+              }
               result[id] = outPath;
               done = true;
             }
@@ -785,6 +808,7 @@ class CherryImporter {
               final src = diskFilesIndexByRel[key]!;
               final bytes = await File(src).readAsBytes();
               await File(outPath).writeAsBytes(bytes);
+              await File(outPath).setLastModified(await File(src).lastModified());
               result[id] = outPath;
               done = true;
             }
@@ -812,6 +836,10 @@ class CherryImporter {
             final entry = filesIndexByBase[base]!;
             final bytes = entry.content as List<int>;
             await File(outPath).writeAsBytes(bytes);
+            final dt = _decodeDosDateTime(entry.lastModTime);
+            if (dt != null) {
+              await File(outPath).setLastModified(dt);
+            }
             result[id] = outPath;
             done = true;
           }
@@ -821,6 +849,7 @@ class CherryImporter {
             final src = diskFilesIndexByBase[base]!;
             final bytes = await File(src).readAsBytes();
             await File(outPath).writeAsBytes(bytes);
+            await File(outPath).setLastModified(await File(src).lastModified());
             result[id] = outPath;
             done = true;
           }
@@ -843,6 +872,10 @@ class CherryImporter {
           final entry = filesIndexById[id]!;
           final bytes = entry.content as List<int>;
           await File(outPath).writeAsBytes(bytes);
+          final dt = _decodeDosDateTime(entry.lastModTime);
+          if (dt != null) {
+            await File(outPath).setLastModified(dt);
+          }
           result[id] = outPath;
           continue;
         }
@@ -850,6 +883,10 @@ class CherryImporter {
           final entry = filesIndexByBase[idPlus]!;
           final bytes = entry.content as List<int>;
           await File(outPath).writeAsBytes(bytes);
+          final dt = _decodeDosDateTime(entry.lastModTime);
+          if (dt != null) {
+            await File(outPath).setLastModified(dt);
+          }
           result[id] = outPath;
           continue;
         }
@@ -857,6 +894,7 @@ class CherryImporter {
           final src = diskFilesIndexById[id]!;
           final bytes = await File(src).readAsBytes();
           await File(outPath).writeAsBytes(bytes);
+          await File(outPath).setLastModified(await File(src).lastModified());
           result[id] = outPath;
           continue;
         }
@@ -865,6 +903,7 @@ class CherryImporter {
           final src = diskFilesIndexByBase[idPlus]!;
           final bytes = await File(src).readAsBytes();
           await File(outPath).writeAsBytes(bytes);
+          await File(outPath).setLastModified(await File(src).lastModified());
           result[id] = outPath;
           continue;
         }

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -289,6 +289,25 @@ class DataSync {
     return name.replaceAll('\\', '/').replaceAll(RegExp(r'^/+'), '');
   }
 
+  /// Decode a DOS date/time packed value (from ZIP entry's lastModTime) into
+  /// a [DateTime]. Returns null when the date portion is zero (unset).
+  static DateTime? _decodeDosDateTime(int packed) {
+    final dosDate = packed >> 16;
+    final dosTime = packed & 0xFFFF;
+    if (dosDate == 0) return null;
+    final year = ((dosDate >> 9) & 0x7f) + 1980;
+    final month = (dosDate >> 5) & 0x0f;
+    final day = dosDate & 0x1f;
+    final hour = (dosTime >> 11) & 0x1f;
+    final minute = (dosTime >> 5) & 0x3f;
+    final second = (dosTime & 0x1f) * 2;
+    try {
+      return DateTime(year, month, day, hour, minute, second);
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Synchronous ZIP extraction — runs inside an Isolate.
   /// Uses InputFileStream so the ZIP bytes are read from disk on demand rather
   /// than loading the entire archive into a single byte array.
@@ -313,6 +332,10 @@ class DataSync {
               entry.writeContent(output);
             } finally {
               output.closeSync();
+            }
+            final dt = _decodeDosDateTime(entry.lastModTime);
+            if (dt != null) {
+              File(outPath).setLastModifiedSync(dt);
             }
           } else {
             Directory(outPath).createSync(recursive: true);
@@ -1093,6 +1116,7 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
+                await target.setLastModified(await ent.lastModified());
               }
             }
           }
@@ -1113,6 +1137,7 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
+                await target.setLastModified(await ent.lastModified());
               }
             }
           }
@@ -1133,6 +1158,7 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
+                await target.setLastModified(await ent.lastModified());
               }
             }
           }
@@ -1152,6 +1178,7 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
+                  await target.setLastModified(await ent.lastModified());
                 }
               }
             }
@@ -1171,6 +1198,7 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
+                  await target.setLastModified(await ent.lastModified());
                 }
               }
             }
@@ -1190,6 +1218,7 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
+                  await target.setLastModified(await ent.lastModified());
                 }
               }
             }

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -335,7 +335,9 @@ class DataSync {
             }
             final dt = _decodeDosDateTime(entry.lastModTime);
             if (dt != null) {
-              File(outPath).setLastModifiedSync(dt);
+              try {
+                File(outPath).setLastModifiedSync(dt);
+              } catch (_) {}
             }
           } else {
             Directory(outPath).createSync(recursive: true);
@@ -1116,7 +1118,9 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
-                await target.setLastModified(await ent.lastModified());
+                try {
+                  await target.setLastModified(await ent.lastModified());
+                } catch (_) {}
               }
             }
           }
@@ -1137,7 +1141,9 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
-                await target.setLastModified(await ent.lastModified());
+                try {
+                  await target.setLastModified(await ent.lastModified());
+                } catch (_) {}
               }
             }
           }
@@ -1158,7 +1164,9 @@ class DataSync {
                 final target = File(p.join(dst.path, rel));
                 await target.parent.create(recursive: true);
                 await ent.copy(target.path);
-                await target.setLastModified(await ent.lastModified());
+                try {
+                  await target.setLastModified(await ent.lastModified());
+                } catch (_) {}
               }
             }
           }
@@ -1178,7 +1186,9 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
-                  await target.setLastModified(await ent.lastModified());
+                  try {
+                    await target.setLastModified(await ent.lastModified());
+                  } catch (_) {}
                 }
               }
             }
@@ -1198,7 +1208,9 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
-                  await target.setLastModified(await ent.lastModified());
+                  try {
+                    await target.setLastModified(await ent.lastModified());
+                  } catch (_) {}
                 }
               }
             }
@@ -1218,7 +1230,9 @@ class DataSync {
                 if (!await target.exists()) {
                   await target.parent.create(recursive: true);
                   await ent.copy(target.path);
-                  await target.setLastModified(await ent.lastModified());
+                  try {
+                    await target.setLastModified(await ent.lastModified());
+                  } catch (_) {}
                 }
               }
             }


### PR DESCRIPTION
解压 ZIP 后和复制文件后，不再丢失文件的修改时间戳。

### 修改内容

- **`_extractZipSync`**: 解压后从 ZIP entry 的 DOS 日期/时间正确解码并调用 `setLastModifiedSync`
- **Overwrite/Merge 恢复**: 6 处 `ent.copy` 后追加 `await target.setLastModified(await ent.lastModified())`
- **Cherry Studio 导入**: 8 处 `writeAsBytes` 后，从 ZIP entry 或磁盘源文件恢复修改时间
- **DOS 解码**: `ArchiveFile.lastModTime` 是 DOS 打包值，用 `_decodeDosDateTime` 正确解析

### 未处理

ZIP 创建时间：格式本身支持（NTFS extra field 0x000a），但 archive 4.0.9 的 `ZipDecoder` 不读取 extra fields，无法恢复。

---

File modification timestamps are now preserved through the full backup/restore pipeline and Cherry Studio import.

- `_extractZipSync`: decode DOS date/time from ZIP entry and apply via `setLastModifiedSync`
- Overwrite/Merge restore: `setLastModified` after each `ent.copy` (6 places)
- Cherry Studio import: restore timestamps from ZIP entry or disk source after `writeAsBytes` (8 places)
- DOS decoding: `_decodeDosDateTime` correctly parses the DOS-packed `lastModTime`

Creation time is not preserved — ZIP format supports it via NTFS extra field, but archive 4.0.9's `ZipDecoder` does not read extra fields.