### PR TITLE
feat: 移动端消息导航按钮支持始终显示/滚动时显示/永不显示三模式

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -38,6 +38,9 @@ enum DesktopMessageNavButtonsMode {
   never,
 }
 
+// Mobile: message navigation buttons visibility mode
+enum MobileMessageNavButtonsMode { always, scroll, never }
+
 enum _MigrationResult { noChange, applied, failed }
 
 class SettingsProvider extends ChangeNotifier {
@@ -127,6 +130,8 @@ class SettingsProvider extends ChangeNotifier {
   static const String _displayShowMessageNavKey = 'display_show_message_nav_v1';
   static const String _displayDesktopMessageNavButtonsModeKey =
       'display_desktop_message_nav_buttons_mode_v1';
+  static const String _displayMobileMessageNavButtonsModeKey =
+      'display_mobile_message_nav_buttons_mode_v1';
   static const String _displayUseNewAssistantAvatarUxKey =
       'display_use_new_assistant_avatar_ux_v1';
   static const String _displayShowProviderInModelCapsuleKey =
@@ -856,6 +861,10 @@ class SettingsProvider extends ChangeNotifier {
     _showRegenerateConfirmDialog =
         prefs.getBool(_displayShowRegenerateConfirmDialogKey) ?? true;
     _showMessageNavButtons = prefs.getBool(_displayShowMessageNavKey) ?? true;
+    _mobileMessageNavButtonsMode = _parseMobileMessageNavButtonsMode(
+      prefs.getString(_displayMobileMessageNavButtonsModeKey),
+      legacyEnabled: _showMessageNavButtons,
+    );
     _desktopMessageNavButtonsMode = _parseDesktopMessageNavButtonsMode(
       prefs.getString(_displayDesktopMessageNavButtonsModeKey),
       legacyEnabled: _showMessageNavButtons,
@@ -3351,6 +3360,56 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     }
   }
 
+  // Mobile: message navigation buttons visibility mode
+  MobileMessageNavButtonsMode _mobileMessageNavButtonsMode =
+      MobileMessageNavButtonsMode.scroll;
+  MobileMessageNavButtonsMode get mobileMessageNavButtonsMode =>
+      _mobileMessageNavButtonsMode;
+
+  Future<void> setMobileMessageNavButtonsMode(
+    MobileMessageNavButtonsMode mode,
+  ) async {
+    if (_mobileMessageNavButtonsMode == mode) return;
+    _mobileMessageNavButtonsMode = mode;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _displayMobileMessageNavButtonsModeKey,
+      _mobileMessageNavButtonsModeToString(mode),
+    );
+  }
+
+  MobileMessageNavButtonsMode _parseMobileMessageNavButtonsMode(
+    String? raw, {
+    required bool legacyEnabled,
+  }) {
+    switch (raw) {
+      case 'always':
+        return MobileMessageNavButtonsMode.always;
+      case 'scroll':
+        return MobileMessageNavButtonsMode.scroll;
+      case 'never':
+        return MobileMessageNavButtonsMode.never;
+      default:
+        return legacyEnabled
+            ? MobileMessageNavButtonsMode.scroll
+            : MobileMessageNavButtonsMode.never;
+    }
+  }
+
+  String _mobileMessageNavButtonsModeToString(
+    MobileMessageNavButtonsMode mode,
+  ) {
+    switch (mode) {
+      case MobileMessageNavButtonsMode.always:
+        return 'always';
+      case MobileMessageNavButtonsMode.scroll:
+        return 'scroll';
+      case MobileMessageNavButtonsMode.never:
+        return 'never';
+    }
+  }
+
   // Display: chat font scale (0.5 - 1.5, default 1.0)
   double _chatFontScale = 1.0;
   double get chatFontScale => _chatFontScale;
@@ -3871,6 +3930,7 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     copy._regenerateDeleteTrailingMessages = _regenerateDeleteTrailingMessages;
     copy._showRegenerateConfirmDialog = _showRegenerateConfirmDialog;
     copy._showMessageNavButtons = _showMessageNavButtons;
+    copy._mobileMessageNavButtonsMode = _mobileMessageNavButtonsMode;
     copy._useNewAssistantAvatarUx = _useNewAssistantAvatarUx;
     copy._showProviderInModelCapsule = _showProviderInModelCapsule;
     copy._showProviderInChatMessage = _showProviderInChatMessage;

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1321,8 +1321,15 @@ class _HomePageState extends State<HomePage>
               return const SizedBox.shrink();
           }
         } else {
-          if (!settings.showMessageNavButtons) {
-            return const SizedBox.shrink();
+          switch (settings.mobileMessageNavButtonsMode) {
+            case MobileMessageNavButtonsMode.always:
+              visible = true;
+              break;
+            case MobileMessageNavButtonsMode.scroll:
+              visible = _controller.scrollCtrl.showNavButtons;
+              break;
+            case MobileMessageNavButtonsMode.never:
+              return const SizedBox.shrink();
           }
         }
         return ScrollNavButtonsPanel(

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -1495,6 +1495,51 @@ Widget _sheetDividerNoIcon(BuildContext context) {
   );
 }
 
+Future<void> _showMobileMessageNavModeSheet(BuildContext context) async {
+  final cs = Theme.of(context).colorScheme;
+  final l10n = AppLocalizations.of(context)!;
+  final choice = await showModalBottomSheet<MobileMessageNavButtonsMode>(
+    context: context,
+    backgroundColor: cs.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _sheetOption(
+              ctx,
+              label: l10n.displaySettingsPageMessageNavButtonsModeAlways,
+              onTap: () =>
+                  Navigator.of(ctx).pop(MobileMessageNavButtonsMode.always),
+            ),
+            _sheetDividerNoIcon(ctx),
+            _sheetOption(
+              ctx,
+              label: l10n.displaySettingsPageMessageNavButtonsModeScroll,
+              onTap: () =>
+                  Navigator.of(ctx).pop(MobileMessageNavButtonsMode.scroll),
+            ),
+            _sheetDividerNoIcon(ctx),
+            _sheetOption(
+              ctx,
+              label: l10n.displaySettingsPageMessageNavButtonsModeNever,
+              onTap: () =>
+                  Navigator.of(ctx).pop(MobileMessageNavButtonsMode.never),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  if (choice == null) return;
+  if (!context.mounted) return;
+  await context.read<SettingsProvider>().setMobileMessageNavButtonsMode(choice);
+}
+
 // --- Subpages ---
 
 class ChatItemDisplaySettingsPage extends StatelessWidget {
@@ -1950,14 +1995,20 @@ class BehaviorStartupSettingsPage extends StatelessWidget {
                     context.read<SettingsProvider>().setShowAppUpdates(v),
               ),
               _iosDivider(context),
-              _iosSwitchRow(
+              _iosNavRow(
                 context,
                 icon: Lucide.ChevronRight,
                 label: l10n.displaySettingsPageMessageNavButtonsTitle,
-                value: sp.showMessageNavButtons,
-                onChanged: (v) => context
-                    .read<SettingsProvider>()
-                    .setShowMessageNavButtons(v),
+                detailBuilder: (_) =>
+                    Text(switch (sp.mobileMessageNavButtonsMode) {
+                      MobileMessageNavButtonsMode.always =>
+                        l10n.displaySettingsPageMessageNavButtonsModeAlways,
+                      MobileMessageNavButtonsMode.scroll =>
+                        l10n.displaySettingsPageMessageNavButtonsModeScroll,
+                      MobileMessageNavButtonsMode.never =>
+                        l10n.displaySettingsPageMessageNavButtonsModeNever,
+                    }),
+                onTap: () => _showMobileMessageNavModeSheet(context),
               ),
               _iosDivider(context),
               _iosSwitchRow(


### PR DESCRIPTION
移动端消息导航按钮支持始终显示/滚动时显示/永不显示三模式，不再只是开/关。和桌面端体验对齐。