### PR TITLE
feat: add User-Agent header support for WebDAV and S3 backup settings

### DIFF
--- a/lib/core/models/backup.dart
+++ b/lib/core/models/backup.dart
@@ -10,6 +10,7 @@ class WebDavConfig {
   final String username;
   final String password;
   final String path;
+  final String userAgent;
   final bool includeChats; // Hive boxes
   final bool includeFiles; // uploads/
 
@@ -18,6 +19,7 @@ class WebDavConfig {
     this.username = '',
     this.password = '',
     this.path = 'kelivo_backups',
+    this.userAgent = '',
     this.includeChats = true,
     this.includeFiles = true,
   });
@@ -27,6 +29,7 @@ class WebDavConfig {
     String? username,
     String? password,
     String? path,
+    String? userAgent,
     bool? includeChats,
     bool? includeFiles,
   }) {
@@ -35,6 +38,7 @@ class WebDavConfig {
       username: username ?? this.username,
       password: password ?? this.password,
       path: path ?? this.path,
+      userAgent: userAgent ?? this.userAgent,
       includeChats: includeChats ?? this.includeChats,
       includeFiles: includeFiles ?? this.includeFiles,
     );
@@ -45,6 +49,7 @@ class WebDavConfig {
     'username': username,
     'password': password,
     'path': path,
+    'userAgent': userAgent,
     'includeChats': includeChats,
     'includeFiles': includeFiles,
   };
@@ -57,6 +62,7 @@ class WebDavConfig {
       path: (json['path'] as String?)?.trim().isNotEmpty == true
           ? (json['path'] as String).trim()
           : 'kelivo_backups',
+      userAgent: (json['userAgent'] as String?) ?? '',
       includeChats: json['includeChats'] as bool? ?? true,
       includeFiles: json['includeFiles'] as bool? ?? true,
     );
@@ -86,6 +92,7 @@ class S3Config {
   final String prefix; // object key prefix/folder
   final bool
   pathStyle; // safer for custom endpoints (no bucket subdomain TLS mismatch)
+  final String userAgent;
   final bool includeChats;
   final bool includeFiles;
 
@@ -98,6 +105,7 @@ class S3Config {
     this.sessionToken = '',
     this.prefix = 'kelivo_backups',
     this.pathStyle = true,
+    this.userAgent = '',
     this.includeChats = true,
     this.includeFiles = true,
   });
@@ -111,6 +119,7 @@ class S3Config {
     String? sessionToken,
     String? prefix,
     bool? pathStyle,
+    String? userAgent,
     bool? includeChats,
     bool? includeFiles,
   }) {
@@ -123,6 +132,7 @@ class S3Config {
       sessionToken: sessionToken ?? this.sessionToken,
       prefix: prefix ?? this.prefix,
       pathStyle: pathStyle ?? this.pathStyle,
+      userAgent: userAgent ?? this.userAgent,
       includeChats: includeChats ?? this.includeChats,
       includeFiles: includeFiles ?? this.includeFiles,
     );
@@ -137,6 +147,7 @@ class S3Config {
     'sessionToken': sessionToken,
     'prefix': prefix,
     'pathStyle': pathStyle,
+    'userAgent': userAgent,
     'includeChats': includeChats,
     'includeFiles': includeFiles,
   };
@@ -155,6 +166,7 @@ class S3Config {
           ? (json['prefix'] as String).trim()
           : 'kelivo_backups',
       pathStyle: json['pathStyle'] as bool? ?? true,
+      userAgent: (json['userAgent'] as String?) ?? '',
       includeChats: json['includeChats'] as bool? ?? true,
       includeFiles: json['includeFiles'] as bool? ?? true,
     );

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -46,6 +46,13 @@ class DataSync {
     return {'Authorization': 'Basic $token'};
   }
 
+  Map<String, String> _extraHeaders(WebDavConfig cfg) {
+    final h = <String, String>{};
+    final ua = cfg.userAgent.trim();
+    if (ua.isNotEmpty) h['User-Agent'] = ua;
+    return h;
+  }
+
   Future<void> _ensureCollection(WebDavConfig cfg) async {
     final client = http.Client();
     try {
@@ -65,6 +72,7 @@ class DataSync {
           'Depth': '0',
           'Content-Type': 'application/xml; charset=utf-8',
           ..._authHeaders(cfg),
+          ..._extraHeaders(cfg),
         });
         req.body =
             '<?xml version="1.0" encoding="utf-8" ?><d:propfind xmlns:d="DAV:"><d:prop><d:displayname/></d:prop></d:propfind>';
@@ -72,7 +80,7 @@ class DataSync {
         if (res.statusCode == 404) {
           // create this level
           final mk = await client
-              .send(http.Request('MKCOL', u)..headers.addAll(_authHeaders(cfg)))
+              .send(http.Request('MKCOL', u)..headers.addAll({..._authHeaders(cfg), ..._extraHeaders(cfg)}))
               .then(http.Response.fromStream);
           if (mk.statusCode != 201 &&
               mk.statusCode != 200 &&
@@ -101,6 +109,7 @@ class DataSync {
       'Depth': '1',
       'Content-Type': 'application/xml; charset=utf-8',
       ..._authHeaders(cfg),
+      ..._extraHeaders(cfg),
     });
     req.body =
         '<?xml version="1.0" encoding="utf-8" ?>\n'
@@ -338,6 +347,7 @@ class DataSync {
         'content-type': 'application/zip',
         'content-length': fileLen.toString(),
         ..._authHeaders(cfg),
+        ..._extraHeaders(cfg),
       });
       // Pipe the file stream into the request body.
       file.openRead().listen(
@@ -367,6 +377,7 @@ class DataSync {
       'Depth': '1',
       'Content-Type': 'application/xml; charset=utf-8',
       ..._authHeaders(cfg),
+      ..._extraHeaders(cfg),
     });
     req.body =
         '<?xml version="1.0" encoding="utf-8" ?>\n'
@@ -466,7 +477,7 @@ class DataSync {
     File? file;
     try {
       final req = http.Request('GET', item.href);
-      req.headers.addAll(_authHeaders(cfg));
+      req.headers.addAll({..._authHeaders(cfg), ..._extraHeaders(cfg)});
       final streamed = await client.send(req);
       if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
         // Drain the response body to allow the client to close cleanly.
@@ -489,7 +500,7 @@ class DataSync {
     BackupFileItem item,
   ) async {
     final req = http.Request('DELETE', item.href);
-    req.headers.addAll(_authHeaders(cfg));
+    req.headers.addAll({..._authHeaders(cfg), ..._extraHeaders(cfg)});
     final res = await http.Client().send(req).then(http.Response.fromStream);
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw Exception('Delete failed: ${res.statusCode}');

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -80,7 +80,13 @@ class DataSync {
         if (res.statusCode == 404) {
           // create this level
           final mk = await client
-              .send(http.Request('MKCOL', u)..headers.addAll({..._authHeaders(cfg), ..._extraHeaders(cfg)}))
+              .send(
+                http.Request('MKCOL', u)
+                  ..headers.addAll({
+                    ..._authHeaders(cfg),
+                    ..._extraHeaders(cfg),
+                  }),
+              )
               .then(http.Response.fromStream);
           if (mk.statusCode != 201 &&
               mk.statusCode != 200 &&

--- a/lib/core/services/backup/s3_client.dart
+++ b/lib/core/services/backup/s3_client.dart
@@ -416,6 +416,9 @@ class S3BackupClient {
     if (cfg.sessionToken.trim().isNotEmpty) {
       reqHeaders['x-amz-security-token'] = cfg.sessionToken.trim();
     }
+    if (cfg.userAgent.trim().isNotEmpty) {
+      reqHeaders['User-Agent'] = cfg.userAgent.trim();
+    }
 
     final canonHeaders = _canonicalHeaders(reqHeaders);
     final signedHeaders = _signedHeaders(reqHeaders);

--- a/lib/core/services/backup/s3_client.dart
+++ b/lib/core/services/backup/s3_client.dart
@@ -263,6 +263,9 @@ class S3BackupClient {
     if (cfg.sessionToken.trim().isNotEmpty) {
       reqHeaders['x-amz-security-token'] = cfg.sessionToken.trim();
     }
+    if (cfg.userAgent.trim().isNotEmpty) {
+      reqHeaders['User-Agent'] = cfg.userAgent.trim();
+    }
 
     final canonHeaders = _canonicalHeaders(reqHeaders);
     final signedHeaders = _signedHeaders(reqHeaders);
@@ -340,6 +343,9 @@ class S3BackupClient {
     };
     if (cfg.sessionToken.trim().isNotEmpty) {
       reqHeaders['x-amz-security-token'] = cfg.sessionToken.trim();
+    }
+    if (cfg.userAgent.trim().isNotEmpty) {
+      reqHeaders['User-Agent'] = cfg.userAgent.trim();
     }
 
     final canonHeaders = _canonicalHeaders(reqHeaders);

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -40,6 +40,8 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
   late TextEditingController _s3SecretAccessKey;
   late TextEditingController _s3SessionToken;
   late TextEditingController _s3Prefix;
+  late TextEditingController _webDavUserAgent;
+  late TextEditingController _s3UserAgent;
   bool _includeChats = true;
   bool _includeFiles = true;
   bool _s3PathStyle = true;
@@ -53,6 +55,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     _username = TextEditingController(text: cfg.username);
     _password = TextEditingController(text: cfg.password);
     _path = TextEditingController(text: cfg.path);
+    _webDavUserAgent = TextEditingController(text: cfg.userAgent);
     _includeChats = cfg.includeChats;
     _includeFiles = cfg.includeFiles;
 
@@ -64,6 +67,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     _s3SecretAccessKey = TextEditingController(text: s3.secretAccessKey);
     _s3SessionToken = TextEditingController(text: s3.sessionToken);
     _s3Prefix = TextEditingController(text: s3.prefix);
+    _s3UserAgent = TextEditingController(text: s3.userAgent);
     _s3PathStyle = s3.pathStyle;
   }
 
@@ -80,6 +84,8 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     _s3SecretAccessKey.dispose();
     _s3SessionToken.dispose();
     _s3Prefix.dispose();
+    _webDavUserAgent.dispose();
+    _s3UserAgent.dispose();
     super.dispose();
   }
 
@@ -89,6 +95,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
       username: _username.text.trim(),
       password: _password.text,
       path: _path.text.trim().isEmpty ? 'kelivo_backups' : _path.text.trim(),
+      userAgent: _webDavUserAgent.text.trim(),
       includeChats: _includeChats,
       includeFiles: _includeFiles,
     );
@@ -107,6 +114,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     String? username,
     String? password,
     String? path,
+    String? userAgent,
     bool? includeChats,
     bool? includeFiles,
   }) async {
@@ -119,6 +127,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
       path:
           path ??
           (_path.text.trim().isEmpty ? 'kelivo_backups' : _path.text.trim()),
+      userAgent: userAgent ?? _webDavUserAgent.text.trim(),
       includeChats: includeChats ?? _includeChats,
       includeFiles: includeFiles ?? _includeFiles,
     );
@@ -140,6 +149,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
           ? 'kelivo_backups'
           : _s3Prefix.text.trim(),
       pathStyle: _s3PathStyle,
+      userAgent: _s3UserAgent.text.trim(),
       includeChats: _includeChats,
       includeFiles: _includeFiles,
     );
@@ -162,6 +172,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     String? sessionToken,
     String? prefix,
     bool? pathStyle,
+    String? userAgent,
     bool? includeChats,
     bool? includeFiles,
   }) async {
@@ -182,6 +193,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
               ? 'kelivo_backups'
               : _s3Prefix.text.trim()),
       pathStyle: pathStyle ?? _s3PathStyle,
+      userAgent: userAgent ?? _s3UserAgent.text.trim(),
       includeChats: includeChats ?? _includeChats,
       includeFiles: includeFiles ?? _includeFiles,
     );
@@ -432,6 +444,22 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                     ),
                     _rowDivider(context),
                     _ItemRow(
+                      label: l10n.backupPageUserAgent,
+                      trailing: SizedBox(
+                        width: 420,
+                        child: TextField(
+                          controller: _webDavUserAgent,
+                          enabled: !busy,
+                          style: const TextStyle(fontSize: 14),
+                          decoration: _deskInputDecoration(
+                            context,
+                          ).copyWith(hintText: l10n.backupPageUserAgentHint),
+                          onChanged: (v) => _applyPartial(userAgent: v),
+                        ),
+                      ),
+                    ),
+                    _rowDivider(context),
+                    _ItemRow(
                       label: l10n.backupPageWebDavBackup,
                       trailing: Wrap(
                         spacing: 8,
@@ -664,6 +692,22 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                             context,
                           ).copyWith(hintText: 'kelivo_backups'),
                           onChanged: (v) => _applyS3Partial(prefix: v),
+                        ),
+                      ),
+                    ),
+                    _rowDivider(context),
+                    _ItemRow(
+                      label: l10n.backupPageUserAgent,
+                      trailing: SizedBox(
+                        width: 420,
+                        child: TextField(
+                          controller: _s3UserAgent,
+                          enabled: !busy,
+                          style: const TextStyle(fontSize: 14),
+                          decoration: _deskInputDecoration(
+                            context,
+                          ).copyWith(hintText: l10n.backupPageUserAgentHint),
+                          onChanged: (v) => _applyS3Partial(userAgent: v),
                         ),
                       ),
                     ),

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -2427,6 +2427,7 @@ class _WebDavSettingsSheetState extends State<_WebDavSettingsSheet> {
   late final TextEditingController _userCtrl;
   late final TextEditingController _passCtrl;
   late final TextEditingController _pathCtrl;
+  late final TextEditingController _userAgentCtrl;
   bool _showPassword = false;
 
   @override
@@ -2438,6 +2439,7 @@ class _WebDavSettingsSheetState extends State<_WebDavSettingsSheet> {
     _pathCtrl = TextEditingController(
       text: widget.cfg.path.isEmpty ? 'kelivo_backups' : widget.cfg.path,
     );
+    _userAgentCtrl = TextEditingController(text: widget.cfg.userAgent);
   }
 
   @override
@@ -2446,6 +2448,7 @@ class _WebDavSettingsSheetState extends State<_WebDavSettingsSheet> {
     _userCtrl.dispose();
     _passCtrl.dispose();
     _pathCtrl.dispose();
+    _userAgentCtrl.dispose();
     super.dispose();
   }
 
@@ -2511,6 +2514,7 @@ class _WebDavSettingsSheetState extends State<_WebDavSettingsSheet> {
                         path: _pathCtrl.text.trim().isEmpty
                             ? 'kelivo_backups'
                             : _pathCtrl.text.trim(),
+                        userAgent: _userAgentCtrl.text.trim(),
                       );
                       await widget.settings.setWebDavConfig(newCfg);
                       widget.vm.updateConfig(newCfg);
@@ -2548,6 +2552,12 @@ class _WebDavSettingsSheetState extends State<_WebDavSettingsSheet> {
                 controller: _pathCtrl,
                 hint: 'kelivo_backups',
               ),
+              const SizedBox(height: 12),
+              _InputRow(
+                label: l10n.backupPageUserAgent,
+                controller: _userAgentCtrl,
+                hint: l10n.backupPageUserAgentHint,
+              ),
               const SizedBox(height: 16),
             ],
           ),
@@ -2580,6 +2590,7 @@ class _S3SettingsSheetState extends State<_S3SettingsSheet> {
   late final TextEditingController _secretKeyCtrl;
   late final TextEditingController _sessionTokenCtrl;
   late final TextEditingController _prefixCtrl;
+  late final TextEditingController _userAgentCtrl;
 
   bool _showSecret = false;
   bool _showToken = false;
@@ -2597,6 +2608,7 @@ class _S3SettingsSheetState extends State<_S3SettingsSheet> {
     _prefixCtrl = TextEditingController(
       text: widget.cfg.prefix.isEmpty ? 'kelivo_backups' : widget.cfg.prefix,
     );
+    _userAgentCtrl = TextEditingController(text: widget.cfg.userAgent);
     _pathStyle = widget.cfg.pathStyle;
   }
 
@@ -2609,6 +2621,7 @@ class _S3SettingsSheetState extends State<_S3SettingsSheet> {
     _secretKeyCtrl.dispose();
     _sessionTokenCtrl.dispose();
     _prefixCtrl.dispose();
+    _userAgentCtrl.dispose();
     super.dispose();
   }
 
@@ -2678,6 +2691,7 @@ class _S3SettingsSheetState extends State<_S3SettingsSheet> {
                             ? 'kelivo_backups'
                             : _prefixCtrl.text.trim(),
                         pathStyle: _pathStyle,
+                        userAgent: _userAgentCtrl.text.trim(),
                       );
                       await widget.settings.setS3Config(newCfg);
                       widget.vm.updateConfig(newCfg);
@@ -2736,6 +2750,12 @@ class _S3SettingsSheetState extends State<_S3SettingsSheet> {
                 label: l10n.backupPageS3Prefix,
                 controller: _prefixCtrl,
                 hint: 'kelivo_backups',
+              ),
+              const SizedBox(height: 12),
+              _InputRow(
+                label: l10n.backupPageUserAgent,
+                controller: _userAgentCtrl,
+                hint: l10n.backupPageUserAgentHint,
               ),
               const SizedBox(height: 12),
               Container(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -668,6 +668,8 @@
   "backupPageS3SessionToken": "Session Token (Optional)",
   "backupPageS3Prefix": "Prefix",
   "backupPageS3PathStyle": "Path-style addressing",
+  "backupPageUserAgent": "User-Agent",
+  "backupPageUserAgentHint": "Optional",
   "backupPageSave": "Save",
   "backupPageBackupNow": "Backup Now",
   "backupPageLocalBackup": "Local Backup",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3179,6 +3179,18 @@ abstract class AppLocalizations {
   /// **'Path-style addressing'**
   String get backupPageS3PathStyle;
 
+  /// No description provided for @backupPageUserAgent.
+  ///
+  /// In en, this message translates to:
+  /// **'User-Agent'**
+  String get backupPageUserAgent;
+
+  /// No description provided for @backupPageUserAgentHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional'**
+  String get backupPageUserAgentHint;
+
   /// No description provided for @backupPageSave.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1651,6 +1651,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupPageS3PathStyle => 'Path-style addressing';
 
   @override
+  String get backupPageUserAgent => 'User-Agent';
+
+  @override
+  String get backupPageUserAgentHint => 'Optional';
+
+  @override
   String get backupPageSave => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1598,6 +1598,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backupPageS3PathStyle => '路径风格（Path-style）';
 
   @override
+  String get backupPageUserAgent => 'User-Agent';
+
+  @override
+  String get backupPageUserAgentHint => '可选';
+
+  @override
   String get backupPageSave => '保存';
 
   @override
@@ -6799,6 +6805,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get backupPageS3PathStyle => '路径风格（Path-style）';
 
   @override
+  String get backupPageUserAgent => 'User-Agent';
+
+  @override
+  String get backupPageUserAgentHint => '可选';
+
+  @override
   String get backupPageSave => '保存';
 
   @override
@@ -11998,6 +12010,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get backupPageS3PathStyle => '路徑風格（Path-style）';
+
+  @override
+  String get backupPageUserAgent => 'User-Agent';
+
+  @override
+  String get backupPageUserAgentHint => '可選';
 
   @override
   String get backupPageSave => '儲存';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -529,6 +529,8 @@
   "backupPageS3SessionToken": "Session Token（可选）",
   "backupPageS3Prefix": "前缀（目录）",
   "backupPageS3PathStyle": "路径风格（Path-style）",
+  "backupPageUserAgent": "User-Agent",
+  "backupPageUserAgentHint": "可选",
   "backupPageSave": "保存",
   "backupPageBackupNow": "立即备份",
   "backupPageLocalBackup": "本地备份",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -573,6 +573,8 @@
   "backupPageS3SessionToken": "Session Token（可选）",
   "backupPageS3Prefix": "前缀（目录）",
   "backupPageS3PathStyle": "路径风格（Path-style）",
+  "backupPageUserAgent": "User-Agent",
+  "backupPageUserAgentHint": "可选",
   "backupPageSave": "保存",
   "backupPageBackupNow": "立即备份",
   "backupPageLocalBackup": "本地备份",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -540,6 +540,8 @@
   "backupPageS3SessionToken": "Session Token（可選）",
   "backupPageS3Prefix": "前綴（目錄）",
   "backupPageS3PathStyle": "路徑風格（Path-style）",
+  "backupPageUserAgent": "User-Agent",
+  "backupPageUserAgentHint": "可選",
   "backupPageSave": "儲存",
   "backupPageBackupNow": "立即備份",
   "backupPageLocalBackup": "本機備份",


### PR DESCRIPTION
在 WebDAV 和 S3 备份设置中新增可选的 User-Agent 请求头配置，支持自定义 HTTP User-Agent。