### PR TITLE
feat: migrate chat data storage from Hive to SQLite (drift)

### DIFF
--- a/lib/core/database/kelivo_database.dart
+++ b/lib/core/database/kelivo_database.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import '../../utils/app_directories.dart';
+
+part 'kelivo_database.g.dart';
+
+// ── Tables ──────────────────────────────────────────────────────────────────
+
+@DataClassName('ConversationRow')
+class Conversations extends Table {
+  TextColumn get id => text()();
+  TextColumn get title => text()();
+  IntColumn get createdAt => integer()();
+  IntColumn get updatedAt => integer()();
+  TextColumn get messageIds => text()();
+  BoolColumn get isPinned => boolean().withDefault(const Constant(false))();
+  TextColumn get mcpServerIds => text()();
+  TextColumn? get assistantId => text().nullable()();
+  IntColumn get truncateIndex => integer().withDefault(const Constant(-1))();
+  TextColumn get versionSelections => text()();
+  TextColumn? get summary => text().nullable()();
+  IntColumn get lastSummarizedMessageCount =>
+      integer().withDefault(const Constant(0))();
+  TextColumn get chatSuggestions => text()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('MessageRow')
+class Messages extends Table {
+  TextColumn get id => text()();
+  TextColumn get role => text()();
+  TextColumn get content => text()();
+  IntColumn get timestamp => integer()();
+  TextColumn? get modelId => text().nullable()();
+  TextColumn? get providerId => text().nullable()();
+  IntColumn? get totalTokens => integer().nullable()();
+  TextColumn get conversationId =>
+      text().references(Conversations, #id, onDelete: KeyAction.cascade)();
+  BoolColumn get isStreaming => boolean().withDefault(const Constant(false))();
+  TextColumn? get reasoningText => text().nullable()();
+  IntColumn? get reasoningStartAt => integer().nullable()();
+  IntColumn? get reasoningFinishedAt => integer().nullable()();
+  TextColumn? get translation => text().nullable()();
+  TextColumn? get reasoningSegmentsJson => text().nullable()();
+  TextColumn? get groupId => text().nullable()();
+  IntColumn get version => integer().withDefault(const Constant(0))();
+  IntColumn? get promptTokens => integer().nullable()();
+  IntColumn? get completionTokens => integer().nullable()();
+  IntColumn? get cachedTokens => integer().nullable()();
+  IntColumn? get durationMs => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('ToolEventRow')
+class ToolEvents extends Table {
+  TextColumn get messageId =>
+      text().references(Messages, #id, onDelete: KeyAction.cascade)();
+  TextColumn get data => text()();
+  TextColumn? get geminiThoughtSig => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {messageId};
+}
+
+@DataClassName('MigrationMetaRow')
+class MigrationMeta extends Table {
+  TextColumn get key => text()();
+  TextColumn get value => text()();
+
+  @override
+  Set<Column> get primaryKey => {key};
+}
+
+// ── Database ───────────────────────────────────────────────────────────────
+
+@DriftDatabase(tables: [Conversations, Messages, ToolEvents, MigrationMeta])
+class KelivoDatabase extends _$KelivoDatabase {
+  KelivoDatabase() : super(_openConnection());
+
+  KelivoDatabase.forTesting(super.executor);
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator m) async {
+      await m.createAll();
+    },
+    beforeOpen: (details) async {
+      await customStatement('PRAGMA journal_mode = WAL');
+      await customStatement('PRAGMA foreign_keys = ON');
+    },
+  );
+
+  Future<bool> migrationCompleted() async {
+    final rows =
+        await (selectOnly(migrationMeta)
+              ..addColumns([migrationMeta.value])
+              ..where(migrationMeta.key.equals('migration_version')))
+            .get();
+    if (rows.isEmpty) return false;
+    final val = rows.first.read<String>(migrationMeta.value);
+    return val == '1';
+  }
+
+  Future<void> markMigrationCompleted() async {
+    await into(migrationMeta).insert(
+      MigrationMetaCompanion.insert(key: 'migration_version', value: '1'),
+      mode: InsertMode.replace,
+    );
+  }
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dir = await AppDirectories.getAppDataDirectory();
+    final file = File(p.join(dir.path, 'kelivo.sqlite'));
+    return NativeDatabase(file);
+  });
+}

--- a/lib/core/database/kelivo_database.g.dart
+++ b/lib/core/database/kelivo_database.g.dart
@@ -1,0 +1,4135 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'kelivo_database.dart';
+
+// ignore_for_file: type=lint
+class $ConversationsTable extends Conversations
+    with TableInfo<$ConversationsTable, ConversationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ConversationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _messageIdsMeta = const VerificationMeta(
+    'messageIds',
+  );
+  @override
+  late final GeneratedColumn<String> messageIds = GeneratedColumn<String>(
+    'message_ids',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _isPinnedMeta = const VerificationMeta(
+    'isPinned',
+  );
+  @override
+  late final GeneratedColumn<bool> isPinned = GeneratedColumn<bool>(
+    'is_pinned',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_pinned" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _mcpServerIdsMeta = const VerificationMeta(
+    'mcpServerIds',
+  );
+  @override
+  late final GeneratedColumn<String> mcpServerIds = GeneratedColumn<String>(
+    'mcp_server_ids',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _assistantIdMeta = const VerificationMeta(
+    'assistantId',
+  );
+  @override
+  late final GeneratedColumn<String> assistantId = GeneratedColumn<String>(
+    'assistant_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _truncateIndexMeta = const VerificationMeta(
+    'truncateIndex',
+  );
+  @override
+  late final GeneratedColumn<int> truncateIndex = GeneratedColumn<int>(
+    'truncate_index',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(-1),
+  );
+  static const VerificationMeta _versionSelectionsMeta = const VerificationMeta(
+    'versionSelections',
+  );
+  @override
+  late final GeneratedColumn<String> versionSelections =
+      GeneratedColumn<String>(
+        'version_selections',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _summaryMeta = const VerificationMeta(
+    'summary',
+  );
+  @override
+  late final GeneratedColumn<String> summary = GeneratedColumn<String>(
+    'summary',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastSummarizedMessageCountMeta =
+      const VerificationMeta('lastSummarizedMessageCount');
+  @override
+  late final GeneratedColumn<int> lastSummarizedMessageCount =
+      GeneratedColumn<int>(
+        'last_summarized_message_count',
+        aliasedName,
+        false,
+        type: DriftSqlType.int,
+        requiredDuringInsert: false,
+        defaultValue: const Constant(0),
+      );
+  static const VerificationMeta _chatSuggestionsMeta = const VerificationMeta(
+    'chatSuggestions',
+  );
+  @override
+  late final GeneratedColumn<String> chatSuggestions = GeneratedColumn<String>(
+    'chat_suggestions',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    title,
+    createdAt,
+    updatedAt,
+    messageIds,
+    isPinned,
+    mcpServerIds,
+    assistantId,
+    truncateIndex,
+    versionSelections,
+    summary,
+    lastSummarizedMessageCount,
+    chatSuggestions,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'conversations';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ConversationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('message_ids')) {
+      context.handle(
+        _messageIdsMeta,
+        messageIds.isAcceptableOrUnknown(data['message_ids']!, _messageIdsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_messageIdsMeta);
+    }
+    if (data.containsKey('is_pinned')) {
+      context.handle(
+        _isPinnedMeta,
+        isPinned.isAcceptableOrUnknown(data['is_pinned']!, _isPinnedMeta),
+      );
+    }
+    if (data.containsKey('mcp_server_ids')) {
+      context.handle(
+        _mcpServerIdsMeta,
+        mcpServerIds.isAcceptableOrUnknown(
+          data['mcp_server_ids']!,
+          _mcpServerIdsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_mcpServerIdsMeta);
+    }
+    if (data.containsKey('assistant_id')) {
+      context.handle(
+        _assistantIdMeta,
+        assistantId.isAcceptableOrUnknown(
+          data['assistant_id']!,
+          _assistantIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('truncate_index')) {
+      context.handle(
+        _truncateIndexMeta,
+        truncateIndex.isAcceptableOrUnknown(
+          data['truncate_index']!,
+          _truncateIndexMeta,
+        ),
+      );
+    }
+    if (data.containsKey('version_selections')) {
+      context.handle(
+        _versionSelectionsMeta,
+        versionSelections.isAcceptableOrUnknown(
+          data['version_selections']!,
+          _versionSelectionsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_versionSelectionsMeta);
+    }
+    if (data.containsKey('summary')) {
+      context.handle(
+        _summaryMeta,
+        summary.isAcceptableOrUnknown(data['summary']!, _summaryMeta),
+      );
+    }
+    if (data.containsKey('last_summarized_message_count')) {
+      context.handle(
+        _lastSummarizedMessageCountMeta,
+        lastSummarizedMessageCount.isAcceptableOrUnknown(
+          data['last_summarized_message_count']!,
+          _lastSummarizedMessageCountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('chat_suggestions')) {
+      context.handle(
+        _chatSuggestionsMeta,
+        chatSuggestions.isAcceptableOrUnknown(
+          data['chat_suggestions']!,
+          _chatSuggestionsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_chatSuggestionsMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ConversationRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ConversationRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      messageIds: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}message_ids'],
+      )!,
+      isPinned: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_pinned'],
+      )!,
+      mcpServerIds: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}mcp_server_ids'],
+      )!,
+      assistantId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}assistant_id'],
+      ),
+      truncateIndex: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}truncate_index'],
+      )!,
+      versionSelections: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}version_selections'],
+      )!,
+      summary: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}summary'],
+      ),
+      lastSummarizedMessageCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_summarized_message_count'],
+      )!,
+      chatSuggestions: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}chat_suggestions'],
+      )!,
+    );
+  }
+
+  @override
+  $ConversationsTable createAlias(String alias) {
+    return $ConversationsTable(attachedDatabase, alias);
+  }
+}
+
+class ConversationRow extends DataClass implements Insertable<ConversationRow> {
+  final String id;
+  final String title;
+  final int createdAt;
+  final int updatedAt;
+  final String messageIds;
+  final bool isPinned;
+  final String mcpServerIds;
+  final String? assistantId;
+  final int truncateIndex;
+  final String versionSelections;
+  final String? summary;
+  final int lastSummarizedMessageCount;
+  final String chatSuggestions;
+  const ConversationRow({
+    required this.id,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.messageIds,
+    required this.isPinned,
+    required this.mcpServerIds,
+    this.assistantId,
+    required this.truncateIndex,
+    required this.versionSelections,
+    this.summary,
+    required this.lastSummarizedMessageCount,
+    required this.chatSuggestions,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['title'] = Variable<String>(title);
+    map['created_at'] = Variable<int>(createdAt);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['message_ids'] = Variable<String>(messageIds);
+    map['is_pinned'] = Variable<bool>(isPinned);
+    map['mcp_server_ids'] = Variable<String>(mcpServerIds);
+    if (!nullToAbsent || assistantId != null) {
+      map['assistant_id'] = Variable<String>(assistantId);
+    }
+    map['truncate_index'] = Variable<int>(truncateIndex);
+    map['version_selections'] = Variable<String>(versionSelections);
+    if (!nullToAbsent || summary != null) {
+      map['summary'] = Variable<String>(summary);
+    }
+    map['last_summarized_message_count'] = Variable<int>(
+      lastSummarizedMessageCount,
+    );
+    map['chat_suggestions'] = Variable<String>(chatSuggestions);
+    return map;
+  }
+
+  ConversationsCompanion toCompanion(bool nullToAbsent) {
+    return ConversationsCompanion(
+      id: Value(id),
+      title: Value(title),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      messageIds: Value(messageIds),
+      isPinned: Value(isPinned),
+      mcpServerIds: Value(mcpServerIds),
+      assistantId: assistantId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(assistantId),
+      truncateIndex: Value(truncateIndex),
+      versionSelections: Value(versionSelections),
+      summary: summary == null && nullToAbsent
+          ? const Value.absent()
+          : Value(summary),
+      lastSummarizedMessageCount: Value(lastSummarizedMessageCount),
+      chatSuggestions: Value(chatSuggestions),
+    );
+  }
+
+  factory ConversationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ConversationRow(
+      id: serializer.fromJson<String>(json['id']),
+      title: serializer.fromJson<String>(json['title']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      messageIds: serializer.fromJson<String>(json['messageIds']),
+      isPinned: serializer.fromJson<bool>(json['isPinned']),
+      mcpServerIds: serializer.fromJson<String>(json['mcpServerIds']),
+      assistantId: serializer.fromJson<String?>(json['assistantId']),
+      truncateIndex: serializer.fromJson<int>(json['truncateIndex']),
+      versionSelections: serializer.fromJson<String>(json['versionSelections']),
+      summary: serializer.fromJson<String?>(json['summary']),
+      lastSummarizedMessageCount: serializer.fromJson<int>(
+        json['lastSummarizedMessageCount'],
+      ),
+      chatSuggestions: serializer.fromJson<String>(json['chatSuggestions']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'title': serializer.toJson<String>(title),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'messageIds': serializer.toJson<String>(messageIds),
+      'isPinned': serializer.toJson<bool>(isPinned),
+      'mcpServerIds': serializer.toJson<String>(mcpServerIds),
+      'assistantId': serializer.toJson<String?>(assistantId),
+      'truncateIndex': serializer.toJson<int>(truncateIndex),
+      'versionSelections': serializer.toJson<String>(versionSelections),
+      'summary': serializer.toJson<String?>(summary),
+      'lastSummarizedMessageCount': serializer.toJson<int>(
+        lastSummarizedMessageCount,
+      ),
+      'chatSuggestions': serializer.toJson<String>(chatSuggestions),
+    };
+  }
+
+  ConversationRow copyWith({
+    String? id,
+    String? title,
+    int? createdAt,
+    int? updatedAt,
+    String? messageIds,
+    bool? isPinned,
+    String? mcpServerIds,
+    Value<String?> assistantId = const Value.absent(),
+    int? truncateIndex,
+    String? versionSelections,
+    Value<String?> summary = const Value.absent(),
+    int? lastSummarizedMessageCount,
+    String? chatSuggestions,
+  }) => ConversationRow(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    messageIds: messageIds ?? this.messageIds,
+    isPinned: isPinned ?? this.isPinned,
+    mcpServerIds: mcpServerIds ?? this.mcpServerIds,
+    assistantId: assistantId.present ? assistantId.value : this.assistantId,
+    truncateIndex: truncateIndex ?? this.truncateIndex,
+    versionSelections: versionSelections ?? this.versionSelections,
+    summary: summary.present ? summary.value : this.summary,
+    lastSummarizedMessageCount:
+        lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
+    chatSuggestions: chatSuggestions ?? this.chatSuggestions,
+  );
+  ConversationRow copyWithCompanion(ConversationsCompanion data) {
+    return ConversationRow(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      messageIds: data.messageIds.present
+          ? data.messageIds.value
+          : this.messageIds,
+      isPinned: data.isPinned.present ? data.isPinned.value : this.isPinned,
+      mcpServerIds: data.mcpServerIds.present
+          ? data.mcpServerIds.value
+          : this.mcpServerIds,
+      assistantId: data.assistantId.present
+          ? data.assistantId.value
+          : this.assistantId,
+      truncateIndex: data.truncateIndex.present
+          ? data.truncateIndex.value
+          : this.truncateIndex,
+      versionSelections: data.versionSelections.present
+          ? data.versionSelections.value
+          : this.versionSelections,
+      summary: data.summary.present ? data.summary.value : this.summary,
+      lastSummarizedMessageCount: data.lastSummarizedMessageCount.present
+          ? data.lastSummarizedMessageCount.value
+          : this.lastSummarizedMessageCount,
+      chatSuggestions: data.chatSuggestions.present
+          ? data.chatSuggestions.value
+          : this.chatSuggestions,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ConversationRow(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('messageIds: $messageIds, ')
+          ..write('isPinned: $isPinned, ')
+          ..write('mcpServerIds: $mcpServerIds, ')
+          ..write('assistantId: $assistantId, ')
+          ..write('truncateIndex: $truncateIndex, ')
+          ..write('versionSelections: $versionSelections, ')
+          ..write('summary: $summary, ')
+          ..write('lastSummarizedMessageCount: $lastSummarizedMessageCount, ')
+          ..write('chatSuggestions: $chatSuggestions')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    title,
+    createdAt,
+    updatedAt,
+    messageIds,
+    isPinned,
+    mcpServerIds,
+    assistantId,
+    truncateIndex,
+    versionSelections,
+    summary,
+    lastSummarizedMessageCount,
+    chatSuggestions,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ConversationRow &&
+          other.id == this.id &&
+          other.title == this.title &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.messageIds == this.messageIds &&
+          other.isPinned == this.isPinned &&
+          other.mcpServerIds == this.mcpServerIds &&
+          other.assistantId == this.assistantId &&
+          other.truncateIndex == this.truncateIndex &&
+          other.versionSelections == this.versionSelections &&
+          other.summary == this.summary &&
+          other.lastSummarizedMessageCount == this.lastSummarizedMessageCount &&
+          other.chatSuggestions == this.chatSuggestions);
+}
+
+class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
+  final Value<String> id;
+  final Value<String> title;
+  final Value<int> createdAt;
+  final Value<int> updatedAt;
+  final Value<String> messageIds;
+  final Value<bool> isPinned;
+  final Value<String> mcpServerIds;
+  final Value<String?> assistantId;
+  final Value<int> truncateIndex;
+  final Value<String> versionSelections;
+  final Value<String?> summary;
+  final Value<int> lastSummarizedMessageCount;
+  final Value<String> chatSuggestions;
+  final Value<int> rowid;
+  const ConversationsCompanion({
+    this.id = const Value.absent(),
+    this.title = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.messageIds = const Value.absent(),
+    this.isPinned = const Value.absent(),
+    this.mcpServerIds = const Value.absent(),
+    this.assistantId = const Value.absent(),
+    this.truncateIndex = const Value.absent(),
+    this.versionSelections = const Value.absent(),
+    this.summary = const Value.absent(),
+    this.lastSummarizedMessageCount = const Value.absent(),
+    this.chatSuggestions = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ConversationsCompanion.insert({
+    required String id,
+    required String title,
+    required int createdAt,
+    required int updatedAt,
+    required String messageIds,
+    this.isPinned = const Value.absent(),
+    required String mcpServerIds,
+    this.assistantId = const Value.absent(),
+    this.truncateIndex = const Value.absent(),
+    required String versionSelections,
+    this.summary = const Value.absent(),
+    this.lastSummarizedMessageCount = const Value.absent(),
+    required String chatSuggestions,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       title = Value(title),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt),
+       messageIds = Value(messageIds),
+       mcpServerIds = Value(mcpServerIds),
+       versionSelections = Value(versionSelections),
+       chatSuggestions = Value(chatSuggestions);
+  static Insertable<ConversationRow> custom({
+    Expression<String>? id,
+    Expression<String>? title,
+    Expression<int>? createdAt,
+    Expression<int>? updatedAt,
+    Expression<String>? messageIds,
+    Expression<bool>? isPinned,
+    Expression<String>? mcpServerIds,
+    Expression<String>? assistantId,
+    Expression<int>? truncateIndex,
+    Expression<String>? versionSelections,
+    Expression<String>? summary,
+    Expression<int>? lastSummarizedMessageCount,
+    Expression<String>? chatSuggestions,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (title != null) 'title': title,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (messageIds != null) 'message_ids': messageIds,
+      if (isPinned != null) 'is_pinned': isPinned,
+      if (mcpServerIds != null) 'mcp_server_ids': mcpServerIds,
+      if (assistantId != null) 'assistant_id': assistantId,
+      if (truncateIndex != null) 'truncate_index': truncateIndex,
+      if (versionSelections != null) 'version_selections': versionSelections,
+      if (summary != null) 'summary': summary,
+      if (lastSummarizedMessageCount != null)
+        'last_summarized_message_count': lastSummarizedMessageCount,
+      if (chatSuggestions != null) 'chat_suggestions': chatSuggestions,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ConversationsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? title,
+    Value<int>? createdAt,
+    Value<int>? updatedAt,
+    Value<String>? messageIds,
+    Value<bool>? isPinned,
+    Value<String>? mcpServerIds,
+    Value<String?>? assistantId,
+    Value<int>? truncateIndex,
+    Value<String>? versionSelections,
+    Value<String?>? summary,
+    Value<int>? lastSummarizedMessageCount,
+    Value<String>? chatSuggestions,
+    Value<int>? rowid,
+  }) {
+    return ConversationsCompanion(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      messageIds: messageIds ?? this.messageIds,
+      isPinned: isPinned ?? this.isPinned,
+      mcpServerIds: mcpServerIds ?? this.mcpServerIds,
+      assistantId: assistantId ?? this.assistantId,
+      truncateIndex: truncateIndex ?? this.truncateIndex,
+      versionSelections: versionSelections ?? this.versionSelections,
+      summary: summary ?? this.summary,
+      lastSummarizedMessageCount:
+          lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
+      chatSuggestions: chatSuggestions ?? this.chatSuggestions,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (messageIds.present) {
+      map['message_ids'] = Variable<String>(messageIds.value);
+    }
+    if (isPinned.present) {
+      map['is_pinned'] = Variable<bool>(isPinned.value);
+    }
+    if (mcpServerIds.present) {
+      map['mcp_server_ids'] = Variable<String>(mcpServerIds.value);
+    }
+    if (assistantId.present) {
+      map['assistant_id'] = Variable<String>(assistantId.value);
+    }
+    if (truncateIndex.present) {
+      map['truncate_index'] = Variable<int>(truncateIndex.value);
+    }
+    if (versionSelections.present) {
+      map['version_selections'] = Variable<String>(versionSelections.value);
+    }
+    if (summary.present) {
+      map['summary'] = Variable<String>(summary.value);
+    }
+    if (lastSummarizedMessageCount.present) {
+      map['last_summarized_message_count'] = Variable<int>(
+        lastSummarizedMessageCount.value,
+      );
+    }
+    if (chatSuggestions.present) {
+      map['chat_suggestions'] = Variable<String>(chatSuggestions.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ConversationsCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('messageIds: $messageIds, ')
+          ..write('isPinned: $isPinned, ')
+          ..write('mcpServerIds: $mcpServerIds, ')
+          ..write('assistantId: $assistantId, ')
+          ..write('truncateIndex: $truncateIndex, ')
+          ..write('versionSelections: $versionSelections, ')
+          ..write('summary: $summary, ')
+          ..write('lastSummarizedMessageCount: $lastSummarizedMessageCount, ')
+          ..write('chatSuggestions: $chatSuggestions, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $MessagesTable extends Messages
+    with TableInfo<$MessagesTable, MessageRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $MessagesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _roleMeta = const VerificationMeta('role');
+  @override
+  late final GeneratedColumn<String> role = GeneratedColumn<String>(
+    'role',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _contentMeta = const VerificationMeta(
+    'content',
+  );
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+    'content',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<int> timestamp = GeneratedColumn<int>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _modelIdMeta = const VerificationMeta(
+    'modelId',
+  );
+  @override
+  late final GeneratedColumn<String> modelId = GeneratedColumn<String>(
+    'model_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _providerIdMeta = const VerificationMeta(
+    'providerId',
+  );
+  @override
+  late final GeneratedColumn<String> providerId = GeneratedColumn<String>(
+    'provider_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _totalTokensMeta = const VerificationMeta(
+    'totalTokens',
+  );
+  @override
+  late final GeneratedColumn<int> totalTokens = GeneratedColumn<int>(
+    'total_tokens',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _conversationIdMeta = const VerificationMeta(
+    'conversationId',
+  );
+  @override
+  late final GeneratedColumn<String> conversationId = GeneratedColumn<String>(
+    'conversation_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES conversations (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _isStreamingMeta = const VerificationMeta(
+    'isStreaming',
+  );
+  @override
+  late final GeneratedColumn<bool> isStreaming = GeneratedColumn<bool>(
+    'is_streaming',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_streaming" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _reasoningTextMeta = const VerificationMeta(
+    'reasoningText',
+  );
+  @override
+  late final GeneratedColumn<String> reasoningText = GeneratedColumn<String>(
+    'reasoning_text',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _reasoningStartAtMeta = const VerificationMeta(
+    'reasoningStartAt',
+  );
+  @override
+  late final GeneratedColumn<int> reasoningStartAt = GeneratedColumn<int>(
+    'reasoning_start_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _reasoningFinishedAtMeta =
+      const VerificationMeta('reasoningFinishedAt');
+  @override
+  late final GeneratedColumn<int> reasoningFinishedAt = GeneratedColumn<int>(
+    'reasoning_finished_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _translationMeta = const VerificationMeta(
+    'translation',
+  );
+  @override
+  late final GeneratedColumn<String> translation = GeneratedColumn<String>(
+    'translation',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _reasoningSegmentsJsonMeta =
+      const VerificationMeta('reasoningSegmentsJson');
+  @override
+  late final GeneratedColumn<String> reasoningSegmentsJson =
+      GeneratedColumn<String>(
+        'reasoning_segments_json',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _groupIdMeta = const VerificationMeta(
+    'groupId',
+  );
+  @override
+  late final GeneratedColumn<String> groupId = GeneratedColumn<String>(
+    'group_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _versionMeta = const VerificationMeta(
+    'version',
+  );
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+    'version',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _promptTokensMeta = const VerificationMeta(
+    'promptTokens',
+  );
+  @override
+  late final GeneratedColumn<int> promptTokens = GeneratedColumn<int>(
+    'prompt_tokens',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _completionTokensMeta = const VerificationMeta(
+    'completionTokens',
+  );
+  @override
+  late final GeneratedColumn<int> completionTokens = GeneratedColumn<int>(
+    'completion_tokens',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _cachedTokensMeta = const VerificationMeta(
+    'cachedTokens',
+  );
+  @override
+  late final GeneratedColumn<int> cachedTokens = GeneratedColumn<int>(
+    'cached_tokens',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _durationMsMeta = const VerificationMeta(
+    'durationMs',
+  );
+  @override
+  late final GeneratedColumn<int> durationMs = GeneratedColumn<int>(
+    'duration_ms',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    role,
+    content,
+    timestamp,
+    modelId,
+    providerId,
+    totalTokens,
+    conversationId,
+    isStreaming,
+    reasoningText,
+    reasoningStartAt,
+    reasoningFinishedAt,
+    translation,
+    reasoningSegmentsJson,
+    groupId,
+    version,
+    promptTokens,
+    completionTokens,
+    cachedTokens,
+    durationMs,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'messages';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<MessageRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('role')) {
+      context.handle(
+        _roleMeta,
+        role.isAcceptableOrUnknown(data['role']!, _roleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_roleMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(
+        _contentMeta,
+        content.isAcceptableOrUnknown(data['content']!, _contentMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('model_id')) {
+      context.handle(
+        _modelIdMeta,
+        modelId.isAcceptableOrUnknown(data['model_id']!, _modelIdMeta),
+      );
+    }
+    if (data.containsKey('provider_id')) {
+      context.handle(
+        _providerIdMeta,
+        providerId.isAcceptableOrUnknown(data['provider_id']!, _providerIdMeta),
+      );
+    }
+    if (data.containsKey('total_tokens')) {
+      context.handle(
+        _totalTokensMeta,
+        totalTokens.isAcceptableOrUnknown(
+          data['total_tokens']!,
+          _totalTokensMeta,
+        ),
+      );
+    }
+    if (data.containsKey('conversation_id')) {
+      context.handle(
+        _conversationIdMeta,
+        conversationId.isAcceptableOrUnknown(
+          data['conversation_id']!,
+          _conversationIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_conversationIdMeta);
+    }
+    if (data.containsKey('is_streaming')) {
+      context.handle(
+        _isStreamingMeta,
+        isStreaming.isAcceptableOrUnknown(
+          data['is_streaming']!,
+          _isStreamingMeta,
+        ),
+      );
+    }
+    if (data.containsKey('reasoning_text')) {
+      context.handle(
+        _reasoningTextMeta,
+        reasoningText.isAcceptableOrUnknown(
+          data['reasoning_text']!,
+          _reasoningTextMeta,
+        ),
+      );
+    }
+    if (data.containsKey('reasoning_start_at')) {
+      context.handle(
+        _reasoningStartAtMeta,
+        reasoningStartAt.isAcceptableOrUnknown(
+          data['reasoning_start_at']!,
+          _reasoningStartAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('reasoning_finished_at')) {
+      context.handle(
+        _reasoningFinishedAtMeta,
+        reasoningFinishedAt.isAcceptableOrUnknown(
+          data['reasoning_finished_at']!,
+          _reasoningFinishedAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('translation')) {
+      context.handle(
+        _translationMeta,
+        translation.isAcceptableOrUnknown(
+          data['translation']!,
+          _translationMeta,
+        ),
+      );
+    }
+    if (data.containsKey('reasoning_segments_json')) {
+      context.handle(
+        _reasoningSegmentsJsonMeta,
+        reasoningSegmentsJson.isAcceptableOrUnknown(
+          data['reasoning_segments_json']!,
+          _reasoningSegmentsJsonMeta,
+        ),
+      );
+    }
+    if (data.containsKey('group_id')) {
+      context.handle(
+        _groupIdMeta,
+        groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta),
+      );
+    }
+    if (data.containsKey('version')) {
+      context.handle(
+        _versionMeta,
+        version.isAcceptableOrUnknown(data['version']!, _versionMeta),
+      );
+    }
+    if (data.containsKey('prompt_tokens')) {
+      context.handle(
+        _promptTokensMeta,
+        promptTokens.isAcceptableOrUnknown(
+          data['prompt_tokens']!,
+          _promptTokensMeta,
+        ),
+      );
+    }
+    if (data.containsKey('completion_tokens')) {
+      context.handle(
+        _completionTokensMeta,
+        completionTokens.isAcceptableOrUnknown(
+          data['completion_tokens']!,
+          _completionTokensMeta,
+        ),
+      );
+    }
+    if (data.containsKey('cached_tokens')) {
+      context.handle(
+        _cachedTokensMeta,
+        cachedTokens.isAcceptableOrUnknown(
+          data['cached_tokens']!,
+          _cachedTokensMeta,
+        ),
+      );
+    }
+    if (data.containsKey('duration_ms')) {
+      context.handle(
+        _durationMsMeta,
+        durationMs.isAcceptableOrUnknown(data['duration_ms']!, _durationMsMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  MessageRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MessageRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      role: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}role'],
+      )!,
+      content: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}content'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}timestamp'],
+      )!,
+      modelId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}model_id'],
+      ),
+      providerId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}provider_id'],
+      ),
+      totalTokens: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}total_tokens'],
+      ),
+      conversationId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}conversation_id'],
+      )!,
+      isStreaming: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_streaming'],
+      )!,
+      reasoningText: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}reasoning_text'],
+      ),
+      reasoningStartAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}reasoning_start_at'],
+      ),
+      reasoningFinishedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}reasoning_finished_at'],
+      ),
+      translation: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}translation'],
+      ),
+      reasoningSegmentsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}reasoning_segments_json'],
+      ),
+      groupId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}group_id'],
+      ),
+      version: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}version'],
+      )!,
+      promptTokens: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}prompt_tokens'],
+      ),
+      completionTokens: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}completion_tokens'],
+      ),
+      cachedTokens: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}cached_tokens'],
+      ),
+      durationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}duration_ms'],
+      ),
+    );
+  }
+
+  @override
+  $MessagesTable createAlias(String alias) {
+    return $MessagesTable(attachedDatabase, alias);
+  }
+}
+
+class MessageRow extends DataClass implements Insertable<MessageRow> {
+  final String id;
+  final String role;
+  final String content;
+  final int timestamp;
+  final String? modelId;
+  final String? providerId;
+  final int? totalTokens;
+  final String conversationId;
+  final bool isStreaming;
+  final String? reasoningText;
+  final int? reasoningStartAt;
+  final int? reasoningFinishedAt;
+  final String? translation;
+  final String? reasoningSegmentsJson;
+  final String? groupId;
+  final int version;
+  final int? promptTokens;
+  final int? completionTokens;
+  final int? cachedTokens;
+  final int? durationMs;
+  const MessageRow({
+    required this.id,
+    required this.role,
+    required this.content,
+    required this.timestamp,
+    this.modelId,
+    this.providerId,
+    this.totalTokens,
+    required this.conversationId,
+    required this.isStreaming,
+    this.reasoningText,
+    this.reasoningStartAt,
+    this.reasoningFinishedAt,
+    this.translation,
+    this.reasoningSegmentsJson,
+    this.groupId,
+    required this.version,
+    this.promptTokens,
+    this.completionTokens,
+    this.cachedTokens,
+    this.durationMs,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['role'] = Variable<String>(role);
+    map['content'] = Variable<String>(content);
+    map['timestamp'] = Variable<int>(timestamp);
+    if (!nullToAbsent || modelId != null) {
+      map['model_id'] = Variable<String>(modelId);
+    }
+    if (!nullToAbsent || providerId != null) {
+      map['provider_id'] = Variable<String>(providerId);
+    }
+    if (!nullToAbsent || totalTokens != null) {
+      map['total_tokens'] = Variable<int>(totalTokens);
+    }
+    map['conversation_id'] = Variable<String>(conversationId);
+    map['is_streaming'] = Variable<bool>(isStreaming);
+    if (!nullToAbsent || reasoningText != null) {
+      map['reasoning_text'] = Variable<String>(reasoningText);
+    }
+    if (!nullToAbsent || reasoningStartAt != null) {
+      map['reasoning_start_at'] = Variable<int>(reasoningStartAt);
+    }
+    if (!nullToAbsent || reasoningFinishedAt != null) {
+      map['reasoning_finished_at'] = Variable<int>(reasoningFinishedAt);
+    }
+    if (!nullToAbsent || translation != null) {
+      map['translation'] = Variable<String>(translation);
+    }
+    if (!nullToAbsent || reasoningSegmentsJson != null) {
+      map['reasoning_segments_json'] = Variable<String>(reasoningSegmentsJson);
+    }
+    if (!nullToAbsent || groupId != null) {
+      map['group_id'] = Variable<String>(groupId);
+    }
+    map['version'] = Variable<int>(version);
+    if (!nullToAbsent || promptTokens != null) {
+      map['prompt_tokens'] = Variable<int>(promptTokens);
+    }
+    if (!nullToAbsent || completionTokens != null) {
+      map['completion_tokens'] = Variable<int>(completionTokens);
+    }
+    if (!nullToAbsent || cachedTokens != null) {
+      map['cached_tokens'] = Variable<int>(cachedTokens);
+    }
+    if (!nullToAbsent || durationMs != null) {
+      map['duration_ms'] = Variable<int>(durationMs);
+    }
+    return map;
+  }
+
+  MessagesCompanion toCompanion(bool nullToAbsent) {
+    return MessagesCompanion(
+      id: Value(id),
+      role: Value(role),
+      content: Value(content),
+      timestamp: Value(timestamp),
+      modelId: modelId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(modelId),
+      providerId: providerId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(providerId),
+      totalTokens: totalTokens == null && nullToAbsent
+          ? const Value.absent()
+          : Value(totalTokens),
+      conversationId: Value(conversationId),
+      isStreaming: Value(isStreaming),
+      reasoningText: reasoningText == null && nullToAbsent
+          ? const Value.absent()
+          : Value(reasoningText),
+      reasoningStartAt: reasoningStartAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(reasoningStartAt),
+      reasoningFinishedAt: reasoningFinishedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(reasoningFinishedAt),
+      translation: translation == null && nullToAbsent
+          ? const Value.absent()
+          : Value(translation),
+      reasoningSegmentsJson: reasoningSegmentsJson == null && nullToAbsent
+          ? const Value.absent()
+          : Value(reasoningSegmentsJson),
+      groupId: groupId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(groupId),
+      version: Value(version),
+      promptTokens: promptTokens == null && nullToAbsent
+          ? const Value.absent()
+          : Value(promptTokens),
+      completionTokens: completionTokens == null && nullToAbsent
+          ? const Value.absent()
+          : Value(completionTokens),
+      cachedTokens: cachedTokens == null && nullToAbsent
+          ? const Value.absent()
+          : Value(cachedTokens),
+      durationMs: durationMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(durationMs),
+    );
+  }
+
+  factory MessageRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MessageRow(
+      id: serializer.fromJson<String>(json['id']),
+      role: serializer.fromJson<String>(json['role']),
+      content: serializer.fromJson<String>(json['content']),
+      timestamp: serializer.fromJson<int>(json['timestamp']),
+      modelId: serializer.fromJson<String?>(json['modelId']),
+      providerId: serializer.fromJson<String?>(json['providerId']),
+      totalTokens: serializer.fromJson<int?>(json['totalTokens']),
+      conversationId: serializer.fromJson<String>(json['conversationId']),
+      isStreaming: serializer.fromJson<bool>(json['isStreaming']),
+      reasoningText: serializer.fromJson<String?>(json['reasoningText']),
+      reasoningStartAt: serializer.fromJson<int?>(json['reasoningStartAt']),
+      reasoningFinishedAt: serializer.fromJson<int?>(
+        json['reasoningFinishedAt'],
+      ),
+      translation: serializer.fromJson<String?>(json['translation']),
+      reasoningSegmentsJson: serializer.fromJson<String?>(
+        json['reasoningSegmentsJson'],
+      ),
+      groupId: serializer.fromJson<String?>(json['groupId']),
+      version: serializer.fromJson<int>(json['version']),
+      promptTokens: serializer.fromJson<int?>(json['promptTokens']),
+      completionTokens: serializer.fromJson<int?>(json['completionTokens']),
+      cachedTokens: serializer.fromJson<int?>(json['cachedTokens']),
+      durationMs: serializer.fromJson<int?>(json['durationMs']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'role': serializer.toJson<String>(role),
+      'content': serializer.toJson<String>(content),
+      'timestamp': serializer.toJson<int>(timestamp),
+      'modelId': serializer.toJson<String?>(modelId),
+      'providerId': serializer.toJson<String?>(providerId),
+      'totalTokens': serializer.toJson<int?>(totalTokens),
+      'conversationId': serializer.toJson<String>(conversationId),
+      'isStreaming': serializer.toJson<bool>(isStreaming),
+      'reasoningText': serializer.toJson<String?>(reasoningText),
+      'reasoningStartAt': serializer.toJson<int?>(reasoningStartAt),
+      'reasoningFinishedAt': serializer.toJson<int?>(reasoningFinishedAt),
+      'translation': serializer.toJson<String?>(translation),
+      'reasoningSegmentsJson': serializer.toJson<String?>(
+        reasoningSegmentsJson,
+      ),
+      'groupId': serializer.toJson<String?>(groupId),
+      'version': serializer.toJson<int>(version),
+      'promptTokens': serializer.toJson<int?>(promptTokens),
+      'completionTokens': serializer.toJson<int?>(completionTokens),
+      'cachedTokens': serializer.toJson<int?>(cachedTokens),
+      'durationMs': serializer.toJson<int?>(durationMs),
+    };
+  }
+
+  MessageRow copyWith({
+    String? id,
+    String? role,
+    String? content,
+    int? timestamp,
+    Value<String?> modelId = const Value.absent(),
+    Value<String?> providerId = const Value.absent(),
+    Value<int?> totalTokens = const Value.absent(),
+    String? conversationId,
+    bool? isStreaming,
+    Value<String?> reasoningText = const Value.absent(),
+    Value<int?> reasoningStartAt = const Value.absent(),
+    Value<int?> reasoningFinishedAt = const Value.absent(),
+    Value<String?> translation = const Value.absent(),
+    Value<String?> reasoningSegmentsJson = const Value.absent(),
+    Value<String?> groupId = const Value.absent(),
+    int? version,
+    Value<int?> promptTokens = const Value.absent(),
+    Value<int?> completionTokens = const Value.absent(),
+    Value<int?> cachedTokens = const Value.absent(),
+    Value<int?> durationMs = const Value.absent(),
+  }) => MessageRow(
+    id: id ?? this.id,
+    role: role ?? this.role,
+    content: content ?? this.content,
+    timestamp: timestamp ?? this.timestamp,
+    modelId: modelId.present ? modelId.value : this.modelId,
+    providerId: providerId.present ? providerId.value : this.providerId,
+    totalTokens: totalTokens.present ? totalTokens.value : this.totalTokens,
+    conversationId: conversationId ?? this.conversationId,
+    isStreaming: isStreaming ?? this.isStreaming,
+    reasoningText: reasoningText.present
+        ? reasoningText.value
+        : this.reasoningText,
+    reasoningStartAt: reasoningStartAt.present
+        ? reasoningStartAt.value
+        : this.reasoningStartAt,
+    reasoningFinishedAt: reasoningFinishedAt.present
+        ? reasoningFinishedAt.value
+        : this.reasoningFinishedAt,
+    translation: translation.present ? translation.value : this.translation,
+    reasoningSegmentsJson: reasoningSegmentsJson.present
+        ? reasoningSegmentsJson.value
+        : this.reasoningSegmentsJson,
+    groupId: groupId.present ? groupId.value : this.groupId,
+    version: version ?? this.version,
+    promptTokens: promptTokens.present ? promptTokens.value : this.promptTokens,
+    completionTokens: completionTokens.present
+        ? completionTokens.value
+        : this.completionTokens,
+    cachedTokens: cachedTokens.present ? cachedTokens.value : this.cachedTokens,
+    durationMs: durationMs.present ? durationMs.value : this.durationMs,
+  );
+  MessageRow copyWithCompanion(MessagesCompanion data) {
+    return MessageRow(
+      id: data.id.present ? data.id.value : this.id,
+      role: data.role.present ? data.role.value : this.role,
+      content: data.content.present ? data.content.value : this.content,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      modelId: data.modelId.present ? data.modelId.value : this.modelId,
+      providerId: data.providerId.present
+          ? data.providerId.value
+          : this.providerId,
+      totalTokens: data.totalTokens.present
+          ? data.totalTokens.value
+          : this.totalTokens,
+      conversationId: data.conversationId.present
+          ? data.conversationId.value
+          : this.conversationId,
+      isStreaming: data.isStreaming.present
+          ? data.isStreaming.value
+          : this.isStreaming,
+      reasoningText: data.reasoningText.present
+          ? data.reasoningText.value
+          : this.reasoningText,
+      reasoningStartAt: data.reasoningStartAt.present
+          ? data.reasoningStartAt.value
+          : this.reasoningStartAt,
+      reasoningFinishedAt: data.reasoningFinishedAt.present
+          ? data.reasoningFinishedAt.value
+          : this.reasoningFinishedAt,
+      translation: data.translation.present
+          ? data.translation.value
+          : this.translation,
+      reasoningSegmentsJson: data.reasoningSegmentsJson.present
+          ? data.reasoningSegmentsJson.value
+          : this.reasoningSegmentsJson,
+      groupId: data.groupId.present ? data.groupId.value : this.groupId,
+      version: data.version.present ? data.version.value : this.version,
+      promptTokens: data.promptTokens.present
+          ? data.promptTokens.value
+          : this.promptTokens,
+      completionTokens: data.completionTokens.present
+          ? data.completionTokens.value
+          : this.completionTokens,
+      cachedTokens: data.cachedTokens.present
+          ? data.cachedTokens.value
+          : this.cachedTokens,
+      durationMs: data.durationMs.present
+          ? data.durationMs.value
+          : this.durationMs,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MessageRow(')
+          ..write('id: $id, ')
+          ..write('role: $role, ')
+          ..write('content: $content, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('modelId: $modelId, ')
+          ..write('providerId: $providerId, ')
+          ..write('totalTokens: $totalTokens, ')
+          ..write('conversationId: $conversationId, ')
+          ..write('isStreaming: $isStreaming, ')
+          ..write('reasoningText: $reasoningText, ')
+          ..write('reasoningStartAt: $reasoningStartAt, ')
+          ..write('reasoningFinishedAt: $reasoningFinishedAt, ')
+          ..write('translation: $translation, ')
+          ..write('reasoningSegmentsJson: $reasoningSegmentsJson, ')
+          ..write('groupId: $groupId, ')
+          ..write('version: $version, ')
+          ..write('promptTokens: $promptTokens, ')
+          ..write('completionTokens: $completionTokens, ')
+          ..write('cachedTokens: $cachedTokens, ')
+          ..write('durationMs: $durationMs')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    role,
+    content,
+    timestamp,
+    modelId,
+    providerId,
+    totalTokens,
+    conversationId,
+    isStreaming,
+    reasoningText,
+    reasoningStartAt,
+    reasoningFinishedAt,
+    translation,
+    reasoningSegmentsJson,
+    groupId,
+    version,
+    promptTokens,
+    completionTokens,
+    cachedTokens,
+    durationMs,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MessageRow &&
+          other.id == this.id &&
+          other.role == this.role &&
+          other.content == this.content &&
+          other.timestamp == this.timestamp &&
+          other.modelId == this.modelId &&
+          other.providerId == this.providerId &&
+          other.totalTokens == this.totalTokens &&
+          other.conversationId == this.conversationId &&
+          other.isStreaming == this.isStreaming &&
+          other.reasoningText == this.reasoningText &&
+          other.reasoningStartAt == this.reasoningStartAt &&
+          other.reasoningFinishedAt == this.reasoningFinishedAt &&
+          other.translation == this.translation &&
+          other.reasoningSegmentsJson == this.reasoningSegmentsJson &&
+          other.groupId == this.groupId &&
+          other.version == this.version &&
+          other.promptTokens == this.promptTokens &&
+          other.completionTokens == this.completionTokens &&
+          other.cachedTokens == this.cachedTokens &&
+          other.durationMs == this.durationMs);
+}
+
+class MessagesCompanion extends UpdateCompanion<MessageRow> {
+  final Value<String> id;
+  final Value<String> role;
+  final Value<String> content;
+  final Value<int> timestamp;
+  final Value<String?> modelId;
+  final Value<String?> providerId;
+  final Value<int?> totalTokens;
+  final Value<String> conversationId;
+  final Value<bool> isStreaming;
+  final Value<String?> reasoningText;
+  final Value<int?> reasoningStartAt;
+  final Value<int?> reasoningFinishedAt;
+  final Value<String?> translation;
+  final Value<String?> reasoningSegmentsJson;
+  final Value<String?> groupId;
+  final Value<int> version;
+  final Value<int?> promptTokens;
+  final Value<int?> completionTokens;
+  final Value<int?> cachedTokens;
+  final Value<int?> durationMs;
+  final Value<int> rowid;
+  const MessagesCompanion({
+    this.id = const Value.absent(),
+    this.role = const Value.absent(),
+    this.content = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.modelId = const Value.absent(),
+    this.providerId = const Value.absent(),
+    this.totalTokens = const Value.absent(),
+    this.conversationId = const Value.absent(),
+    this.isStreaming = const Value.absent(),
+    this.reasoningText = const Value.absent(),
+    this.reasoningStartAt = const Value.absent(),
+    this.reasoningFinishedAt = const Value.absent(),
+    this.translation = const Value.absent(),
+    this.reasoningSegmentsJson = const Value.absent(),
+    this.groupId = const Value.absent(),
+    this.version = const Value.absent(),
+    this.promptTokens = const Value.absent(),
+    this.completionTokens = const Value.absent(),
+    this.cachedTokens = const Value.absent(),
+    this.durationMs = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  MessagesCompanion.insert({
+    required String id,
+    required String role,
+    required String content,
+    required int timestamp,
+    this.modelId = const Value.absent(),
+    this.providerId = const Value.absent(),
+    this.totalTokens = const Value.absent(),
+    required String conversationId,
+    this.isStreaming = const Value.absent(),
+    this.reasoningText = const Value.absent(),
+    this.reasoningStartAt = const Value.absent(),
+    this.reasoningFinishedAt = const Value.absent(),
+    this.translation = const Value.absent(),
+    this.reasoningSegmentsJson = const Value.absent(),
+    this.groupId = const Value.absent(),
+    this.version = const Value.absent(),
+    this.promptTokens = const Value.absent(),
+    this.completionTokens = const Value.absent(),
+    this.cachedTokens = const Value.absent(),
+    this.durationMs = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       role = Value(role),
+       content = Value(content),
+       timestamp = Value(timestamp),
+       conversationId = Value(conversationId);
+  static Insertable<MessageRow> custom({
+    Expression<String>? id,
+    Expression<String>? role,
+    Expression<String>? content,
+    Expression<int>? timestamp,
+    Expression<String>? modelId,
+    Expression<String>? providerId,
+    Expression<int>? totalTokens,
+    Expression<String>? conversationId,
+    Expression<bool>? isStreaming,
+    Expression<String>? reasoningText,
+    Expression<int>? reasoningStartAt,
+    Expression<int>? reasoningFinishedAt,
+    Expression<String>? translation,
+    Expression<String>? reasoningSegmentsJson,
+    Expression<String>? groupId,
+    Expression<int>? version,
+    Expression<int>? promptTokens,
+    Expression<int>? completionTokens,
+    Expression<int>? cachedTokens,
+    Expression<int>? durationMs,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (role != null) 'role': role,
+      if (content != null) 'content': content,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (modelId != null) 'model_id': modelId,
+      if (providerId != null) 'provider_id': providerId,
+      if (totalTokens != null) 'total_tokens': totalTokens,
+      if (conversationId != null) 'conversation_id': conversationId,
+      if (isStreaming != null) 'is_streaming': isStreaming,
+      if (reasoningText != null) 'reasoning_text': reasoningText,
+      if (reasoningStartAt != null) 'reasoning_start_at': reasoningStartAt,
+      if (reasoningFinishedAt != null)
+        'reasoning_finished_at': reasoningFinishedAt,
+      if (translation != null) 'translation': translation,
+      if (reasoningSegmentsJson != null)
+        'reasoning_segments_json': reasoningSegmentsJson,
+      if (groupId != null) 'group_id': groupId,
+      if (version != null) 'version': version,
+      if (promptTokens != null) 'prompt_tokens': promptTokens,
+      if (completionTokens != null) 'completion_tokens': completionTokens,
+      if (cachedTokens != null) 'cached_tokens': cachedTokens,
+      if (durationMs != null) 'duration_ms': durationMs,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  MessagesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? role,
+    Value<String>? content,
+    Value<int>? timestamp,
+    Value<String?>? modelId,
+    Value<String?>? providerId,
+    Value<int?>? totalTokens,
+    Value<String>? conversationId,
+    Value<bool>? isStreaming,
+    Value<String?>? reasoningText,
+    Value<int?>? reasoningStartAt,
+    Value<int?>? reasoningFinishedAt,
+    Value<String?>? translation,
+    Value<String?>? reasoningSegmentsJson,
+    Value<String?>? groupId,
+    Value<int>? version,
+    Value<int?>? promptTokens,
+    Value<int?>? completionTokens,
+    Value<int?>? cachedTokens,
+    Value<int?>? durationMs,
+    Value<int>? rowid,
+  }) {
+    return MessagesCompanion(
+      id: id ?? this.id,
+      role: role ?? this.role,
+      content: content ?? this.content,
+      timestamp: timestamp ?? this.timestamp,
+      modelId: modelId ?? this.modelId,
+      providerId: providerId ?? this.providerId,
+      totalTokens: totalTokens ?? this.totalTokens,
+      conversationId: conversationId ?? this.conversationId,
+      isStreaming: isStreaming ?? this.isStreaming,
+      reasoningText: reasoningText ?? this.reasoningText,
+      reasoningStartAt: reasoningStartAt ?? this.reasoningStartAt,
+      reasoningFinishedAt: reasoningFinishedAt ?? this.reasoningFinishedAt,
+      translation: translation ?? this.translation,
+      reasoningSegmentsJson:
+          reasoningSegmentsJson ?? this.reasoningSegmentsJson,
+      groupId: groupId ?? this.groupId,
+      version: version ?? this.version,
+      promptTokens: promptTokens ?? this.promptTokens,
+      completionTokens: completionTokens ?? this.completionTokens,
+      cachedTokens: cachedTokens ?? this.cachedTokens,
+      durationMs: durationMs ?? this.durationMs,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (role.present) {
+      map['role'] = Variable<String>(role.value);
+    }
+    if (content.present) {
+      map['content'] = Variable<String>(content.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<int>(timestamp.value);
+    }
+    if (modelId.present) {
+      map['model_id'] = Variable<String>(modelId.value);
+    }
+    if (providerId.present) {
+      map['provider_id'] = Variable<String>(providerId.value);
+    }
+    if (totalTokens.present) {
+      map['total_tokens'] = Variable<int>(totalTokens.value);
+    }
+    if (conversationId.present) {
+      map['conversation_id'] = Variable<String>(conversationId.value);
+    }
+    if (isStreaming.present) {
+      map['is_streaming'] = Variable<bool>(isStreaming.value);
+    }
+    if (reasoningText.present) {
+      map['reasoning_text'] = Variable<String>(reasoningText.value);
+    }
+    if (reasoningStartAt.present) {
+      map['reasoning_start_at'] = Variable<int>(reasoningStartAt.value);
+    }
+    if (reasoningFinishedAt.present) {
+      map['reasoning_finished_at'] = Variable<int>(reasoningFinishedAt.value);
+    }
+    if (translation.present) {
+      map['translation'] = Variable<String>(translation.value);
+    }
+    if (reasoningSegmentsJson.present) {
+      map['reasoning_segments_json'] = Variable<String>(
+        reasoningSegmentsJson.value,
+      );
+    }
+    if (groupId.present) {
+      map['group_id'] = Variable<String>(groupId.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (promptTokens.present) {
+      map['prompt_tokens'] = Variable<int>(promptTokens.value);
+    }
+    if (completionTokens.present) {
+      map['completion_tokens'] = Variable<int>(completionTokens.value);
+    }
+    if (cachedTokens.present) {
+      map['cached_tokens'] = Variable<int>(cachedTokens.value);
+    }
+    if (durationMs.present) {
+      map['duration_ms'] = Variable<int>(durationMs.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MessagesCompanion(')
+          ..write('id: $id, ')
+          ..write('role: $role, ')
+          ..write('content: $content, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('modelId: $modelId, ')
+          ..write('providerId: $providerId, ')
+          ..write('totalTokens: $totalTokens, ')
+          ..write('conversationId: $conversationId, ')
+          ..write('isStreaming: $isStreaming, ')
+          ..write('reasoningText: $reasoningText, ')
+          ..write('reasoningStartAt: $reasoningStartAt, ')
+          ..write('reasoningFinishedAt: $reasoningFinishedAt, ')
+          ..write('translation: $translation, ')
+          ..write('reasoningSegmentsJson: $reasoningSegmentsJson, ')
+          ..write('groupId: $groupId, ')
+          ..write('version: $version, ')
+          ..write('promptTokens: $promptTokens, ')
+          ..write('completionTokens: $completionTokens, ')
+          ..write('cachedTokens: $cachedTokens, ')
+          ..write('durationMs: $durationMs, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ToolEventsTable extends ToolEvents
+    with TableInfo<$ToolEventsTable, ToolEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ToolEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _messageIdMeta = const VerificationMeta(
+    'messageId',
+  );
+  @override
+  late final GeneratedColumn<String> messageId = GeneratedColumn<String>(
+    'message_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES messages (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _dataMeta = const VerificationMeta('data');
+  @override
+  late final GeneratedColumn<String> data = GeneratedColumn<String>(
+    'data',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _geminiThoughtSigMeta = const VerificationMeta(
+    'geminiThoughtSig',
+  );
+  @override
+  late final GeneratedColumn<String> geminiThoughtSig = GeneratedColumn<String>(
+    'gemini_thought_sig',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [messageId, data, geminiThoughtSig];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'tool_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ToolEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('message_id')) {
+      context.handle(
+        _messageIdMeta,
+        messageId.isAcceptableOrUnknown(data['message_id']!, _messageIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_messageIdMeta);
+    }
+    if (data.containsKey('data')) {
+      context.handle(
+        _dataMeta,
+        this.data.isAcceptableOrUnknown(data['data']!, _dataMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dataMeta);
+    }
+    if (data.containsKey('gemini_thought_sig')) {
+      context.handle(
+        _geminiThoughtSigMeta,
+        geminiThoughtSig.isAcceptableOrUnknown(
+          data['gemini_thought_sig']!,
+          _geminiThoughtSigMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {messageId};
+  @override
+  ToolEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ToolEventRow(
+      messageId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}message_id'],
+      )!,
+      data: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}data'],
+      )!,
+      geminiThoughtSig: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}gemini_thought_sig'],
+      ),
+    );
+  }
+
+  @override
+  $ToolEventsTable createAlias(String alias) {
+    return $ToolEventsTable(attachedDatabase, alias);
+  }
+}
+
+class ToolEventRow extends DataClass implements Insertable<ToolEventRow> {
+  final String messageId;
+  final String data;
+  final String? geminiThoughtSig;
+  const ToolEventRow({
+    required this.messageId,
+    required this.data,
+    this.geminiThoughtSig,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['message_id'] = Variable<String>(messageId);
+    map['data'] = Variable<String>(data);
+    if (!nullToAbsent || geminiThoughtSig != null) {
+      map['gemini_thought_sig'] = Variable<String>(geminiThoughtSig);
+    }
+    return map;
+  }
+
+  ToolEventsCompanion toCompanion(bool nullToAbsent) {
+    return ToolEventsCompanion(
+      messageId: Value(messageId),
+      data: Value(data),
+      geminiThoughtSig: geminiThoughtSig == null && nullToAbsent
+          ? const Value.absent()
+          : Value(geminiThoughtSig),
+    );
+  }
+
+  factory ToolEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ToolEventRow(
+      messageId: serializer.fromJson<String>(json['messageId']),
+      data: serializer.fromJson<String>(json['data']),
+      geminiThoughtSig: serializer.fromJson<String?>(json['geminiThoughtSig']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'messageId': serializer.toJson<String>(messageId),
+      'data': serializer.toJson<String>(data),
+      'geminiThoughtSig': serializer.toJson<String?>(geminiThoughtSig),
+    };
+  }
+
+  ToolEventRow copyWith({
+    String? messageId,
+    String? data,
+    Value<String?> geminiThoughtSig = const Value.absent(),
+  }) => ToolEventRow(
+    messageId: messageId ?? this.messageId,
+    data: data ?? this.data,
+    geminiThoughtSig: geminiThoughtSig.present
+        ? geminiThoughtSig.value
+        : this.geminiThoughtSig,
+  );
+  ToolEventRow copyWithCompanion(ToolEventsCompanion data) {
+    return ToolEventRow(
+      messageId: data.messageId.present ? data.messageId.value : this.messageId,
+      data: data.data.present ? data.data.value : this.data,
+      geminiThoughtSig: data.geminiThoughtSig.present
+          ? data.geminiThoughtSig.value
+          : this.geminiThoughtSig,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ToolEventRow(')
+          ..write('messageId: $messageId, ')
+          ..write('data: $data, ')
+          ..write('geminiThoughtSig: $geminiThoughtSig')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(messageId, data, geminiThoughtSig);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ToolEventRow &&
+          other.messageId == this.messageId &&
+          other.data == this.data &&
+          other.geminiThoughtSig == this.geminiThoughtSig);
+}
+
+class ToolEventsCompanion extends UpdateCompanion<ToolEventRow> {
+  final Value<String> messageId;
+  final Value<String> data;
+  final Value<String?> geminiThoughtSig;
+  final Value<int> rowid;
+  const ToolEventsCompanion({
+    this.messageId = const Value.absent(),
+    this.data = const Value.absent(),
+    this.geminiThoughtSig = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ToolEventsCompanion.insert({
+    required String messageId,
+    required String data,
+    this.geminiThoughtSig = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : messageId = Value(messageId),
+       data = Value(data);
+  static Insertable<ToolEventRow> custom({
+    Expression<String>? messageId,
+    Expression<String>? data,
+    Expression<String>? geminiThoughtSig,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (messageId != null) 'message_id': messageId,
+      if (data != null) 'data': data,
+      if (geminiThoughtSig != null) 'gemini_thought_sig': geminiThoughtSig,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ToolEventsCompanion copyWith({
+    Value<String>? messageId,
+    Value<String>? data,
+    Value<String?>? geminiThoughtSig,
+    Value<int>? rowid,
+  }) {
+    return ToolEventsCompanion(
+      messageId: messageId ?? this.messageId,
+      data: data ?? this.data,
+      geminiThoughtSig: geminiThoughtSig ?? this.geminiThoughtSig,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (messageId.present) {
+      map['message_id'] = Variable<String>(messageId.value);
+    }
+    if (data.present) {
+      map['data'] = Variable<String>(data.value);
+    }
+    if (geminiThoughtSig.present) {
+      map['gemini_thought_sig'] = Variable<String>(geminiThoughtSig.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ToolEventsCompanion(')
+          ..write('messageId: $messageId, ')
+          ..write('data: $data, ')
+          ..write('geminiThoughtSig: $geminiThoughtSig, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $MigrationMetaTable extends MigrationMeta
+    with TableInfo<$MigrationMetaTable, MigrationMetaRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $MigrationMetaTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _keyMeta = const VerificationMeta('key');
+  @override
+  late final GeneratedColumn<String> key = GeneratedColumn<String>(
+    'key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  @override
+  late final GeneratedColumn<String> value = GeneratedColumn<String>(
+    'value',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [key, value];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'migration_meta';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<MigrationMetaRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('key')) {
+      context.handle(
+        _keyMeta,
+        key.isAcceptableOrUnknown(data['key']!, _keyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_keyMeta);
+    }
+    if (data.containsKey('value')) {
+      context.handle(
+        _valueMeta,
+        value.isAcceptableOrUnknown(data['value']!, _valueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {key};
+  @override
+  MigrationMetaRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MigrationMetaRow(
+      key: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}key'],
+      )!,
+      value: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}value'],
+      )!,
+    );
+  }
+
+  @override
+  $MigrationMetaTable createAlias(String alias) {
+    return $MigrationMetaTable(attachedDatabase, alias);
+  }
+}
+
+class MigrationMetaRow extends DataClass
+    implements Insertable<MigrationMetaRow> {
+  final String key;
+  final String value;
+  const MigrationMetaRow({required this.key, required this.value});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['key'] = Variable<String>(key);
+    map['value'] = Variable<String>(value);
+    return map;
+  }
+
+  MigrationMetaCompanion toCompanion(bool nullToAbsent) {
+    return MigrationMetaCompanion(key: Value(key), value: Value(value));
+  }
+
+  factory MigrationMetaRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MigrationMetaRow(
+      key: serializer.fromJson<String>(json['key']),
+      value: serializer.fromJson<String>(json['value']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'key': serializer.toJson<String>(key),
+      'value': serializer.toJson<String>(value),
+    };
+  }
+
+  MigrationMetaRow copyWith({String? key, String? value}) =>
+      MigrationMetaRow(key: key ?? this.key, value: value ?? this.value);
+  MigrationMetaRow copyWithCompanion(MigrationMetaCompanion data) {
+    return MigrationMetaRow(
+      key: data.key.present ? data.key.value : this.key,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MigrationMetaRow(')
+          ..write('key: $key, ')
+          ..write('value: $value')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(key, value);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MigrationMetaRow &&
+          other.key == this.key &&
+          other.value == this.value);
+}
+
+class MigrationMetaCompanion extends UpdateCompanion<MigrationMetaRow> {
+  final Value<String> key;
+  final Value<String> value;
+  final Value<int> rowid;
+  const MigrationMetaCompanion({
+    this.key = const Value.absent(),
+    this.value = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  MigrationMetaCompanion.insert({
+    required String key,
+    required String value,
+    this.rowid = const Value.absent(),
+  }) : key = Value(key),
+       value = Value(value);
+  static Insertable<MigrationMetaRow> custom({
+    Expression<String>? key,
+    Expression<String>? value,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (key != null) 'key': key,
+      if (value != null) 'value': value,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  MigrationMetaCompanion copyWith({
+    Value<String>? key,
+    Value<String>? value,
+    Value<int>? rowid,
+  }) {
+    return MigrationMetaCompanion(
+      key: key ?? this.key,
+      value: value ?? this.value,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (key.present) {
+      map['key'] = Variable<String>(key.value);
+    }
+    if (value.present) {
+      map['value'] = Variable<String>(value.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MigrationMetaCompanion(')
+          ..write('key: $key, ')
+          ..write('value: $value, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$KelivoDatabase extends GeneratedDatabase {
+  _$KelivoDatabase(QueryExecutor e) : super(e);
+  $KelivoDatabaseManager get managers => $KelivoDatabaseManager(this);
+  late final $ConversationsTable conversations = $ConversationsTable(this);
+  late final $MessagesTable messages = $MessagesTable(this);
+  late final $ToolEventsTable toolEvents = $ToolEventsTable(this);
+  late final $MigrationMetaTable migrationMeta = $MigrationMetaTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    conversations,
+    messages,
+    toolEvents,
+    migrationMeta,
+  ];
+  @override
+  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'conversations',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('messages', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'messages',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('tool_events', kind: UpdateKind.delete)],
+    ),
+  ]);
+}
+
+typedef $$ConversationsTableCreateCompanionBuilder =
+    ConversationsCompanion Function({
+      required String id,
+      required String title,
+      required int createdAt,
+      required int updatedAt,
+      required String messageIds,
+      Value<bool> isPinned,
+      required String mcpServerIds,
+      Value<String?> assistantId,
+      Value<int> truncateIndex,
+      required String versionSelections,
+      Value<String?> summary,
+      Value<int> lastSummarizedMessageCount,
+      required String chatSuggestions,
+      Value<int> rowid,
+    });
+typedef $$ConversationsTableUpdateCompanionBuilder =
+    ConversationsCompanion Function({
+      Value<String> id,
+      Value<String> title,
+      Value<int> createdAt,
+      Value<int> updatedAt,
+      Value<String> messageIds,
+      Value<bool> isPinned,
+      Value<String> mcpServerIds,
+      Value<String?> assistantId,
+      Value<int> truncateIndex,
+      Value<String> versionSelections,
+      Value<String?> summary,
+      Value<int> lastSummarizedMessageCount,
+      Value<String> chatSuggestions,
+      Value<int> rowid,
+    });
+
+final class $$ConversationsTableReferences
+    extends
+        BaseReferences<_$KelivoDatabase, $ConversationsTable, ConversationRow> {
+  $$ConversationsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static MultiTypedResultKey<$MessagesTable, List<MessageRow>>
+  _messagesRefsTable(_$KelivoDatabase db) => MultiTypedResultKey.fromTable(
+    db.messages,
+    aliasName: 'conversations__id__messages__conversation_id',
+  );
+
+  $$MessagesTableProcessedTableManager get messagesRefs {
+    final manager = $$MessagesTableTableManager(
+      $_db,
+      $_db.messages,
+    ).filter((f) => f.conversationId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_messagesRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$ConversationsTableFilterComposer
+    extends Composer<_$KelivoDatabase, $ConversationsTable> {
+  $$ConversationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get messageIds => $composableBuilder(
+    column: $table.messageIds,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isPinned => $composableBuilder(
+    column: $table.isPinned,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get mcpServerIds => $composableBuilder(
+    column: $table.mcpServerIds,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get assistantId => $composableBuilder(
+    column: $table.assistantId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get truncateIndex => $composableBuilder(
+    column: $table.truncateIndex,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get versionSelections => $composableBuilder(
+    column: $table.versionSelections,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastSummarizedMessageCount => $composableBuilder(
+    column: $table.lastSummarizedMessageCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get chatSuggestions => $composableBuilder(
+    column: $table.chatSuggestions,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> messagesRefs(
+    Expression<bool> Function($$MessagesTableFilterComposer f) f,
+  ) {
+    final $$MessagesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.messages,
+      getReferencedColumn: (t) => t.conversationId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessagesTableFilterComposer(
+            $db: $db,
+            $table: $db.messages,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ConversationsTableOrderingComposer
+    extends Composer<_$KelivoDatabase, $ConversationsTable> {
+  $$ConversationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get messageIds => $composableBuilder(
+    column: $table.messageIds,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isPinned => $composableBuilder(
+    column: $table.isPinned,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get mcpServerIds => $composableBuilder(
+    column: $table.mcpServerIds,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get assistantId => $composableBuilder(
+    column: $table.assistantId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get truncateIndex => $composableBuilder(
+    column: $table.truncateIndex,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get versionSelections => $composableBuilder(
+    column: $table.versionSelections,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastSummarizedMessageCount => $composableBuilder(
+    column: $table.lastSummarizedMessageCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get chatSuggestions => $composableBuilder(
+    column: $table.chatSuggestions,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ConversationsTableAnnotationComposer
+    extends Composer<_$KelivoDatabase, $ConversationsTable> {
+  $$ConversationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get messageIds => $composableBuilder(
+    column: $table.messageIds,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isPinned =>
+      $composableBuilder(column: $table.isPinned, builder: (column) => column);
+
+  GeneratedColumn<String> get mcpServerIds => $composableBuilder(
+    column: $table.mcpServerIds,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get assistantId => $composableBuilder(
+    column: $table.assistantId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get truncateIndex => $composableBuilder(
+    column: $table.truncateIndex,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get versionSelections => $composableBuilder(
+    column: $table.versionSelections,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get summary =>
+      $composableBuilder(column: $table.summary, builder: (column) => column);
+
+  GeneratedColumn<int> get lastSummarizedMessageCount => $composableBuilder(
+    column: $table.lastSummarizedMessageCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get chatSuggestions => $composableBuilder(
+    column: $table.chatSuggestions,
+    builder: (column) => column,
+  );
+
+  Expression<T> messagesRefs<T extends Object>(
+    Expression<T> Function($$MessagesTableAnnotationComposer a) f,
+  ) {
+    final $$MessagesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.messages,
+      getReferencedColumn: (t) => t.conversationId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessagesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.messages,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ConversationsTableTableManager
+    extends
+        RootTableManager<
+          _$KelivoDatabase,
+          $ConversationsTable,
+          ConversationRow,
+          $$ConversationsTableFilterComposer,
+          $$ConversationsTableOrderingComposer,
+          $$ConversationsTableAnnotationComposer,
+          $$ConversationsTableCreateCompanionBuilder,
+          $$ConversationsTableUpdateCompanionBuilder,
+          (ConversationRow, $$ConversationsTableReferences),
+          ConversationRow,
+          PrefetchHooks Function({bool messagesRefs})
+        > {
+  $$ConversationsTableTableManager(
+    _$KelivoDatabase db,
+    $ConversationsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ConversationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ConversationsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ConversationsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<String> messageIds = const Value.absent(),
+                Value<bool> isPinned = const Value.absent(),
+                Value<String> mcpServerIds = const Value.absent(),
+                Value<String?> assistantId = const Value.absent(),
+                Value<int> truncateIndex = const Value.absent(),
+                Value<String> versionSelections = const Value.absent(),
+                Value<String?> summary = const Value.absent(),
+                Value<int> lastSummarizedMessageCount = const Value.absent(),
+                Value<String> chatSuggestions = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ConversationsCompanion(
+                id: id,
+                title: title,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                messageIds: messageIds,
+                isPinned: isPinned,
+                mcpServerIds: mcpServerIds,
+                assistantId: assistantId,
+                truncateIndex: truncateIndex,
+                versionSelections: versionSelections,
+                summary: summary,
+                lastSummarizedMessageCount: lastSummarizedMessageCount,
+                chatSuggestions: chatSuggestions,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String title,
+                required int createdAt,
+                required int updatedAt,
+                required String messageIds,
+                Value<bool> isPinned = const Value.absent(),
+                required String mcpServerIds,
+                Value<String?> assistantId = const Value.absent(),
+                Value<int> truncateIndex = const Value.absent(),
+                required String versionSelections,
+                Value<String?> summary = const Value.absent(),
+                Value<int> lastSummarizedMessageCount = const Value.absent(),
+                required String chatSuggestions,
+                Value<int> rowid = const Value.absent(),
+              }) => ConversationsCompanion.insert(
+                id: id,
+                title: title,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                messageIds: messageIds,
+                isPinned: isPinned,
+                mcpServerIds: mcpServerIds,
+                assistantId: assistantId,
+                truncateIndex: truncateIndex,
+                versionSelections: versionSelections,
+                summary: summary,
+                lastSummarizedMessageCount: lastSummarizedMessageCount,
+                chatSuggestions: chatSuggestions,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$ConversationsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({messagesRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (messagesRefs) db.messages],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (messagesRefs)
+                    await $_getPrefetchedData<
+                      ConversationRow,
+                      $ConversationsTable,
+                      MessageRow
+                    >(
+                      currentTable: table,
+                      referencedTable: $$ConversationsTableReferences
+                          ._messagesRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$ConversationsTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).messagesRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where(
+                            (e) => e.conversationId == item.id,
+                          ),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$ConversationsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$KelivoDatabase,
+      $ConversationsTable,
+      ConversationRow,
+      $$ConversationsTableFilterComposer,
+      $$ConversationsTableOrderingComposer,
+      $$ConversationsTableAnnotationComposer,
+      $$ConversationsTableCreateCompanionBuilder,
+      $$ConversationsTableUpdateCompanionBuilder,
+      (ConversationRow, $$ConversationsTableReferences),
+      ConversationRow,
+      PrefetchHooks Function({bool messagesRefs})
+    >;
+typedef $$MessagesTableCreateCompanionBuilder =
+    MessagesCompanion Function({
+      required String id,
+      required String role,
+      required String content,
+      required int timestamp,
+      Value<String?> modelId,
+      Value<String?> providerId,
+      Value<int?> totalTokens,
+      required String conversationId,
+      Value<bool> isStreaming,
+      Value<String?> reasoningText,
+      Value<int?> reasoningStartAt,
+      Value<int?> reasoningFinishedAt,
+      Value<String?> translation,
+      Value<String?> reasoningSegmentsJson,
+      Value<String?> groupId,
+      Value<int> version,
+      Value<int?> promptTokens,
+      Value<int?> completionTokens,
+      Value<int?> cachedTokens,
+      Value<int?> durationMs,
+      Value<int> rowid,
+    });
+typedef $$MessagesTableUpdateCompanionBuilder =
+    MessagesCompanion Function({
+      Value<String> id,
+      Value<String> role,
+      Value<String> content,
+      Value<int> timestamp,
+      Value<String?> modelId,
+      Value<String?> providerId,
+      Value<int?> totalTokens,
+      Value<String> conversationId,
+      Value<bool> isStreaming,
+      Value<String?> reasoningText,
+      Value<int?> reasoningStartAt,
+      Value<int?> reasoningFinishedAt,
+      Value<String?> translation,
+      Value<String?> reasoningSegmentsJson,
+      Value<String?> groupId,
+      Value<int> version,
+      Value<int?> promptTokens,
+      Value<int?> completionTokens,
+      Value<int?> cachedTokens,
+      Value<int?> durationMs,
+      Value<int> rowid,
+    });
+
+final class $$MessagesTableReferences
+    extends BaseReferences<_$KelivoDatabase, $MessagesTable, MessageRow> {
+  $$MessagesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $ConversationsTable _conversationIdTable(_$KelivoDatabase db) => db
+      .conversations
+      .createAlias('messages__conversation_id__conversations__id');
+
+  $$ConversationsTableProcessedTableManager get conversationId {
+    final $_column = $_itemColumn<String>('conversation_id')!;
+
+    final manager = $$ConversationsTableTableManager(
+      $_db,
+      $_db.conversations,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_conversationIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static MultiTypedResultKey<$ToolEventsTable, List<ToolEventRow>>
+  _toolEventsRefsTable(_$KelivoDatabase db) => MultiTypedResultKey.fromTable(
+    db.toolEvents,
+    aliasName: 'messages__id__tool_events__message_id',
+  );
+
+  $$ToolEventsTableProcessedTableManager get toolEventsRefs {
+    final manager = $$ToolEventsTableTableManager(
+      $_db,
+      $_db.toolEvents,
+    ).filter((f) => f.messageId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_toolEventsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$MessagesTableFilterComposer
+    extends Composer<_$KelivoDatabase, $MessagesTable> {
+  $$MessagesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get role => $composableBuilder(
+    column: $table.role,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get modelId => $composableBuilder(
+    column: $table.modelId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get totalTokens => $composableBuilder(
+    column: $table.totalTokens,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isStreaming => $composableBuilder(
+    column: $table.isStreaming,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get reasoningText => $composableBuilder(
+    column: $table.reasoningText,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get reasoningStartAt => $composableBuilder(
+    column: $table.reasoningStartAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get reasoningFinishedAt => $composableBuilder(
+    column: $table.reasoningFinishedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get translation => $composableBuilder(
+    column: $table.translation,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get reasoningSegmentsJson => $composableBuilder(
+    column: $table.reasoningSegmentsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get groupId => $composableBuilder(
+    column: $table.groupId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get version => $composableBuilder(
+    column: $table.version,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get promptTokens => $composableBuilder(
+    column: $table.promptTokens,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get completionTokens => $composableBuilder(
+    column: $table.completionTokens,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get cachedTokens => $composableBuilder(
+    column: $table.cachedTokens,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$ConversationsTableFilterComposer get conversationId {
+    final $$ConversationsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationId,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableFilterComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<bool> toolEventsRefs(
+    Expression<bool> Function($$ToolEventsTableFilterComposer f) f,
+  ) {
+    final $$ToolEventsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.toolEvents,
+      getReferencedColumn: (t) => t.messageId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ToolEventsTableFilterComposer(
+            $db: $db,
+            $table: $db.toolEvents,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$MessagesTableOrderingComposer
+    extends Composer<_$KelivoDatabase, $MessagesTable> {
+  $$MessagesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get role => $composableBuilder(
+    column: $table.role,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get modelId => $composableBuilder(
+    column: $table.modelId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get totalTokens => $composableBuilder(
+    column: $table.totalTokens,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isStreaming => $composableBuilder(
+    column: $table.isStreaming,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get reasoningText => $composableBuilder(
+    column: $table.reasoningText,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get reasoningStartAt => $composableBuilder(
+    column: $table.reasoningStartAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get reasoningFinishedAt => $composableBuilder(
+    column: $table.reasoningFinishedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get translation => $composableBuilder(
+    column: $table.translation,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get reasoningSegmentsJson => $composableBuilder(
+    column: $table.reasoningSegmentsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get groupId => $composableBuilder(
+    column: $table.groupId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get version => $composableBuilder(
+    column: $table.version,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get promptTokens => $composableBuilder(
+    column: $table.promptTokens,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get completionTokens => $composableBuilder(
+    column: $table.completionTokens,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get cachedTokens => $composableBuilder(
+    column: $table.cachedTokens,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$ConversationsTableOrderingComposer get conversationId {
+    final $$ConversationsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationId,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableOrderingComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$MessagesTableAnnotationComposer
+    extends Composer<_$KelivoDatabase, $MessagesTable> {
+  $$MessagesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get role =>
+      $composableBuilder(column: $table.role, builder: (column) => column);
+
+  GeneratedColumn<String> get content =>
+      $composableBuilder(column: $table.content, builder: (column) => column);
+
+  GeneratedColumn<int> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumn<String> get modelId =>
+      $composableBuilder(column: $table.modelId, builder: (column) => column);
+
+  GeneratedColumn<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get totalTokens => $composableBuilder(
+    column: $table.totalTokens,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isStreaming => $composableBuilder(
+    column: $table.isStreaming,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get reasoningText => $composableBuilder(
+    column: $table.reasoningText,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get reasoningStartAt => $composableBuilder(
+    column: $table.reasoningStartAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get reasoningFinishedAt => $composableBuilder(
+    column: $table.reasoningFinishedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get translation => $composableBuilder(
+    column: $table.translation,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get reasoningSegmentsJson => $composableBuilder(
+    column: $table.reasoningSegmentsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get groupId =>
+      $composableBuilder(column: $table.groupId, builder: (column) => column);
+
+  GeneratedColumn<int> get version =>
+      $composableBuilder(column: $table.version, builder: (column) => column);
+
+  GeneratedColumn<int> get promptTokens => $composableBuilder(
+    column: $table.promptTokens,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get completionTokens => $composableBuilder(
+    column: $table.completionTokens,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get cachedTokens => $composableBuilder(
+    column: $table.cachedTokens,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => column,
+  );
+
+  $$ConversationsTableAnnotationComposer get conversationId {
+    final $$ConversationsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationId,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<T> toolEventsRefs<T extends Object>(
+    Expression<T> Function($$ToolEventsTableAnnotationComposer a) f,
+  ) {
+    final $$ToolEventsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.toolEvents,
+      getReferencedColumn: (t) => t.messageId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ToolEventsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.toolEvents,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$MessagesTableTableManager
+    extends
+        RootTableManager<
+          _$KelivoDatabase,
+          $MessagesTable,
+          MessageRow,
+          $$MessagesTableFilterComposer,
+          $$MessagesTableOrderingComposer,
+          $$MessagesTableAnnotationComposer,
+          $$MessagesTableCreateCompanionBuilder,
+          $$MessagesTableUpdateCompanionBuilder,
+          (MessageRow, $$MessagesTableReferences),
+          MessageRow,
+          PrefetchHooks Function({bool conversationId, bool toolEventsRefs})
+        > {
+  $$MessagesTableTableManager(_$KelivoDatabase db, $MessagesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$MessagesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$MessagesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$MessagesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> role = const Value.absent(),
+                Value<String> content = const Value.absent(),
+                Value<int> timestamp = const Value.absent(),
+                Value<String?> modelId = const Value.absent(),
+                Value<String?> providerId = const Value.absent(),
+                Value<int?> totalTokens = const Value.absent(),
+                Value<String> conversationId = const Value.absent(),
+                Value<bool> isStreaming = const Value.absent(),
+                Value<String?> reasoningText = const Value.absent(),
+                Value<int?> reasoningStartAt = const Value.absent(),
+                Value<int?> reasoningFinishedAt = const Value.absent(),
+                Value<String?> translation = const Value.absent(),
+                Value<String?> reasoningSegmentsJson = const Value.absent(),
+                Value<String?> groupId = const Value.absent(),
+                Value<int> version = const Value.absent(),
+                Value<int?> promptTokens = const Value.absent(),
+                Value<int?> completionTokens = const Value.absent(),
+                Value<int?> cachedTokens = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => MessagesCompanion(
+                id: id,
+                role: role,
+                content: content,
+                timestamp: timestamp,
+                modelId: modelId,
+                providerId: providerId,
+                totalTokens: totalTokens,
+                conversationId: conversationId,
+                isStreaming: isStreaming,
+                reasoningText: reasoningText,
+                reasoningStartAt: reasoningStartAt,
+                reasoningFinishedAt: reasoningFinishedAt,
+                translation: translation,
+                reasoningSegmentsJson: reasoningSegmentsJson,
+                groupId: groupId,
+                version: version,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                cachedTokens: cachedTokens,
+                durationMs: durationMs,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String role,
+                required String content,
+                required int timestamp,
+                Value<String?> modelId = const Value.absent(),
+                Value<String?> providerId = const Value.absent(),
+                Value<int?> totalTokens = const Value.absent(),
+                required String conversationId,
+                Value<bool> isStreaming = const Value.absent(),
+                Value<String?> reasoningText = const Value.absent(),
+                Value<int?> reasoningStartAt = const Value.absent(),
+                Value<int?> reasoningFinishedAt = const Value.absent(),
+                Value<String?> translation = const Value.absent(),
+                Value<String?> reasoningSegmentsJson = const Value.absent(),
+                Value<String?> groupId = const Value.absent(),
+                Value<int> version = const Value.absent(),
+                Value<int?> promptTokens = const Value.absent(),
+                Value<int?> completionTokens = const Value.absent(),
+                Value<int?> cachedTokens = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => MessagesCompanion.insert(
+                id: id,
+                role: role,
+                content: content,
+                timestamp: timestamp,
+                modelId: modelId,
+                providerId: providerId,
+                totalTokens: totalTokens,
+                conversationId: conversationId,
+                isStreaming: isStreaming,
+                reasoningText: reasoningText,
+                reasoningStartAt: reasoningStartAt,
+                reasoningFinishedAt: reasoningFinishedAt,
+                translation: translation,
+                reasoningSegmentsJson: reasoningSegmentsJson,
+                groupId: groupId,
+                version: version,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                cachedTokens: cachedTokens,
+                durationMs: durationMs,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$MessagesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback:
+              ({conversationId = false, toolEventsRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [if (toolEventsRefs) db.toolEvents],
+                  addJoins:
+                      <
+                        T extends TableManagerState<
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic
+                        >
+                      >(state) {
+                        if (conversationId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.conversationId,
+                                    referencedTable: $$MessagesTableReferences
+                                        ._conversationIdTable(db),
+                                    referencedColumn: $$MessagesTableReferences
+                                        ._conversationIdTable(db)
+                                        .id,
+                                  )
+                                  as T;
+                        }
+
+                        return state;
+                      },
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (toolEventsRefs)
+                        await $_getPrefetchedData<
+                          MessageRow,
+                          $MessagesTable,
+                          ToolEventRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$MessagesTableReferences
+                              ._toolEventsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$MessagesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).toolEventsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.messageId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
+              },
+        ),
+      );
+}
+
+typedef $$MessagesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$KelivoDatabase,
+      $MessagesTable,
+      MessageRow,
+      $$MessagesTableFilterComposer,
+      $$MessagesTableOrderingComposer,
+      $$MessagesTableAnnotationComposer,
+      $$MessagesTableCreateCompanionBuilder,
+      $$MessagesTableUpdateCompanionBuilder,
+      (MessageRow, $$MessagesTableReferences),
+      MessageRow,
+      PrefetchHooks Function({bool conversationId, bool toolEventsRefs})
+    >;
+typedef $$ToolEventsTableCreateCompanionBuilder =
+    ToolEventsCompanion Function({
+      required String messageId,
+      required String data,
+      Value<String?> geminiThoughtSig,
+      Value<int> rowid,
+    });
+typedef $$ToolEventsTableUpdateCompanionBuilder =
+    ToolEventsCompanion Function({
+      Value<String> messageId,
+      Value<String> data,
+      Value<String?> geminiThoughtSig,
+      Value<int> rowid,
+    });
+
+final class $$ToolEventsTableReferences
+    extends BaseReferences<_$KelivoDatabase, $ToolEventsTable, ToolEventRow> {
+  $$ToolEventsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $MessagesTable _messageIdTable(_$KelivoDatabase db) =>
+      db.messages.createAlias('tool_events__message_id__messages__id');
+
+  $$MessagesTableProcessedTableManager get messageId {
+    final $_column = $_itemColumn<String>('message_id')!;
+
+    final manager = $$MessagesTableTableManager(
+      $_db,
+      $_db.messages,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_messageIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$ToolEventsTableFilterComposer
+    extends Composer<_$KelivoDatabase, $ToolEventsTable> {
+  $$ToolEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get data => $composableBuilder(
+    column: $table.data,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get geminiThoughtSig => $composableBuilder(
+    column: $table.geminiThoughtSig,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$MessagesTableFilterComposer get messageId {
+    final $$MessagesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.messageId,
+      referencedTable: $db.messages,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessagesTableFilterComposer(
+            $db: $db,
+            $table: $db.messages,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ToolEventsTableOrderingComposer
+    extends Composer<_$KelivoDatabase, $ToolEventsTable> {
+  $$ToolEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get data => $composableBuilder(
+    column: $table.data,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get geminiThoughtSig => $composableBuilder(
+    column: $table.geminiThoughtSig,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$MessagesTableOrderingComposer get messageId {
+    final $$MessagesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.messageId,
+      referencedTable: $db.messages,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessagesTableOrderingComposer(
+            $db: $db,
+            $table: $db.messages,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ToolEventsTableAnnotationComposer
+    extends Composer<_$KelivoDatabase, $ToolEventsTable> {
+  $$ToolEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get data =>
+      $composableBuilder(column: $table.data, builder: (column) => column);
+
+  GeneratedColumn<String> get geminiThoughtSig => $composableBuilder(
+    column: $table.geminiThoughtSig,
+    builder: (column) => column,
+  );
+
+  $$MessagesTableAnnotationComposer get messageId {
+    final $$MessagesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.messageId,
+      referencedTable: $db.messages,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessagesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.messages,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ToolEventsTableTableManager
+    extends
+        RootTableManager<
+          _$KelivoDatabase,
+          $ToolEventsTable,
+          ToolEventRow,
+          $$ToolEventsTableFilterComposer,
+          $$ToolEventsTableOrderingComposer,
+          $$ToolEventsTableAnnotationComposer,
+          $$ToolEventsTableCreateCompanionBuilder,
+          $$ToolEventsTableUpdateCompanionBuilder,
+          (ToolEventRow, $$ToolEventsTableReferences),
+          ToolEventRow,
+          PrefetchHooks Function({bool messageId})
+        > {
+  $$ToolEventsTableTableManager(_$KelivoDatabase db, $ToolEventsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ToolEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ToolEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ToolEventsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> messageId = const Value.absent(),
+                Value<String> data = const Value.absent(),
+                Value<String?> geminiThoughtSig = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ToolEventsCompanion(
+                messageId: messageId,
+                data: data,
+                geminiThoughtSig: geminiThoughtSig,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String messageId,
+                required String data,
+                Value<String?> geminiThoughtSig = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ToolEventsCompanion.insert(
+                messageId: messageId,
+                data: data,
+                geminiThoughtSig: geminiThoughtSig,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$ToolEventsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({messageId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (messageId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.messageId,
+                                referencedTable: $$ToolEventsTableReferences
+                                    ._messageIdTable(db),
+                                referencedColumn: $$ToolEventsTableReferences
+                                    ._messageIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$ToolEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$KelivoDatabase,
+      $ToolEventsTable,
+      ToolEventRow,
+      $$ToolEventsTableFilterComposer,
+      $$ToolEventsTableOrderingComposer,
+      $$ToolEventsTableAnnotationComposer,
+      $$ToolEventsTableCreateCompanionBuilder,
+      $$ToolEventsTableUpdateCompanionBuilder,
+      (ToolEventRow, $$ToolEventsTableReferences),
+      ToolEventRow,
+      PrefetchHooks Function({bool messageId})
+    >;
+typedef $$MigrationMetaTableCreateCompanionBuilder =
+    MigrationMetaCompanion Function({
+      required String key,
+      required String value,
+      Value<int> rowid,
+    });
+typedef $$MigrationMetaTableUpdateCompanionBuilder =
+    MigrationMetaCompanion Function({
+      Value<String> key,
+      Value<String> value,
+      Value<int> rowid,
+    });
+
+class $$MigrationMetaTableFilterComposer
+    extends Composer<_$KelivoDatabase, $MigrationMetaTable> {
+  $$MigrationMetaTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get key => $composableBuilder(
+    column: $table.key,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$MigrationMetaTableOrderingComposer
+    extends Composer<_$KelivoDatabase, $MigrationMetaTable> {
+  $$MigrationMetaTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get key => $composableBuilder(
+    column: $table.key,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$MigrationMetaTableAnnotationComposer
+    extends Composer<_$KelivoDatabase, $MigrationMetaTable> {
+  $$MigrationMetaTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get key =>
+      $composableBuilder(column: $table.key, builder: (column) => column);
+
+  GeneratedColumn<String> get value =>
+      $composableBuilder(column: $table.value, builder: (column) => column);
+}
+
+class $$MigrationMetaTableTableManager
+    extends
+        RootTableManager<
+          _$KelivoDatabase,
+          $MigrationMetaTable,
+          MigrationMetaRow,
+          $$MigrationMetaTableFilterComposer,
+          $$MigrationMetaTableOrderingComposer,
+          $$MigrationMetaTableAnnotationComposer,
+          $$MigrationMetaTableCreateCompanionBuilder,
+          $$MigrationMetaTableUpdateCompanionBuilder,
+          (
+            MigrationMetaRow,
+            BaseReferences<
+              _$KelivoDatabase,
+              $MigrationMetaTable,
+              MigrationMetaRow
+            >,
+          ),
+          MigrationMetaRow,
+          PrefetchHooks Function()
+        > {
+  $$MigrationMetaTableTableManager(
+    _$KelivoDatabase db,
+    $MigrationMetaTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$MigrationMetaTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$MigrationMetaTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$MigrationMetaTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> key = const Value.absent(),
+                Value<String> value = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) =>
+                  MigrationMetaCompanion(key: key, value: value, rowid: rowid),
+          createCompanionCallback:
+              ({
+                required String key,
+                required String value,
+                Value<int> rowid = const Value.absent(),
+              }) => MigrationMetaCompanion.insert(
+                key: key,
+                value: value,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$MigrationMetaTableProcessedTableManager =
+    ProcessedTableManager<
+      _$KelivoDatabase,
+      $MigrationMetaTable,
+      MigrationMetaRow,
+      $$MigrationMetaTableFilterComposer,
+      $$MigrationMetaTableOrderingComposer,
+      $$MigrationMetaTableAnnotationComposer,
+      $$MigrationMetaTableCreateCompanionBuilder,
+      $$MigrationMetaTableUpdateCompanionBuilder,
+      (
+        MigrationMetaRow,
+        BaseReferences<_$KelivoDatabase, $MigrationMetaTable, MigrationMetaRow>,
+      ),
+      MigrationMetaRow,
+      PrefetchHooks Function()
+    >;
+
+class $KelivoDatabaseManager {
+  final _$KelivoDatabase _db;
+  $KelivoDatabaseManager(this._db);
+  $$ConversationsTableTableManager get conversations =>
+      $$ConversationsTableTableManager(_db, _db.conversations);
+  $$MessagesTableTableManager get messages =>
+      $$MessagesTableTableManager(_db, _db.messages);
+  $$ToolEventsTableTableManager get toolEvents =>
+      $$ToolEventsTableTableManager(_db, _db.toolEvents);
+  $$MigrationMetaTableTableManager get migrationMeta =>
+      $$MigrationMetaTableTableManager(_db, _db.migrationMeta);
+}

--- a/lib/core/database/mappers/chat_message_mapper.dart
+++ b/lib/core/database/mappers/chat_message_mapper.dart
@@ -1,0 +1,61 @@
+import 'package:drift/drift.dart';
+import 'package:Kelivo/core/models/chat_message.dart';
+import '../kelivo_database.dart';
+
+ChatMessage chatMessageFromRow(MessageRow row) {
+  return ChatMessage(
+    id: row.id,
+    role: row.role,
+    content: row.content,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(row.timestamp),
+    modelId: row.modelId,
+    providerId: row.providerId,
+    totalTokens: row.totalTokens,
+    conversationId: row.conversationId,
+    isStreaming: row.isStreaming,
+    reasoningText: row.reasoningText,
+    reasoningStartAt: row.reasoningStartAt != null
+        ? DateTime.fromMillisecondsSinceEpoch(row.reasoningStartAt!)
+        : null,
+    reasoningFinishedAt: row.reasoningFinishedAt != null
+        ? DateTime.fromMillisecondsSinceEpoch(row.reasoningFinishedAt!)
+        : null,
+    translation: row.translation,
+    reasoningSegmentsJson: row.reasoningSegmentsJson,
+    groupId: row.groupId,
+    version: row.version,
+    promptTokens: row.promptTokens,
+    completionTokens: row.completionTokens,
+    cachedTokens: row.cachedTokens,
+    durationMs: row.durationMs,
+  );
+}
+
+MessagesCompanion chatMessageToCompanion(ChatMessage msg) {
+  return MessagesCompanion(
+    id: Value(msg.id),
+    role: Value(msg.role),
+    content: Value(msg.content),
+    timestamp: Value(msg.timestamp.millisecondsSinceEpoch),
+    modelId: Value(msg.modelId),
+    providerId: Value(msg.providerId),
+    totalTokens: Value(msg.totalTokens),
+    conversationId: Value(msg.conversationId),
+    isStreaming: Value(msg.isStreaming),
+    reasoningText: Value(msg.reasoningText),
+    reasoningStartAt: msg.reasoningStartAt != null
+        ? Value(msg.reasoningStartAt!.millisecondsSinceEpoch)
+        : const Value(null),
+    reasoningFinishedAt: msg.reasoningFinishedAt != null
+        ? Value(msg.reasoningFinishedAt!.millisecondsSinceEpoch)
+        : const Value(null),
+    translation: Value(msg.translation),
+    reasoningSegmentsJson: Value(msg.reasoningSegmentsJson),
+    groupId: Value(msg.groupId),
+    version: Value(msg.version),
+    promptTokens: Value(msg.promptTokens),
+    completionTokens: Value(msg.completionTokens),
+    cachedTokens: Value(msg.cachedTokens),
+    durationMs: Value(msg.durationMs),
+  );
+}

--- a/lib/core/database/mappers/conversation_mapper.dart
+++ b/lib/core/database/mappers/conversation_mapper.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:drift/drift.dart';
+import 'package:Kelivo/core/models/conversation.dart';
+import '../kelivo_database.dart';
+
+Conversation conversationFromRow(ConversationRow row) {
+  return Conversation(
+    id: row.id,
+    title: row.title,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+    messageIds: (jsonDecode(row.messageIds) as List).cast<String>(),
+    isPinned: row.isPinned,
+    mcpServerIds: (jsonDecode(row.mcpServerIds) as List).cast<String>(),
+    assistantId: row.assistantId,
+    truncateIndex: row.truncateIndex,
+    versionSelections: (jsonDecode(row.versionSelections) as Map).map(
+      (k, v) => MapEntry(k.toString(), (v as num).toInt()),
+    ),
+    summary: row.summary,
+    lastSummarizedMessageCount: row.lastSummarizedMessageCount,
+    chatSuggestions: (jsonDecode(row.chatSuggestions) as List).cast<String>(),
+  );
+}
+
+ConversationsCompanion conversationToCompanion(Conversation c) {
+  return ConversationsCompanion(
+    id: Value(c.id),
+    title: Value(c.title),
+    createdAt: Value(c.createdAt.millisecondsSinceEpoch),
+    updatedAt: Value(c.updatedAt.millisecondsSinceEpoch),
+    messageIds: Value(jsonEncode(c.messageIds)),
+    isPinned: Value(c.isPinned),
+    mcpServerIds: Value(jsonEncode(c.mcpServerIds)),
+    assistantId: Value(c.assistantId),
+    truncateIndex: Value(c.truncateIndex),
+    versionSelections: Value(jsonEncode(c.versionSelections)),
+    summary: Value(c.summary),
+    lastSummarizedMessageCount: Value(c.lastSummarizedMessageCount),
+    chatSuggestions: Value(jsonEncode(c.chatSuggestions)),
+  );
+}

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1,28 +1,25 @@
-import 'package:flutter/foundation.dart';
+import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:drift/drift.dart';
 import 'package:path/path.dart' as p;
-import 'package:hive_flutter/hive_flutter.dart';
 import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
+import '../../database/kelivo_database.dart';
+import '../../database/mappers/chat_message_mapper.dart';
+import '../../database/mappers/conversation_mapper.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
 
 class ChatService extends ChangeNotifier {
-  static const String _conversationsBoxName = 'conversations';
-  static const String _messagesBoxName = 'messages';
-  static const String _toolEventsBoxName = 'tool_events_v1';
-  static const String _activeStreamingKey = '_active_streaming_ids';
   static const int defaultInitialMessageMin = 2;
   static const int defaultInitialMessageMax = 240;
   static const int defaultInitialTextBudget = 20000;
   static const int defaultHistoryPageSize = 20;
   static const int defaultLoadedWindowMax = 360;
 
-  late Box<Conversation> _conversationsBox;
-  late Box<ChatMessage> _messagesBox;
-  late Box
-  _toolEventsBox; // key: assistantMessageId, value: List<Map<String,dynamic>>
-  String _sigKey(String id) => 'sig_$id';
+  late KelivoDatabase _db;
+  final Map<String, Conversation> _conversationsCache = {};
 
   String? _currentConversationId;
   final Map<String, List<ChatMessage>> _messagesCache = {};
@@ -31,6 +28,9 @@ class ChatService extends ChangeNotifier {
   final Map<String, List<Map<String, dynamic>>> _temporaryToolEvents =
       <String, List<Map<String, dynamic>>>{};
   final Map<String, String> _temporaryGeminiThoughtSigs = <String, String>{};
+  final Map<String, List<Map<String, dynamic>>> _toolEventsCache =
+      <String, List<Map<String, dynamic>>>{};
+  final Map<String, String?> _thoughtSigsCache = <String, String?>{};
 
   // Localized default title for new conversations; set by UI on startup.
   String _defaultConversationTitle = 'New Chat';
@@ -48,31 +48,43 @@ class ChatService extends ChangeNotifier {
     return id != null && _temporaryConversationIds.contains(id);
   }
 
+  bool isDraft(String id) => _draftConversations.containsKey(id);
+
   Future<void> init() async {
     if (_initialized) return;
 
-    // Initialize Hive with platform-specific directory
-    final appDataDir = await AppDirectories.getAppDataDirectory();
-    await Hive.initFlutter(appDataDir.path);
+    _db = KelivoDatabase();
 
-    // Register adapters if not already registered
-    if (!Hive.isAdapterRegistered(0)) {
-      Hive.registerAdapter(ChatMessageAdapter());
-    }
-    if (!Hive.isAdapterRegistered(1)) {
-      Hive.registerAdapter(ConversationAdapter());
+    // Preload all conversations into memory cache
+    final rows = await _db.select(_db.conversations).get();
+    for (final row in rows) {
+      _conversationsCache[row.id] = conversationFromRow(row);
     }
 
-    _conversationsBox = await Hive.openBox<Conversation>(_conversationsBoxName);
-    _messagesBox = await Hive.openBox<ChatMessage>(_messagesBoxName);
-    _toolEventsBox = await Hive.openBox(_toolEventsBoxName);
+    // Preload all messages into memory cache (grouped by conversation)
+    final allMessageRows = await _db.select(_db.messages).get();
+    final grouped = <String, List<ChatMessage>>{};
+    for (final row in allMessageRows) {
+      final msg = chatMessageFromRow(row);
+      grouped.putIfAbsent(msg.conversationId, () => []).add(msg);
+    }
+    _messagesCache.addAll(grouped);
 
     // Migrate any persisted message content that references old iOS sandbox paths
     await _migrateSandboxPaths();
 
-    // Reset any stale isStreaming flags left over from a previous app crash or
-    // force-quit.  After a fresh launch no message can be actively streaming.
-    await _resetStaleStreamingFlags();
+    // Preload tool events and Gemini thought signatures into memory
+    final toolRows = await _db.select(_db.toolEvents).get();
+    for (final row in toolRows) {
+      try {
+        _toolEventsCache[row.messageId] =
+            (jsonDecode(row.data) as List<dynamic>)
+                .cast<Map<String, dynamic>>();
+      } catch (_) {
+        _toolEventsCache[row.messageId] = const <Map<String, dynamic>>[];
+      }
+      _thoughtSigsCache[row.messageId] = row.geminiThoughtSig;
+    }
 
     _initialized = true;
     notifyListeners();
@@ -80,7 +92,7 @@ class ChatService extends ChangeNotifier {
 
   List<Conversation> getAllConversations() {
     if (!_initialized) return [];
-    final conversations = _conversationsBox.values.toList();
+    final conversations = _conversationsCache.values.toList();
     conversations.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
     return conversations;
   }
@@ -91,12 +103,12 @@ class ChatService extends ChangeNotifier {
 
   Conversation? getConversation(String id) {
     if (!_initialized) return null;
-    return _conversationsBox.get(id) ?? _draftConversations[id];
+    return _conversationsCache[id] ?? _draftConversations[id];
   }
 
   Conversation? _conversationForMessages(String conversationId) {
     if (!_initialized) return _draftConversations[conversationId];
-    return _conversationsBox.get(conversationId) ??
+    return _conversationsCache[conversationId] ??
         _draftConversations[conversationId];
   }
 
@@ -181,7 +193,13 @@ class ChatService extends ChangeNotifier {
       }
       return null;
     }
-    return _messagesBox.get(messageId);
+    final messages = _messagesCache[conversationId];
+    if (messages == null) return null;
+    for (final message in messages) {
+      if (message.id == messageId) return message;
+    }
+
+    return null;
   }
 
   List<ChatMessage> getMessages(String conversationId) {
@@ -194,7 +212,7 @@ class ChatService extends ChangeNotifier {
 
     // Load from storage
     final conversation =
-        _conversationsBox.get(conversationId) ??
+        _conversationsCache[conversationId] ??
         _draftConversations[conversationId];
     if (conversation == null) return [];
 
@@ -277,6 +295,10 @@ class ChatService extends ChangeNotifier {
     );
   }
 
+  Future<void> ensureMessagesLoaded(String conversationId) async {
+    // no-op: all messages are preloaded at init
+  }
+
   int _estimateInitialLoadWeight(ChatMessage message) {
     final len = message.content.length;
     if (message.role == 'user') return len < 200 ? 200 : len;
@@ -296,7 +318,10 @@ class ChatService extends ChangeNotifier {
       assistantId: assistantId,
     );
 
-    await _conversationsBox.put(conversation.id, conversation);
+    _conversationsCache[conversation.id] = conversation;
+    await _db
+        .into(_db.conversations)
+        .insert(conversationToCompanion(conversation));
     _currentConversationId = conversation.id;
     notifyListeners();
     return conversation;
@@ -330,6 +355,8 @@ class ChatService extends ChangeNotifier {
     for (final message in messages) {
       _temporaryToolEvents.remove(message.id);
       _temporaryGeminiThoughtSigs.remove(message.id);
+      _toolEventsCache.remove(message.id);
+      _thoughtSigsCache.remove(message.id);
     }
     _draftConversations.remove(id);
     _messagesCache.remove(id);
@@ -361,8 +388,11 @@ class ChatService extends ChangeNotifier {
     for (final message in messages) {
       _temporaryToolEvents.remove(message.id);
       _temporaryGeminiThoughtSigs.remove(message.id);
+      _toolEventsCache.remove(message.id);
+      _thoughtSigsCache.remove(message.id);
     }
     _messagesCache.remove(id);
+    _conversationsCache.remove(id);
     if (_currentConversationId == id) {
       _currentConversationId = null;
     }
@@ -370,24 +400,19 @@ class ChatService extends ChangeNotifier {
   }
 
   Future<bool> _deletePersistedConversation(String id) async {
-    final conversation = _conversationsBox.get(id);
-    if (conversation == null) return false;
+    if (!_conversationsCache.containsKey(id)) return false;
 
-    for (final messageId in conversation.messageIds) {
-      final msg = _messagesBox.get(messageId);
-      if (msg != null && msg.role == 'assistant') {
-        try {
-          await _toolEventsBox.delete(msg.id);
-        } catch (_) {}
-        try {
-          await _toolEventsBox.delete(_sigKey(msg.id));
-        } catch (_) {}
+    // Cascade delete via SQLite foreign key handles messages + tool_events
+    await (_db.delete(_db.conversations)..where((t) => t.id.equals(id))).go();
+
+    _conversationsCache.remove(id);
+    final msgs = _messagesCache.remove(id);
+    if (msgs != null) {
+      for (final m in msgs) {
+        _toolEventsCache.remove(m.id);
+        _thoughtSigsCache.remove(m.id);
       }
-      await _messagesBox.delete(messageId);
     }
-
-    await _conversationsBox.delete(id);
-    _messagesCache.remove(id);
 
     if (_currentConversationId == id) {
       _currentConversationId = null;
@@ -401,20 +426,20 @@ class ChatService extends ChangeNotifier {
     final targetId = assistantId.trim();
     if (targetId.isEmpty) return;
 
-    final persistedConversationIds = _conversationsBox.values
-        .where((conversation) => conversation.assistantId == targetId)
-        .map((conversation) => conversation.id)
+    final persistedIds = _conversationsCache.values
+        .where((c) => c.assistantId == targetId)
+        .map((c) => c.id)
         .toList(growable: false);
-    final draftConversationIds = _draftConversations.values
-        .where((conversation) => conversation.assistantId == targetId)
-        .map((conversation) => conversation.id)
+    final draftIds = _draftConversations.values
+        .where((c) => c.assistantId == targetId)
+        .map((c) => c.id)
         .toList(growable: false);
 
     var deleted = false;
-    for (final conversationId in draftConversationIds) {
+    for (final conversationId in draftIds) {
       deleted = await _deleteDraftConversation(conversationId) || deleted;
     }
-    for (final conversationId in persistedConversationIds) {
+    for (final conversationId in persistedIds) {
       deleted = await _deletePersistedConversation(conversationId) || deleted;
     }
 
@@ -450,19 +475,17 @@ class ChatService extends ChangeNotifier {
 
   Future<void> _migrateSandboxPaths() async {
     try {
-      // No-op if empty
-      if (_messagesBox.isEmpty) return;
+      final rows = await _db.select(_db.messages).get();
+      if (rows.isEmpty) return;
       final imgRe = RegExp(r"\[image:(.+?)\]");
       final fileRe = RegExp(r"\[file:(.+?)\|(.+?)\|(.+?)\]");
 
-      for (final key in _messagesBox.keys) {
-        final msg = _messagesBox.get(key);
-        if (msg == null) continue;
+      for (final row in rows) {
+        final msg = chatMessageFromRow(row);
         final content = msg.content;
         String updated = content;
         bool changed = false;
 
-        // Rewrite image paths
         updated = updated.replaceAllMapped(imgRe, (m) {
           final raw = (m.group(1) ?? '').trim();
           final fixed = SandboxPathResolver.fix(raw);
@@ -470,7 +493,6 @@ class ChatService extends ChangeNotifier {
           return '[image:$fixed]';
         });
 
-        // Rewrite file attachment paths
         updated = updated.replaceAllMapped(fileRe, (m) {
           final raw = (m.group(1) ?? '').trim();
           final name = (m.group(2) ?? '').trim();
@@ -481,8 +503,9 @@ class ChatService extends ChangeNotifier {
         });
 
         if (changed && updated != content) {
-          final newMsg = msg.copyWith(content: updated);
-          await _messagesBox.put(msg.id, newMsg);
+          await _db
+              .update(_db.messages)
+              .replace(chatMessageToCompanion(msg.copyWith(content: updated)));
         }
       }
     } catch (_) {
@@ -490,83 +513,25 @@ class ChatService extends ChangeNotifier {
     }
   }
 
-  /// Reset stale isStreaming flags left over from a previous app crash or
-  /// force-quit.  After a fresh launch no message can be actively streaming,
-  /// so any persisted `isStreaming: true` is stale and must be cleared to
-  /// avoid stuck loading indicators.
-  ///
-  /// Uses a tracked set of streaming message IDs for O(1) lookup instead of
-  /// scanning every message in the box.
-  Future<void> _resetStaleStreamingFlags() async {
-    try {
-      final raw = _toolEventsBox.get(_activeStreamingKey);
-      if (raw == null) return;
-      final ids = (raw as List).cast<String>();
-      if (ids.isEmpty) return;
-      for (final id in ids) {
-        final msg = _messagesBox.get(id);
-        if (msg != null && msg.isStreaming) {
-          await _messagesBox.put(id, msg.copyWith(isStreaming: false));
-        }
-      }
-      await _toolEventsBox.delete(_activeStreamingKey);
-    } catch (_) {
-      // best-effort; ignore errors
-    }
-  }
-
-  /// Record a message ID as actively streaming.
-  void _trackStreamingId(String messageId) {
-    try {
-      final raw = _toolEventsBox.get(_activeStreamingKey);
-      final ids = raw != null
-          ? (raw as List).cast<String>().toList()
-          : <String>[];
-      if (!ids.contains(messageId)) {
-        ids.add(messageId);
-        _toolEventsBox.put(_activeStreamingKey, ids);
-      }
-    } catch (_) {}
-  }
-
-  /// Remove a message ID from the active streaming set.
-  void _untrackStreamingId(String messageId) {
-    try {
-      final raw = _toolEventsBox.get(_activeStreamingKey);
-      if (raw == null) return;
-      final ids = (raw as List).cast<String>().toList();
-      if (ids.remove(messageId)) {
-        if (ids.isEmpty) {
-          _toolEventsBox.delete(_activeStreamingKey);
-        } else {
-          _toolEventsBox.put(_activeStreamingKey, ids);
-        }
-      }
-    } catch (_) {}
-  }
-
   Future<void> _cleanupOrphanUploads() async {
     try {
       final uploadDir = await AppDirectories.getUploadDirectory();
       if (!await uploadDir.exists()) return;
 
-      // Build the set of all referenced paths across all messages
       String canon(String pth) {
-        // Normalize separators and resolve redundant segments to enable
-        // reliable equality checks across platforms (esp. Windows).
         final normalized = p.normalize(pth);
-        // On Windows, paths are case-insensitive; compare in lowercase.
         return Platform.isWindows ? normalized.toLowerCase() : normalized;
       }
 
       final referenced = <String>{};
-      for (final m in _messagesBox.values) {
-        for (final pth in _extractAttachmentPaths(m.content)) {
+      final msgRows = await _db.select(_db.messages).get();
+      for (final row in msgRows) {
+        final msg = chatMessageFromRow(row);
+        for (final pth in _extractAttachmentPaths(msg.content)) {
           referenced.add(canon(pth));
         }
       }
 
-      // Walk upload directory recursively to consider all files
       final entries = uploadDir.listSync(recursive: true, followLinks: false);
       for (final ent in entries) {
         if (ent is File) {
@@ -586,11 +551,6 @@ class ChatService extends ChangeNotifier {
     List<ChatMessage> messages,
   ) async {
     if (!_initialized) await init();
-    // Restore messages first
-    for (final m in messages) {
-      await _messagesBox.put(m.id, m);
-    }
-    // Ensure messageIds are in the same order
     final ids = messages.map((m) => m.id).toList();
     final restored = Conversation(
       id: conversation.id,
@@ -607,11 +567,16 @@ class ChatService extends ChangeNotifier {
       lastSummarizedMessageCount: conversation.lastSummarizedMessageCount,
       chatSuggestions: List<String>.of(conversation.chatSuggestions),
     );
-    await _conversationsBox.put(restored.id, restored);
-
-    // Update caches
+    _conversationsCache[restored.id] = restored;
+    await _db
+        .into(_db.conversations)
+        .insert(conversationToCompanion(restored), mode: InsertMode.replace);
+    for (final m in messages) {
+      await _db
+          .into(_db.messages)
+          .insert(chatMessageToCompanion(m), mode: InsertMode.replace);
+    }
     _messagesCache[restored.id] = List.of(messages);
-
     notifyListeners();
   }
 
@@ -622,24 +587,25 @@ class ChatService extends ChangeNotifier {
   ) async {
     if (!_initialized) await init();
 
-    // Add message to box
-    await _messagesBox.put(message.id, message);
+    await _db
+        .into(_db.messages)
+        .insert(chatMessageToCompanion(message), mode: InsertMode.replace);
 
-    // Update conversation
-    final conversation = _conversationsBox.get(conversationId);
+    final conversation = _conversationsCache[conversationId];
     if (conversation != null) {
       if (!conversation.messageIds.contains(message.id)) {
         conversation.messageIds.add(message.id);
-        // Keep original updatedAt during restore
-        await conversation.save();
+        await _saveConversation(conversation);
       }
     }
 
     // Update cache
-    if (_messagesCache.containsKey(conversationId)) {
-      if (!_messagesCache[conversationId]!.any((m) => m.id == message.id)) {
-        _messagesCache[conversationId]!.add(message);
-      }
+    final cache = _messagesCache.putIfAbsent(
+      conversationId,
+      () => <ChatMessage>[],
+    );
+    if (!cache.any((m) => m.id == message.id)) {
+      cache.add(message);
     }
 
     notifyListeners();
@@ -649,7 +615,7 @@ class ChatService extends ChangeNotifier {
   List<String> getConversationMcpServers(String conversationId) {
     if (!_initialized) return const <String>[];
     final c =
-        _conversationsBox.get(conversationId) ??
+        _conversationsCache[conversationId] ??
         _draftConversations[conversationId];
     return c?.mcpServerIds ?? const <String>[];
   }
@@ -666,11 +632,11 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    final c = _conversationsBox.get(conversationId);
+    final c = _conversationsCache[conversationId];
     if (c == null) return;
     c.mcpServerIds = List.of(serverIds);
     c.updatedAt = DateTime.now();
-    await c.save();
+    await _saveConversation(c);
     notifyListeners();
   }
 
@@ -699,23 +665,84 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    final conversation = _conversationsBox.get(id);
-    if (conversation == null) return;
-
-    conversation.title = newTitle;
-    conversation.updatedAt = DateTime.now();
-    await conversation.save();
+    final c = _conversationsCache[id];
+    if (c == null) return;
+    c.title = newTitle;
+    c.updatedAt = DateTime.now();
+    await _saveConversation(c);
     notifyListeners();
   }
 
-  /// Updates the conversation summary generated by LLM.
+  Future<void> setConversationSummary(
+    String conversationId,
+    String summary,
+  ) async {
+    if (!_initialized) return;
+    if (_draftConversations.containsKey(conversationId)) {
+      final draft = _draftConversations[conversationId]!;
+      draft.summary = summary;
+      draft.updatedAt = DateTime.now();
+      notifyListeners();
+      return;
+    }
+    final c = _conversationsCache[conversationId];
+    if (c == null) return;
+    c.summary = summary;
+    c.updatedAt = DateTime.now();
+    await _saveConversation(c);
+    notifyListeners();
+  }
+
+  List<String> getChatSuggestions(String conversationId) {
+    if (!_initialized) return const <String>[];
+    final c =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    return List<String>.of(c?.chatSuggestions ?? const <String>[]);
+  }
+
+  Future<void> setChatSuggestions(
+    String conversationId,
+    List<String> suggestions,
+  ) async {
+    if (!_initialized) return;
+    if (_draftConversations.containsKey(conversationId)) {
+      final draft = _draftConversations[conversationId]!;
+      draft.chatSuggestions = List.of(suggestions);
+      draft.updatedAt = DateTime.now();
+      notifyListeners();
+      return;
+    }
+    final c = _conversationsCache[conversationId];
+    if (c == null) return;
+    c.chatSuggestions = List.of(suggestions);
+    c.updatedAt = DateTime.now();
+    await _saveConversation(c);
+    notifyListeners();
+  }
+
+  Future<void> clearChatSuggestions(String conversationId) async {
+    if (!_initialized) return;
+    if (_draftConversations.containsKey(conversationId)) {
+      final draft = _draftConversations[conversationId]!;
+      if (draft.chatSuggestions.isEmpty) return;
+      draft.chatSuggestions = <String>[];
+      notifyListeners();
+      return;
+    }
+    final conversation = _conversationsCache[conversationId];
+    if (conversation == null || conversation.chatSuggestions.isEmpty) return;
+    conversation.chatSuggestions = <String>[];
+    await _saveConversation(conversation);
+    notifyListeners();
+  }
+
   Future<void> updateConversationSummary(
     String id,
     String summary,
     int messageCount,
   ) async {
     if (!_initialized) return;
-
     if (_draftConversations.containsKey(id)) {
       final draft = _draftConversations[id]!;
       draft.summary = summary;
@@ -723,17 +750,14 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-
-    final conversation = _conversationsBox.get(id);
-    if (conversation == null) return;
-
-    conversation.summary = summary;
-    conversation.lastSummarizedMessageCount = messageCount;
-    await conversation.save();
+    final c = _conversationsCache[id];
+    if (c == null) return;
+    c.summary = summary;
+    c.lastSummarizedMessageCount = messageCount;
+    await _saveConversation(c);
     notifyListeners();
   }
 
-  /// Gets all conversations with non-empty summaries for a specific assistant.
   List<Conversation> getConversationsWithSummaryForAssistant(
     String assistantId,
   ) {
@@ -748,10 +772,8 @@ class ChatService extends ChangeNotifier {
         .toList();
   }
 
-  /// Clears the summary of a specific conversation.
   Future<void> clearConversationSummary(String conversationId) async {
     if (!_initialized) return;
-
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
       draft.summary = null;
@@ -759,13 +781,11 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-
-    final conversation = _conversationsBox.get(conversationId);
-    if (conversation == null) return;
-
-    conversation.summary = null;
-    conversation.lastSummarizedMessageCount = 0;
-    await conversation.save();
+    final c = _conversationsCache[conversationId];
+    if (c == null) return;
+    c.summary = null;
+    c.lastSummarizedMessageCount = 0;
+    await _saveConversation(c);
     notifyListeners();
   }
 
@@ -774,31 +794,26 @@ class ChatService extends ChangeNotifier {
     List<String> suggestions,
   ) async {
     if (!_initialized) return;
-
     final clean = suggestions
         .map((s) => s.trim())
         .where((s) => s.isNotEmpty)
         .take(3)
         .toList();
-
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
       draft.chatSuggestions = clean;
       notifyListeners();
       return;
     }
-
-    final conversation = _conversationsBox.get(conversationId);
-    if (conversation == null) return;
-
-    conversation.chatSuggestions = clean;
-    await conversation.save();
+    final c = _conversationsCache[conversationId];
+    if (c == null) return;
+    c.chatSuggestions = clean;
+    await _saveConversation(c);
     notifyListeners();
   }
 
   Future<void> clearConversationSuggestions(String conversationId) async {
     if (!_initialized) return;
-
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
       if (draft.chatSuggestions.isEmpty) return;
@@ -806,12 +821,10 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-
-    final conversation = _conversationsBox.get(conversationId);
-    if (conversation == null || conversation.chatSuggestions.isEmpty) return;
-
-    conversation.chatSuggestions = <String>[];
-    await conversation.save();
+    final c = _conversationsCache[conversationId];
+    if (c == null || c.chatSuggestions.isEmpty) return;
+    c.chatSuggestions = <String>[];
+    await _saveConversation(c);
     notifyListeners();
   }
 
@@ -824,11 +837,10 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    final conversation = _conversationsBox.get(id);
+    final conversation = _conversationsCache[id];
     if (conversation == null) return;
-
     conversation.isPinned = !conversation.isPinned;
-    await conversation.save();
+    await _saveConversation(conversation);
     notifyListeners();
   }
 
@@ -848,26 +860,30 @@ class ChatService extends ChangeNotifier {
   }) async {
     if (!_initialized) await init();
 
-    var conversation = _conversationsBox.get(conversationId);
+    var conversation = _conversationsCache[conversationId];
     final temporary = _temporaryConversationIds.contains(conversationId);
-    // If conversation doesn't exist yet, persist draft (if any)
     if (conversation == null) {
       final draft = temporary
           ? _draftConversations[conversationId]
           : _draftConversations.remove(conversationId);
       if (draft != null) {
         if (!temporary) {
-          await _conversationsBox.put(draft.id, draft);
+          _conversationsCache[draft.id] = draft;
+          await _db
+              .into(_db.conversations)
+              .insert(conversationToCompanion(draft));
         }
         conversation = draft;
       } else {
-        // Create a new one on the fly as a fallback
         conversation = Conversation(
           id: conversationId,
           title: _defaultConversationTitle,
         );
         if (!temporary) {
-          await _conversationsBox.put(conversationId, conversation);
+          _conversationsCache[conversationId] = conversation;
+          await _db
+              .into(_db.conversations)
+              .insert(conversationToCompanion(conversation));
         } else {
           _draftConversations[conversationId] = conversation;
         }
@@ -890,12 +906,7 @@ class ChatService extends ChangeNotifier {
     );
 
     if (!temporary) {
-      await _messagesBox.put(message.id, message);
-    }
-
-    // Track streaming state for crash-recovery cleanup
-    if (isStreaming && !temporary) {
-      _trackStreamingId(message.id);
+      await _db.into(_db.messages).insert(chatMessageToCompanion(message));
     }
 
     conversation.messageIds.add(message.id);
@@ -903,13 +914,13 @@ class ChatService extends ChangeNotifier {
     if (temporary) {
       _messagesCache.putIfAbsent(conversationId, () => <ChatMessage>[]);
     } else {
-      await conversation.save();
+      await _saveConversation(conversation);
     }
 
     // Update cache
-    if (_messagesCache.containsKey(conversationId)) {
-      _messagesCache[conversationId]!.add(message);
-    }
+    _messagesCache
+        .putIfAbsent(conversationId, () => <ChatMessage>[])
+        .add(message);
 
     notifyListeners();
     return message;
@@ -956,7 +967,7 @@ class ChatService extends ChangeNotifier {
     if (!_initialized) return;
 
     final message =
-        _messagesBox.get(messageId) ?? _cachedTemporaryMessage(messageId);
+        _cachedTemporaryMessage(messageId) ?? await _messageFromDb(messageId);
     if (message == null) return;
 
     final updatedMessage = message.copyWith(
@@ -981,17 +992,14 @@ class ChatService extends ChangeNotifier {
       return;
     }
 
-    await _messagesBox.put(messageId, updatedMessage);
-
-    // Update streaming tracking for crash-recovery
-    if (isStreaming == false) {
-      _untrackStreamingId(messageId);
-    }
+    await _db
+        .update(_db.messages)
+        .replace(chatMessageToCompanion(updatedMessage));
 
     // Update cache
-    final conversationId = message.conversationId;
-    if (_messagesCache.containsKey(conversationId)) {
-      final messages = _messagesCache[conversationId]!;
+    final convId = message.conversationId;
+    if (_messagesCache.containsKey(convId)) {
+      final messages = _messagesCache[convId]!;
       final index = messages.indexWhere((m) => m.id == messageId);
       if (index != -1) {
         messages[index] = updatedMessage;
@@ -1001,9 +1009,6 @@ class ChatService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Update message content during streaming without triggering notifyListeners.
-  /// This is used for streaming updates to avoid unnecessary rebuilds of
-  /// widgets watching ChatService (e.g., side_drawer).
   Future<void> updateMessageSilent(
     String messageId, {
     String? content,
@@ -1022,7 +1027,7 @@ class ChatService extends ChangeNotifier {
     if (!_initialized) return;
 
     final message =
-        _messagesBox.get(messageId) ?? _cachedTemporaryMessage(messageId);
+        _cachedTemporaryMessage(messageId) ?? await _messageFromDb(messageId);
     if (message == null) return;
 
     final updatedMessage = message.copyWith(
@@ -1046,17 +1051,14 @@ class ChatService extends ChangeNotifier {
       return;
     }
 
-    await _messagesBox.put(messageId, updatedMessage);
-
-    // Update streaming tracking for crash-recovery
-    if (isStreaming == false) {
-      _untrackStreamingId(messageId);
-    }
+    await _db
+        .update(_db.messages)
+        .replace(chatMessageToCompanion(updatedMessage));
 
     // Update cache
-    final conversationId = message.conversationId;
-    if (_messagesCache.containsKey(conversationId)) {
-      final messages = _messagesCache[conversationId]!;
+    final convId = message.conversationId;
+    if (_messagesCache.containsKey(convId)) {
+      final messages = _messagesCache[convId]!;
       final index = messages.indexWhere((m) => m.id == messageId);
       if (index != -1) {
         messages[index] = updatedMessage;
@@ -1065,18 +1067,28 @@ class ChatService extends ChangeNotifier {
     // NOTE: Do NOT call notifyListeners() here to avoid UI rebuilds during streaming
   }
 
+  Future<ChatMessage?> _messageFromDb(String messageId) async {
+    // Check cache first
+    for (final entry in _messagesCache.entries) {
+      for (final m in entry.value) {
+        if (m.id == messageId) return m;
+      }
+    }
+    // Fallback to PK query
+    final row = await (_db.select(
+      _db.messages,
+    )..where((t) => t.id.equals(messageId))).getSingleOrNull();
+    if (row == null) return null;
+    return chatMessageFromRow(row);
+  }
+
   // Tool events persistence (per assistant message)
   List<Map<String, dynamic>> getToolEvents(String assistantMessageId) {
     if (!_initialized) return const <Map<String, dynamic>>[];
     final temporary = _temporaryToolEvents[assistantMessageId];
     if (temporary != null) return List<Map<String, dynamic>>.of(temporary);
-    final v = _toolEventsBox.get(assistantMessageId);
-    if (v is List) {
-      return v
-          .whereType<Map>()
-          .map((e) => e.map((k, v) => MapEntry(k.toString(), v)))
-          .toList();
-    }
+    final cached = _toolEventsCache[assistantMessageId];
+    if (cached != null) return List<Map<String, dynamic>>.of(cached);
     return const <Map<String, dynamic>>[];
   }
 
@@ -1092,7 +1104,19 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    await _toolEventsBox.put(assistantMessageId, events);
+    final jsonStr = jsonEncode(events);
+    await _db
+        .into(_db.toolEvents)
+        .insert(
+          ToolEventsCompanion.insert(
+            messageId: assistantMessageId,
+            data: jsonStr,
+          ),
+          mode: InsertMode.replace,
+        );
+    _toolEventsCache[assistantMessageId] = List<Map<String, dynamic>>.of(
+      events,
+    );
     notifyListeners();
   }
 
@@ -1111,11 +1135,9 @@ class ChatService extends ChangeNotifier {
     final cleanId = (id).toString();
 
     int idx = -1;
-    // Prefer matching by a non-empty id
     if (cleanId.isNotEmpty) {
       idx = list.indexWhere((e) => (e['id']?.toString() ?? '') == cleanId);
     }
-    // If no id or not found, match the first placeholder (no content) with same name
     if (idx < 0) {
       idx = list.indexWhere(
         (e) =>
@@ -1147,7 +1169,17 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    await _toolEventsBox.put(assistantMessageId, list);
+    final jsonStr = jsonEncode(list);
+    await _db
+        .into(_db.toolEvents)
+        .insert(
+          ToolEventsCompanion.insert(
+            messageId: assistantMessageId,
+            data: jsonStr,
+          ),
+          mode: InsertMode.replace,
+        );
+    _toolEventsCache[assistantMessageId] = list;
     notifyListeners();
   }
 
@@ -1156,8 +1188,8 @@ class ChatService extends ChangeNotifier {
     if (!_initialized) return null;
     final temporary = _temporaryGeminiThoughtSigs[assistantMessageId];
     if (temporary != null && temporary.trim().isNotEmpty) return temporary;
-    final v = _toolEventsBox.get(_sigKey(assistantMessageId));
-    if (v is String && v.trim().isNotEmpty) return v;
+    final cached = _thoughtSigsCache[assistantMessageId];
+    if (cached != null && cached.trim().isNotEmpty) return cached;
     return null;
   }
 
@@ -1171,7 +1203,18 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    await _toolEventsBox.put(_sigKey(assistantMessageId), signature);
+    // Store in tool_events table's gemini_thought_sig column
+    await _db
+        .into(_db.toolEvents)
+        .insert(
+          ToolEventsCompanion.insert(
+            messageId: assistantMessageId,
+            data: '[]',
+            geminiThoughtSig: Value(signature),
+          ),
+          mode: InsertMode.replace,
+        );
+    _thoughtSigsCache[assistantMessageId] = signature;
     notifyListeners();
   }
 
@@ -1181,9 +1224,10 @@ class ChatService extends ChangeNotifier {
       _temporaryGeminiThoughtSigs.remove(assistantMessageId);
       return;
     }
-    try {
-      await _toolEventsBox.delete(_sigKey(assistantMessageId));
-    } catch (_) {}
+    await (_db.update(_db.toolEvents)
+          ..where((t) => t.messageId.equals(assistantMessageId)))
+        .write(const ToolEventsCompanion(geminiThoughtSig: Value(null)));
+    _thoughtSigsCache.remove(assistantMessageId);
   }
 
   Future<Conversation> forkConversation({
@@ -1193,7 +1237,6 @@ class ChatService extends ChangeNotifier {
     Map<String, int>? versionSelections,
   }) async {
     if (!_initialized) await init();
-    // Create new conversation first
     final convo = await createConversation(
       title: title,
       assistantId: assistantId,
@@ -1217,11 +1260,10 @@ class ChatService extends ChangeNotifier {
         groupId: src.groupId,
         version: src.version,
       );
-      await _messagesBox.put(clone.id, clone);
+      await _db.into(_db.messages).insert(chatMessageToCompanion(clone));
       ids.add(clone.id);
     }
-    // Attach to conversation in storage
-    final c = _conversationsBox.get(convo.id);
+    final c = _conversationsCache[convo.id];
     if (c != null) {
       c.messageIds
         ..clear()
@@ -1230,12 +1272,18 @@ class ChatService extends ChangeNotifier {
         versionSelections ?? const <String, int>{},
       );
       c.updatedAt = DateTime.now();
-      await c.save();
+      await _saveConversation(c);
     }
-    // Cache
-    _messagesCache[convo.id] = [for (final id in ids) _messagesBox.get(id)!];
+    final loadedMessages = <ChatMessage>[];
+    for (final id in ids) {
+      final row = await (_db.select(
+        _db.messages,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      if (row != null) loadedMessages.add(chatMessageFromRow(row));
+    }
+    _messagesCache[convo.id] = loadedMessages;
     notifyListeners();
-    return _conversationsBox.get(convo.id)!;
+    return _conversationsCache[convo.id]!;
   }
 
   Future<ChatMessage?> appendMessageVersion({
@@ -1243,18 +1291,17 @@ class ChatService extends ChangeNotifier {
     required String content,
   }) async {
     if (!_initialized) await init();
-    final original = _messagesBox.get(messageId);
+    final original = await _messageFromDb(messageId);
     if (original == null) return null;
 
     final cid = original.conversationId;
-    final convo = _conversationsBox.get(cid) ?? _draftConversations[cid];
+    final convo = _conversationsCache[cid] ?? _draftConversations[cid];
     if (convo == null) return null;
 
     final gid = (original.groupId ?? original.id);
-    // Find current max version within this group in this conversation
     int maxVersion = -1;
     for (final mid in convo.messageIds) {
-      final m = _messagesBox.get(mid);
+      final m = await _messageFromDb(mid);
       if (m == null) continue;
       final mg = (m.groupId ?? m.id);
       if (mg == gid) {
@@ -1274,24 +1321,21 @@ class ChatService extends ChangeNotifier {
       groupId: gid,
       version: nextVersion,
     );
-    await _messagesBox.put(newMsg.id, newMsg);
-    // Append to conversation order at the end (we'll group when rendering)
+    await _db.into(_db.messages).insert(chatMessageToCompanion(newMsg));
     if (_draftConversations.containsKey(cid)) {
       final draft = _draftConversations[cid]!;
       draft.messageIds.add(newMsg.id);
       draft.updatedAt = DateTime.now();
       draft.versionSelections[gid] = nextVersion;
     } else {
-      final c = _conversationsBox.get(cid);
+      final c = _conversationsCache[cid];
       if (c != null) {
         c.messageIds.add(newMsg.id);
         c.updatedAt = DateTime.now();
-        // Persist selection of latest version for this group
         c.versionSelections[gid] = nextVersion;
-        await c.save();
+        await _saveConversation(c);
       }
     }
-    // Update caches
     final arr = _messagesCache[cid];
     if (arr != null) arr.add(newMsg);
     notifyListeners();
@@ -1300,7 +1344,7 @@ class ChatService extends ChangeNotifier {
 
   Map<String, int> getVersionSelections(String conversationId) {
     final c =
-        _conversationsBox.get(conversationId) ??
+        _conversationsCache[conversationId] ??
         _draftConversations[conversationId];
     return Map<String, int>.from(c?.versionSelections ?? const <String, int>{});
   }
@@ -1317,11 +1361,11 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    final c = _conversationsBox.get(conversationId);
+    final c = _conversationsCache[conversationId];
     if (c == null) return;
     c.versionSelections[groupId] = version;
     c.updatedAt = DateTime.now();
-    await c.save();
+    await _saveConversation(c);
     notifyListeners();
   }
 
@@ -1336,11 +1380,11 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    final c = _conversationsBox.get(conversationId);
+    final c = _conversationsCache[conversationId];
     if (c == null) return;
     c.versionSelections.remove(groupId);
     c.updatedAt = DateTime.now();
-    await c.save();
+    await _saveConversation(c);
     notifyListeners();
   }
 
@@ -1349,10 +1393,9 @@ class ChatService extends ChangeNotifier {
     String? defaultTitle,
   }) async {
     if (!_initialized) await init();
-    // Draft case
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
-      final lastIndexPlusOne = draft.messageIds.length; // last index + 1
+      final lastIndexPlusOne = draft.messageIds.length;
       final newValue = (draft.truncateIndex == lastIndexPlusOne)
           ? -1
           : lastIndexPlusOne;
@@ -1362,8 +1405,7 @@ class ChatService extends ChangeNotifier {
       notifyListeners();
       return draft;
     }
-    // Persisted case
-    final c = _conversationsBox.get(conversationId);
+    final c = _conversationsCache[conversationId];
     if (c == null) return null;
     final lastIndexPlusOne = c.messageIds.length;
     final newValue = (c.truncateIndex == lastIndexPlusOne)
@@ -1372,7 +1414,7 @@ class ChatService extends ChangeNotifier {
     c.truncateIndex = newValue;
     if ((defaultTitle ?? '').isNotEmpty) c.title = defaultTitle!;
     c.updatedAt = DateTime.now();
-    await c.save();
+    await _saveConversation(c);
     notifyListeners();
     return c;
   }
@@ -1381,7 +1423,7 @@ class ChatService extends ChangeNotifier {
     if (!_initialized) return;
 
     final message =
-        _messagesBox.get(messageId) ?? _cachedTemporaryMessage(messageId);
+        await _messageFromDb(messageId) ?? _cachedTemporaryMessage(messageId);
     if (message == null) return;
 
     if (isTemporaryConversation(message.conversationId)) {
@@ -1395,17 +1437,15 @@ class ChatService extends ChangeNotifier {
       return;
     }
 
-    final conversation = _conversationsBox.get(message.conversationId);
+    final conversation = _conversationsCache[message.conversationId];
     if (conversation != null) {
       final gid = message.groupId ?? message.id;
       final ids = conversation.messageIds;
 
-      // Find the earliest position of this message group before removal so we
-      // can keep the group anchored when deleting one of its versions.
       int anchorIndex = -1;
       for (int i = 0; i < ids.length; i++) {
         final mid = ids[i];
-        final m = _messagesBox.get(mid);
+        final m = await _messageFromDb(mid);
         if (m == null) continue;
         final mgid = m.groupId ?? m.id;
         if (mgid == gid) {
@@ -1416,14 +1456,11 @@ class ChatService extends ChangeNotifier {
 
       ids.remove(messageId);
 
-      // If we removed the earliest version but other versions remain, move the
-      // earliest remaining one back to the original anchor index to preserve
-      // the group's relative order in the conversation.
       if (anchorIndex >= 0) {
         int? earliestRemaining;
         for (int i = 0; i < ids.length; i++) {
           final mid = ids[i];
-          final m = _messagesBox.get(mid);
+          final m = await _messageFromDb(mid);
           if (m == null) continue;
           final mgid = m.groupId ?? m.id;
           if (mgid == gid) {
@@ -1439,25 +1476,14 @@ class ChatService extends ChangeNotifier {
         }
       }
 
-      await conversation.save();
+      await _saveConversation(conversation);
     }
 
-    await _messagesBox.delete(messageId);
-    // Remove any tool events linked to this assistant message
-    if (message.role == 'assistant') {
-      try {
-        await _toolEventsBox.delete(message.id);
-      } catch (_) {}
-      try {
-        await _toolEventsBox.delete(_sigKey(message.id));
-      } catch (_) {}
-    }
+    // Delete message + cascade tool_events via FK
+    await (_db.delete(_db.messages)..where((t) => t.id.equals(messageId))).go();
 
-    // Update cache: clear this conversation so that next getMessages()
-    // reloads messages in the updated order from conversation.messageIds.
     _messagesCache.remove(message.conversationId);
 
-    // Clean up orphaned upload files that are no longer referenced by any message
     await _cleanupOrphanUploads();
 
     notifyListeners();
@@ -1474,16 +1500,18 @@ class ChatService extends ChangeNotifier {
   Future<void> clearAllData() async {
     if (!_initialized) return;
 
-    await _messagesBox.clear();
-    await _conversationsBox.clear();
-    await _toolEventsBox.clear();
+    await _db.delete(_db.messages).go();
+    await _db.delete(_db.conversations).go();
+    await _db.delete(_db.toolEvents).go();
     _messagesCache.clear();
+    _conversationsCache.clear();
     _draftConversations.clear();
     _temporaryConversationIds.clear();
     _temporaryToolEvents.clear();
     _temporaryGeminiThoughtSigs.clear();
+    _toolEventsCache.clear();
+    _thoughtSigsCache.clear();
     _currentConversationId = null;
-    // Remove uploads directory completely
     try {
       final uploadDir = await AppDirectories.getUploadDirectory();
       if (await uploadDir.exists()) {
@@ -1526,7 +1554,6 @@ class ChatService extends ChangeNotifier {
   }) async {
     if (!_initialized) await init();
 
-    // Draft conversation case
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
       draft.assistantId = assistantId;
@@ -1535,12 +1562,26 @@ class ChatService extends ChangeNotifier {
       return;
     }
 
-    final c = _conversationsBox.get(conversationId);
+    final c = _conversationsCache[conversationId];
     if (c == null) return;
     c.assistantId = assistantId;
     c.updatedAt = DateTime.now();
-    await c.save();
+    await _saveConversation(c);
     notifyListeners();
+  }
+
+  // ── helpers ──────────────────────────────────────────────
+
+  Future<void> _saveConversation(Conversation c) async {
+    if (isDraft(c.id)) return;
+    await _db.update(_db.conversations).replace(conversationToCompanion(c));
+    _conversationsCache[c.id] = c;
+  }
+
+  Future<void> close() async {
+    if (!_initialized) return;
+    await _db.close();
+    _initialized = false;
   }
 }
 

--- a/lib/core/services/migration/migration_service.dart
+++ b/lib/core/services/migration/migration_service.dart
@@ -1,0 +1,275 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
+import '../../database/kelivo_database.dart';
+import '../../database/mappers/chat_message_mapper.dart';
+import '../../database/mappers/conversation_mapper.dart';
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../../utils/app_directories.dart';
+
+enum MigrationStep { readingHive, writingSqlite, verifying, completed, error }
+
+class MigrationProgress {
+  final MigrationStep step;
+  final double progress; // 0.0 - 1.0
+  final String message;
+  final int? currentConversation;
+  final int? totalConversations;
+  final String? error;
+
+  const MigrationProgress({
+    required this.step,
+    required this.progress,
+    required this.message,
+    this.currentConversation,
+    this.totalConversations,
+    this.error,
+  });
+}
+
+class MigrationResult {
+  final bool success;
+  final int conversationsMigrated;
+  final int messagesMigrated;
+  final int toolEventsMigrated;
+  final String? error;
+
+  const MigrationResult({
+    required this.success,
+    this.conversationsMigrated = 0,
+    this.messagesMigrated = 0,
+    this.toolEventsMigrated = 0,
+    this.error,
+  });
+}
+
+class MigrationService {
+  static const String _conversationsBoxName = 'conversations';
+  static const String _messagesBoxName = 'messages';
+  static const String _toolEventsBoxName = 'tool_events_v1';
+
+  static Future<bool> isMigrationRequired() async {
+    final dir = await AppDirectories.getAppDataDirectory();
+    final dbFile = File(p.join(dir.path, 'kelivo.sqlite'));
+
+    if (await dbFile.exists()) {
+      final db = KelivoDatabase();
+      try {
+        final completed = await db.migrationCompleted();
+        return !completed;
+      } finally {
+        await db.close();
+      }
+    }
+
+    final hiveFile = File(p.join(dir.path, '$_messagesBoxName.hive'));
+    return await hiveFile.exists();
+  }
+
+  static Future<MigrationResult> run({
+    required void Function(MigrationProgress) onProgress,
+  }) async {
+    try {
+      // Step 1: Read Hive data
+      onProgress(
+        const MigrationProgress(
+          step: MigrationStep.readingHive,
+          progress: 0.0,
+          message: '正在读取 Hive 数据…',
+        ),
+      );
+
+      final hiveData = await _readHiveData(onProgress);
+
+      if (hiveData == null) {
+        // No Hive boxes found — create empty SQLite and mark done
+        final db = KelivoDatabase();
+        try {
+          await db.markMigrationCompleted();
+        } finally {
+          await db.close();
+        }
+        return const MigrationResult(success: true);
+      }
+
+      final conversations = hiveData.$1;
+      final messages = hiveData.$2;
+      final toolEvents = hiveData.$3;
+
+      // Step 2: Write to SQLite
+      onProgress(
+        MigrationProgress(
+          step: MigrationStep.writingSqlite,
+          progress: 0.0,
+          message: '正在写入 SQLite…',
+          totalConversations: conversations.length,
+        ),
+      );
+
+      final db = KelivoDatabase();
+      try {
+        await db.runMigration(conversations, messages, toolEvents, onProgress);
+      } finally {
+        await db.close();
+      }
+
+      // Step 3: Verify
+      onProgress(
+        const MigrationProgress(
+          step: MigrationStep.verifying,
+          progress: 0.0,
+          message: '正在一致性校验…',
+        ),
+      );
+
+      final verifyDb = KelivoDatabase();
+      try {
+        final verified = await _verify(verifyDb, conversations, messages);
+        if (!verified) {
+          return const MigrationResult(success: false, error: '一致性校验失败，请重试');
+        }
+        await verifyDb.markMigrationCompleted();
+      } finally {
+        await verifyDb.close();
+      }
+
+      return MigrationResult(
+        success: true,
+        conversationsMigrated: conversations.length,
+        messagesMigrated: messages.length,
+        toolEventsMigrated: toolEvents.length,
+      );
+    } catch (e, s) {
+      return MigrationResult(success: false, error: '迁移失败: $e\n$s');
+    }
+  }
+
+  static Future<
+    (List<Conversation>, List<ChatMessage>, Map<String, Map<String, dynamic>>)?
+  >
+  _readHiveData(void Function(MigrationProgress) onProgress) async {
+    final appDataDir = await AppDirectories.getAppDataDirectory();
+    final messagesHive = File(
+      p.join(appDataDir.path, '$_messagesBoxName.hive'),
+    );
+    if (!await messagesHive.exists()) return null;
+
+    await Hive.initFlutter(appDataDir.path);
+
+    if (!Hive.isAdapterRegistered(0)) {
+      Hive.registerAdapter(ChatMessageAdapter());
+    }
+    if (!Hive.isAdapterRegistered(1)) {
+      Hive.registerAdapter(ConversationAdapter());
+    }
+
+    final conversationsBox = await Hive.openBox<Conversation>(
+      _conversationsBoxName,
+    );
+    final messagesBox = await Hive.openBox<ChatMessage>(_messagesBoxName);
+    final toolEventsBox = await Hive.openBox(_toolEventsBoxName);
+
+    try {
+      final allConversations = conversationsBox.values.toList();
+      final allMessages = messagesBox.values.toList();
+      final toolEventData = <String, Map<String, dynamic>>{};
+
+      for (final key in toolEventsBox.keys) {
+        final k = key.toString();
+        final v = toolEventsBox.get(key);
+        if (v != null) {
+          toolEventData[k] = {'data': v};
+        }
+        final sigKey = 'sig_$k';
+        final sig = toolEventsBox.get(sigKey);
+        if (sig != null && sig is String) {
+          toolEventData.putIfAbsent(k, () => {});
+          toolEventData[k]!['gemini_thought_sig'] = sig;
+        }
+      }
+
+      return (allConversations, allMessages, toolEventData);
+    } finally {
+      await conversationsBox.close();
+      await messagesBox.close();
+      await toolEventsBox.close();
+    }
+  }
+
+  static Future<bool> _verify(
+    KelivoDatabase db,
+    List<Conversation> conversations,
+    List<ChatMessage> messages,
+  ) async {
+    final dbConversationCount = await db
+        .customSelect('SELECT COUNT(*) AS c FROM conversations')
+        .getSingle()
+        .then((r) => r.read<int>('c'));
+    if (dbConversationCount != conversations.length) return false;
+
+    final dbMessageCount = await db
+        .customSelect('SELECT COUNT(*) AS c FROM messages')
+        .getSingle()
+        .then((r) => r.read<int>('c'));
+    if (dbMessageCount != messages.length) return false;
+
+    return true;
+  }
+}
+
+extension _MigrationDatabase on KelivoDatabase {
+  Future<void> runMigration(
+    List<Conversation> convList,
+    List<ChatMessage> msgList,
+    Map<String, Map<String, dynamic>> toolEvents,
+    void Function(MigrationProgress) onProgress,
+  ) async {
+    final total = convList.length;
+
+    for (var i = 0; i < total; i++) {
+      final conv = convList[i];
+
+      await into(
+        conversations,
+      ).insert(conversationToCompanion(conv), mode: InsertMode.replace);
+
+      final convMessages = msgList
+          .where((m) => m.conversationId == conv.id)
+          .toList();
+      for (final msg in convMessages) {
+        await into(
+          messages,
+        ).insert(chatMessageToCompanion(msg), mode: InsertMode.replace);
+      }
+
+      final progress = (i + 1) / total;
+      onProgress(
+        MigrationProgress(
+          step: MigrationStep.writingSqlite,
+          progress: progress,
+          message: '正在写入 SQLite…',
+          currentConversation: i + 1,
+          totalConversations: total,
+        ),
+      );
+    }
+
+    for (final entry in toolEvents.entries) {
+      final data = entry.value['data'] != null
+          ? jsonEncode(entry.value['data'] as List)
+          : '[]';
+      final sig = entry.value['gemini_thought_sig'] as String?;
+      await into(this.toolEvents).insert(
+        ToolEventsCompanion(
+          messageId: Value(entry.key),
+          data: Value(data),
+          geminiThoughtSig: Value(sig),
+        ),
+        mode: InsertMode.replace,
+      );
+    }
+  }
+}

--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -109,6 +109,7 @@ abstract final class StorageUsageService {
     };
 
     final chatSubs = <String, _MutableStats>{
+      'database': _MutableStats(),
       'messages': _MutableStats(),
       'conversations': _MutableStats(),
       'tool_events_v1': _MutableStats(),
@@ -170,9 +171,10 @@ abstract final class StorageUsageService {
           final name = parts.first;
           final lower = name.toLowerCase();
           final isHive = lower.endsWith('.hive') || lower.endsWith('.lock');
-          if (isHive) {
+          final isSqlite = lower.endsWith('.sqlite');
+          if (isHive || isSqlite) {
             byCat[StorageUsageCategoryKey.chatData]!.add(bytes);
-            final box = _basenameNoExt(name);
+            final box = isSqlite ? 'database' : _basenameNoExt(name);
             final sub = chatSubs[box];
             if (sub != null) sub.add(bytes);
           } else {
@@ -283,7 +285,9 @@ abstract final class StorageUsageService {
               StorageUsageSubcategory(
                 id: e.key,
                 stats: e.value.toStats(),
-                path: p.join(root.path, '${e.key}.hive'),
+                path: e.key == 'database'
+                    ? p.join(root.path, 'kelivo.sqlite')
+                    : p.join(root.path, '${e.key}.hive'),
               ),
         ],
       ),

--- a/lib/features/home/controllers/chat_controller.dart
+++ b/lib/features/home/controllers/chat_controller.dart
@@ -160,6 +160,7 @@ class ChatController extends ChangeNotifier {
     final convo = _chatService.getConversation(id);
     if (convo != null) {
       _currentConversation = convo;
+      await _chatService.ensureMessagesLoaded(id);
       _loadInitialMessageWindow(id);
       _loadVersionSelections();
       notifyListeners();

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -584,6 +584,7 @@ class HomePageController extends ChangeNotifier {
           } catch (_) {}
         }
         _chatService.setCurrentConversation(recent.id);
+        await _chatService.ensureMessagesLoaded(recent.id);
         _chatController.setCurrentConversation(recent);
         _streamController.clearGeminiThoughtSigs();
         _restoreMessageUiState();

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -787,6 +787,7 @@ class HomeViewModel extends ChangeNotifier {
           assistantProvider.getById(convoAssistantId) != null) {
         await assistantProvider.setCurrentAssistant(convoAssistantId);
       }
+      await _chatService.ensureMessagesLoaded(id);
       _chatController.setCurrentConversation(convo);
       _streamController.clearGeminiThoughtSigs();
       notifyListeners();

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show File;
+import 'dart:io' show File, stderr;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -466,7 +466,11 @@ class _HomePageState extends State<HomePage>
     _controller.addListener(_onControllerChanged);
     _drawerController.addListener(_onDrawerValueChanged);
 
-    _controller.initChat();
+    _controller.initChat().catchError((e, st) {
+      stderr.writeln('=== initChat ERROR ===');
+      stderr.writeln(e);
+      stderr.writeln(st);
+    });
     _initProcessText();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/features/migration/pages/migration_screen.dart
+++ b/lib/features/migration/pages/migration_screen.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:restart_app/restart_app.dart';
+import '../../../core/services/migration/migration_service.dart';
+import '../../../l10n/app_localizations.dart';
+
+class MigrationScreen extends StatefulWidget {
+  const MigrationScreen({super.key});
+
+  @override
+  State<MigrationScreen> createState() => _MigrationScreenState();
+}
+
+class _MigrationScreenState extends State<MigrationScreen> {
+  MigrationProgress? _progress;
+  MigrationResult? _result;
+  bool _running = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<void> _startMigration() async {
+    if (_running) return;
+    setState(() {
+      _running = true;
+      _result = null;
+      _progress = null;
+    });
+
+    final result = await MigrationService.run(
+      onProgress: (p) {
+        if (!mounted) return;
+        setState(() => _progress = p);
+      },
+    );
+
+    if (!mounted) return;
+    setState(() {
+      _result = result;
+      _running = false;
+    });
+
+    if (result.success) {
+      // Wait briefly so user sees completion message
+      await Future.delayed(const Duration(seconds: 2));
+      if (mounted) {
+        Restart.restartApp();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Material(
+      color: const Color(0xFF1C1C1E),
+      child: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(_icon, size: 64, color: _iconColor),
+                  const SizedBox(height: 24),
+                  Text(
+                    _title(l10n),
+                    style: const TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    _description(l10n),
+                    style: const TextStyle(
+                      fontSize: 15,
+                      color: Color(0xFF8E8E93),
+                      height: 1.4,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  if (_progress != null) ...[
+                    const SizedBox(height: 32),
+                    _buildProgressBar(),
+                  ],
+                  if (_result != null && !_result!.success) ...[
+                    const SizedBox(height: 24),
+                    Text(
+                      '${l10n.migrateStepError}: ${_result!.error}',
+                      style: const TextStyle(color: Color(0xFFFF453A)),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    _buildButton(
+                      label: l10n.migrateRetry,
+                      onTap: _startMigration,
+                    ),
+                  ],
+                  if (!_running && _result == null) ...[
+                    const SizedBox(height: 32),
+                    _buildButton(
+                      label: l10n.migrateButtonStart,
+                      onTap: _startMigration,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressBar() {
+    final progress = _progress!;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: progress.progress,
+            backgroundColor: const Color(0xFF3A3A3C),
+            valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF0A84FF)),
+            minHeight: 6,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          progress.message,
+          style: const TextStyle(fontSize: 14, color: Color(0xFFEBEBF5)),
+          textAlign: TextAlign.center,
+        ),
+        if (progress.currentConversation != null &&
+            progress.totalConversations != null &&
+            progress.totalConversations! > 1)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              AppLocalizations.of(context)!.migrateConversationCount(
+                progress.currentConversation!,
+                progress.totalConversations!,
+              ),
+              style: const TextStyle(fontSize: 12, color: Color(0xFF8E8E93)),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildButton({required String label, required VoidCallback onTap}) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: ElevatedButton(
+        onPressed: onTap,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF0A84FF),
+          foregroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          elevation: 0,
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+
+  IconData get _icon {
+    if (_result?.success == true) return Icons.check_circle_outline;
+    if (_result != null && !_result!.success) return Icons.error_outline;
+    if (_running) return Icons.hourglass_top;
+    return Icons.storage_outlined;
+  }
+
+  Color get _iconColor {
+    if (_result?.success == true) return const Color(0xFF30D158);
+    if (_result != null && !_result!.success) return const Color(0xFFFF453A);
+    return const Color(0xFF0A84FF);
+  }
+
+  String _title(AppLocalizations l10n) {
+    if (_result?.success == true) return l10n.migrateStepComplete;
+    if (_result != null && !_result!.success) return l10n.migrateStepError;
+    return l10n.migrateTitle;
+  }
+
+  String _description(AppLocalizations l10n) {
+    if (_result?.success == true) return '';
+    if (_result != null && !_result!.success) return '';
+    return l10n.migrateDescription;
+  }
+}

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -620,9 +620,9 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
   }
 
   Future<void> _openFolder() async {
+    final l10n = AppLocalizations.of(context)!;
     final dir = await AppDirectories.getAppDataDirectory();
     final path = dir.path;
-    final l10n = AppLocalizations.of(context)!;
     try {
       final res = await OpenFilex.open(path);
       if (res.type != ResultType.done) {
@@ -848,9 +848,9 @@ class _StorageCategoryPageState extends State<_StorageCategoryPage> {
   }
 
   Future<void> _openFolder() async {
+    final l10n = AppLocalizations.of(context)!;
     final dir = await AppDirectories.getAppDataDirectory();
     final path = dir.path;
-    final l10n = AppLocalizations.of(context)!;
     try {
       final res = await OpenFilex.open(path);
       if (res.type != ResultType.done) {

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -11,6 +11,7 @@ import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
+import '../../../utils/app_directories.dart';
 import '../../../utils/platform_utils.dart';
 import '../../chat/pages/image_viewer_page.dart';
 import 'log_viewer_page.dart';
@@ -128,12 +129,14 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
 
   String _subTitleFor(String id, AppLocalizations l10n) {
     switch (id) {
+      case 'database':
+        return l10n.storageSpaceSubChatDatabase;
       case 'messages':
-        return l10n.storageSpaceSubChatMessages;
+        return '${l10n.storageSpaceSubChatMessages} ${l10n.storageSpaceSubChatOutdated}';
       case 'conversations':
-        return l10n.storageSpaceSubChatConversations;
+        return '${l10n.storageSpaceSubChatConversations} ${l10n.storageSpaceSubChatOutdated}';
       case 'tool_events_v1':
-        return l10n.storageSpaceSubChatToolEvents;
+        return '${l10n.storageSpaceSubChatToolEvents} ${l10n.storageSpaceSubChatOutdated}';
       case 'avatars':
         return l10n.storageSpaceSubAssistantAvatars;
       case 'images':
@@ -509,6 +512,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                             ? null
                             : _doClearSystemCache,
                         onClearLogs: _clearing ? null : _doClearLogs,
+                        onOpenFolder: _openFolder,
                         refreshReport: _refreshReport,
                       ),
                     ),
@@ -613,6 +617,30 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         ),
       ],
     );
+  }
+
+  Future<void> _openFolder() async {
+    final dir = await AppDirectories.getAppDataDirectory();
+    final path = dir.path;
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final res = await OpenFilex.open(path);
+      if (res.type != ResultType.done) {
+        if (!mounted) return;
+        showAppSnackBar(
+          context,
+          message: l10n.chatMessageWidgetCannotOpenFile(res.message),
+          type: NotificationType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.chatMessageWidgetOpenFileError(e.toString()),
+        type: NotificationType.error,
+      );
+    }
   }
 }
 
@@ -819,6 +847,30 @@ class _StorageCategoryPageState extends State<_StorageCategoryPage> {
     }
   }
 
+  Future<void> _openFolder() async {
+    final dir = await AppDirectories.getAppDataDirectory();
+    final path = dir.path;
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final res = await OpenFilex.open(path);
+      if (res.type != ResultType.done) {
+        if (!mounted) return;
+        showAppSnackBar(
+          context,
+          message: l10n.chatMessageWidgetCannotOpenFile(res.message),
+          type: NotificationType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.chatMessageWidgetOpenFileError(e.toString()),
+        type: NotificationType.error,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -867,6 +919,7 @@ class _StorageCategoryPageState extends State<_StorageCategoryPage> {
           onClearLogs: (category.key == StorageUsageCategoryKey.logs)
               ? _clearLogs
               : null,
+          onOpenFolder: _openFolder,
           refreshReport: _refresh,
         ),
       ),
@@ -1065,6 +1118,7 @@ class _CategoryDetail extends StatelessWidget {
     required this.onClearOtherCache,
     required this.onClearSystemCache,
     required this.onClearLogs,
+    required this.onOpenFolder,
     required this.refreshReport,
   });
 
@@ -1077,6 +1131,7 @@ class _CategoryDetail extends StatelessWidget {
   final Future<void> Function()? onClearOtherCache;
   final Future<void> Function()? onClearSystemCache;
   final Future<void> Function()? onClearLogs;
+  final Future<void> Function()? onOpenFolder;
   final Future<void> Function() refreshReport;
 
   @override
@@ -1139,6 +1194,20 @@ class _CategoryDetail extends StatelessWidget {
           ),
         ],
       );
+    } else if (category.key == StorageUsageCategoryKey.chatData) {
+      actions = Wrap(
+        spacing: 10,
+        runSpacing: 10,
+        children: [
+          IosTileButton(
+            label: l10n.storageSpaceChatDataOpenFolder,
+            icon: Lucide.FolderOpen,
+            backgroundColor: cs.primary,
+            enabled: onOpenFolder != null,
+            onTap: () => onOpenFolder?.call(),
+          ),
+        ],
+      );
     }
 
     if (category.key == StorageUsageCategoryKey.images ||
@@ -1196,7 +1265,9 @@ class _CategoryDetail extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         Text(
-          hint,
+          category.key == StorageUsageCategoryKey.chatData
+              ? l10n.storageSpaceChatDataMigrationNote
+              : hint,
           style: TextStyle(
             fontSize: 12.5,
             color: cs.onSurface.withValues(alpha: 0.7),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -77,6 +77,10 @@
   "storageSpaceSubChatMessages": "Messages",
   "storageSpaceSubChatConversations": "Conversations",
   "storageSpaceSubChatToolEvents": "Tool events",
+  "storageSpaceSubChatDatabase": "Database",
+  "storageSpaceSubChatOutdated": "(outdated)",
+  "storageSpaceChatDataMigrationNote": "May affect your chat history. Please delete with care. Chat data has been migrated from Hive to SQLite, with old files still preserved on disk. If you have confirmed the new version is running stably, you can navigate to the directory below to clean up Hive files.",
+  "storageSpaceChatDataOpenFolder": "Open folder",
   "storageSpaceSubAssistantAvatars": "Avatars",
   "storageSpaceSubAssistantImages": "Images",
   "storageSpaceSubCacheAvatars": "Avatar cache",
@@ -2355,5 +2359,26 @@
         "type": "int"
       }
     }
-  }
+  },
+  "migrateTitle": "Data Migration",
+  "migrateDescription": "Your chat data needs to be migrated to a new storage format.\nDo not close the app during migration.",
+  "migrateStepReading": "Reading existing data…",
+  "migrateStepWriting": "Writing to new storage…",
+  "migrateStepVerifying": "Verifying data integrity…",
+  "migrateStepComplete": "Migration complete. Restarting…",
+  "migrateStepError": "Migration failed",
+  "migrateRetry": "Retry",
+  "migrateButtonStart": "Start Migration",
+  "migrateConversationCount": "Migrating conversation {current} of {total}",
+  "@migrateConversationCount": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "migrateConsistencyFailed": "Consistency check failed. Please try again."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -382,6 +382,30 @@ abstract class AppLocalizations {
   /// **'Tool events'**
   String get storageSpaceSubChatToolEvents;
 
+  /// No description provided for @storageSpaceSubChatDatabase.
+  ///
+  /// In en, this message translates to:
+  /// **'Database'**
+  String get storageSpaceSubChatDatabase;
+
+  /// No description provided for @storageSpaceSubChatOutdated.
+  ///
+  /// In en, this message translates to:
+  /// **'(outdated)'**
+  String get storageSpaceSubChatOutdated;
+
+  /// No description provided for @storageSpaceChatDataMigrationNote.
+  ///
+  /// In en, this message translates to:
+  /// **'May affect your chat history. Please delete with care. Chat data has been migrated from Hive to SQLite, with old files still preserved on disk. If you have confirmed the new version is running stably, you can navigate to the directory below to clean up Hive files.'**
+  String get storageSpaceChatDataMigrationNote;
+
+  /// No description provided for @storageSpaceChatDataOpenFolder.
+  ///
+  /// In en, this message translates to:
+  /// **'Open folder'**
+  String get storageSpaceChatDataOpenFolder;
+
   /// No description provided for @storageSpaceSubAssistantAvatars.
   ///
   /// In en, this message translates to:
@@ -10093,6 +10117,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{role} message #{index}: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.'**
   String debugPageManyMessagesSeedText(String role, int index);
+
+  /// No description provided for @migrateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Data Migration'**
+  String get migrateTitle;
+
+  /// No description provided for @migrateDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Your chat data needs to be migrated to a new storage format.\nDo not close the app during migration.'**
+  String get migrateDescription;
+
+  /// No description provided for @migrateStepReading.
+  ///
+  /// In en, this message translates to:
+  /// **'Reading existing data…'**
+  String get migrateStepReading;
+
+  /// No description provided for @migrateStepWriting.
+  ///
+  /// In en, this message translates to:
+  /// **'Writing to new storage…'**
+  String get migrateStepWriting;
+
+  /// No description provided for @migrateStepVerifying.
+  ///
+  /// In en, this message translates to:
+  /// **'Verifying data integrity…'**
+  String get migrateStepVerifying;
+
+  /// No description provided for @migrateStepComplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Migration complete. Restarting…'**
+  String get migrateStepComplete;
+
+  /// No description provided for @migrateStepError.
+  ///
+  /// In en, this message translates to:
+  /// **'Migration failed'**
+  String get migrateStepError;
+
+  /// No description provided for @migrateRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get migrateRetry;
+
+  /// No description provided for @migrateButtonStart.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Migration'**
+  String get migrateButtonStart;
+
+  /// No description provided for @migrateConversationCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Migrating conversation {current} of {total}'**
+  String migrateConversationCount(int current, int total);
+
+  /// No description provided for @migrateConsistencyFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Consistency check failed. Please try again.'**
+  String get migrateConsistencyFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -162,6 +162,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get storageSpaceSubChatToolEvents => 'Tool events';
 
   @override
+  String get storageSpaceSubChatDatabase => 'Database';
+
+  @override
+  String get storageSpaceSubChatOutdated => '(outdated)';
+
+  @override
+  String get storageSpaceChatDataMigrationNote =>
+      'May affect your chat history. Please delete with care. Chat data has been migrated from Hive to SQLite, with old files still preserved on disk. If you have confirmed the new version is running stably, you can navigate to the directory below to clean up Hive files.';
+
+  @override
+  String get storageSpaceChatDataOpenFolder => 'Open folder';
+
+  @override
   String get storageSpaceSubAssistantAvatars => 'Avatars';
 
   @override
@@ -5483,4 +5496,41 @@ class AppLocalizationsEn extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role message #$index: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.';
   }
+
+  @override
+  String get migrateTitle => 'Data Migration';
+
+  @override
+  String get migrateDescription =>
+      'Your chat data needs to be migrated to a new storage format.\nDo not close the app during migration.';
+
+  @override
+  String get migrateStepReading => 'Reading existing data…';
+
+  @override
+  String get migrateStepWriting => 'Writing to new storage…';
+
+  @override
+  String get migrateStepVerifying => 'Verifying data integrity…';
+
+  @override
+  String get migrateStepComplete => 'Migration complete. Restarting…';
+
+  @override
+  String get migrateStepError => 'Migration failed';
+
+  @override
+  String get migrateRetry => 'Retry';
+
+  @override
+  String get migrateButtonStart => 'Start Migration';
+
+  @override
+  String migrateConversationCount(int current, int total) {
+    return 'Migrating conversation $current of $total';
+  }
+
+  @override
+  String get migrateConsistencyFailed =>
+      'Consistency check failed. Please try again.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -158,6 +158,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get storageSpaceSubChatToolEvents => '工具事件';
 
   @override
+  String get storageSpaceSubChatDatabase => '数据库';
+
+  @override
+  String get storageSpaceSubChatOutdated => '(已废弃)';
+
+  @override
+  String get storageSpaceChatDataMigrationNote =>
+      '可能影响聊天记录，请谨慎删除。聊天数据已从 Hive 迁移至 SQLite，旧文件仍然保留在磁盘上。若确认新版本已稳定运行，可前往目录清理 hive 文件。';
+
+  @override
+  String get storageSpaceChatDataOpenFolder => '打开目录';
+
+  @override
   String get storageSpaceSubAssistantAvatars => '头像';
 
   @override
@@ -5269,6 +5282,41 @@ class AppLocalizationsZh extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get migrateTitle => '数据迁移';
+
+  @override
+  String get migrateDescription => '检测到旧版本聊天数据，需要迁移到新存储格式。\n迁移期间请勿关闭应用。';
+
+  @override
+  String get migrateStepReading => '正在读取旧数据…';
+
+  @override
+  String get migrateStepWriting => '正在写入新存储…';
+
+  @override
+  String get migrateStepVerifying => '正在校验数据一致性…';
+
+  @override
+  String get migrateStepComplete => '迁移完成，正在重启…';
+
+  @override
+  String get migrateStepError => '迁移失败';
+
+  @override
+  String get migrateRetry => '重试';
+
+  @override
+  String get migrateButtonStart => '开始迁移';
+
+  @override
+  String migrateConversationCount(int current, int total) {
+    return '正在迁移对话 $current/$total';
+  }
+
+  @override
+  String get migrateConsistencyFailed => '一致性校验失败，请重试';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5423,6 +5471,19 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get storageSpaceSubChatToolEvents => '工具事件';
+
+  @override
+  String get storageSpaceSubChatDatabase => '数据库';
+
+  @override
+  String get storageSpaceSubChatOutdated => '(已废弃)';
+
+  @override
+  String get storageSpaceChatDataMigrationNote =>
+      '可能影响聊天记录，请谨慎删除。聊天数据已从 Hive 迁移至 SQLite，旧文件仍然保留在磁盘上。若确认新版本已稳定运行，可前往目录清理 hive 文件。';
+
+  @override
+  String get storageSpaceChatDataOpenFolder => '打开目录';
 
   @override
   String get storageSpaceSubAssistantAvatars => '头像';
@@ -10536,6 +10597,41 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get migrateTitle => '数据迁移';
+
+  @override
+  String get migrateDescription => '检测到旧版本聊天数据，需要迁移到新存储格式。\n迁移期间请勿关闭应用。';
+
+  @override
+  String get migrateStepReading => '正在读取旧数据…';
+
+  @override
+  String get migrateStepWriting => '正在写入新存储…';
+
+  @override
+  String get migrateStepVerifying => '正在校验数据一致性…';
+
+  @override
+  String get migrateStepComplete => '迁移完成，正在重启…';
+
+  @override
+  String get migrateStepError => '迁移失败';
+
+  @override
+  String get migrateRetry => '重试';
+
+  @override
+  String get migrateButtonStart => '开始迁移';
+
+  @override
+  String migrateConversationCount(int current, int total) {
+    return '正在迁移对话 $current/$total';
+  }
+
+  @override
+  String get migrateConsistencyFailed => '一致性校验失败，请重试';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -10690,6 +10786,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get storageSpaceSubChatToolEvents => '工具事件';
+
+  @override
+  String get storageSpaceSubChatDatabase => '資料庫';
+
+  @override
+  String get storageSpaceSubChatOutdated => '(已廢棄)';
+
+  @override
+  String get storageSpaceChatDataMigrationNote =>
+      '可能影響聊天記錄，請謹慎刪除。聊天資料已從 Hive 遷移至 SQLite，舊檔案仍然保留在磁碟上。若確認新版本已穩定運行，可前往目錄清理 hive 檔案。';
+
+  @override
+  String get storageSpaceChatDataOpenFolder => '開啟目錄';
 
   @override
   String get storageSpaceSubAssistantAvatars => '頭像';
@@ -15803,4 +15912,39 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 訊息 #$index：快速隨機調試樣例，用於測試列表渲染、捲動穩定性、訊息分組和會話歷史效能。';
   }
+
+  @override
+  String get migrateTitle => '資料遷移';
+
+  @override
+  String get migrateDescription => '偵測到舊版聊天資料，需要遷移至新儲存格式。\n遷移期間請勿關閉應用程式。';
+
+  @override
+  String get migrateStepReading => '正在讀取舊資料…';
+
+  @override
+  String get migrateStepWriting => '正在寫入新儲存…';
+
+  @override
+  String get migrateStepVerifying => '正在驗證資料一致性…';
+
+  @override
+  String get migrateStepComplete => '遷移完成，正在重新啟動…';
+
+  @override
+  String get migrateStepError => '遷移失敗';
+
+  @override
+  String get migrateRetry => '重試';
+
+  @override
+  String get migrateButtonStart => '開始遷移';
+
+  @override
+  String migrateConversationCount(int current, int total) {
+    return '正在遷移對話 $current/$total';
+  }
+
+  @override
+  String get migrateConsistencyFailed => '一致性驗證失敗，請重試';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -46,6 +46,10 @@
   "storageSpaceSubChatMessages": "消息",
   "storageSpaceSubChatConversations": "会话",
   "storageSpaceSubChatToolEvents": "工具事件",
+  "storageSpaceSubChatDatabase": "数据库",
+  "storageSpaceSubChatOutdated": "(已废弃)",
+  "storageSpaceChatDataMigrationNote": "可能影响聊天记录，请谨慎删除。聊天数据已从 Hive 迁移至 SQLite，旧文件仍然保留在磁盘上。若确认新版本已稳定运行，可前往目录清理 hive 文件。",
+  "storageSpaceChatDataOpenFolder": "打开目录",
   "storageSpaceSubAssistantAvatars": "头像",
   "storageSpaceSubAssistantImages": "图片",
   "storageSpaceSubCacheAvatars": "头像缓存",
@@ -1932,5 +1936,26 @@
         "type": "int"
       }
     }
-  }
+  },
+  "migrateTitle": "数据迁移",
+  "migrateDescription": "检测到旧版本聊天数据，需要迁移到新存储格式。\n迁移期间请勿关闭应用。",
+  "migrateStepReading": "正在读取旧数据…",
+  "migrateStepWriting": "正在写入新存储…",
+  "migrateStepVerifying": "正在校验数据一致性…",
+  "migrateStepComplete": "迁移完成，正在重启…",
+  "migrateStepError": "迁移失败",
+  "migrateRetry": "重试",
+  "migrateButtonStart": "开始迁移",
+  "migrateConversationCount": "正在迁移对话 {current}/{total}",
+  "@migrateConversationCount": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "migrateConsistencyFailed": "一致性校验失败，请重试"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -46,6 +46,10 @@
   "storageSpaceSubChatMessages": "消息",
   "storageSpaceSubChatConversations": "会话",
   "storageSpaceSubChatToolEvents": "工具事件",
+  "storageSpaceSubChatDatabase": "数据库",
+  "storageSpaceSubChatOutdated": "(已废弃)",
+  "storageSpaceChatDataMigrationNote": "可能影响聊天记录，请谨慎删除。聊天数据已从 Hive 迁移至 SQLite，旧文件仍然保留在磁盘上。若确认新版本已稳定运行，可前往目录清理 hive 文件。",
+  "storageSpaceChatDataOpenFolder": "打开目录",
   "storageSpaceSubAssistantAvatars": "头像",
   "storageSpaceSubAssistantImages": "图片",
   "storageSpaceSubCacheAvatars": "头像缓存",
@@ -1932,5 +1936,26 @@
         "type": "int"
       }
     }
-  }
+  },
+  "migrateTitle": "数据迁移",
+  "migrateDescription": "检测到旧版本聊天数据，需要迁移到新存储格式。\n迁移期间请勿关闭应用。",
+  "migrateStepReading": "正在读取旧数据…",
+  "migrateStepWriting": "正在写入新存储…",
+  "migrateStepVerifying": "正在校验数据一致性…",
+  "migrateStepComplete": "迁移完成，正在重启…",
+  "migrateStepError": "迁移失败",
+  "migrateRetry": "重试",
+  "migrateButtonStart": "开始迁移",
+  "migrateConversationCount": "正在迁移对话 {current}/{total}",
+  "@migrateConversationCount": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "migrateConsistencyFailed": "一致性校验失败，请重试"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -46,6 +46,10 @@
   "storageSpaceSubChatMessages": "訊息",
   "storageSpaceSubChatConversations": "對話",
   "storageSpaceSubChatToolEvents": "工具事件",
+  "storageSpaceSubChatDatabase": "資料庫",
+  "storageSpaceSubChatOutdated": "(已廢棄)",
+  "storageSpaceChatDataMigrationNote": "可能影響聊天記錄，請謹慎刪除。聊天資料已從 Hive 遷移至 SQLite，舊檔案仍然保留在磁碟上。若確認新版本已穩定運行，可前往目錄清理 hive 檔案。",
+  "storageSpaceChatDataOpenFolder": "開啟目錄",
   "storageSpaceSubAssistantAvatars": "頭像",
   "storageSpaceSubAssistantImages": "圖片",
   "storageSpaceSubCacheAvatars": "頭像快取",
@@ -1932,5 +1936,26 @@
         "type": "int"
       }
     }
-  }
+  },
+  "migrateTitle": "資料遷移",
+  "migrateDescription": "偵測到舊版聊天資料，需要遷移至新儲存格式。\n遷移期間請勿關閉應用程式。",
+  "migrateStepReading": "正在讀取舊資料…",
+  "migrateStepWriting": "正在寫入新儲存…",
+  "migrateStepVerifying": "正在驗證資料一致性…",
+  "migrateStepComplete": "遷移完成，正在重新啟動…",
+  "migrateStepError": "遷移失敗",
+  "migrateRetry": "重試",
+  "migrateButtonStart": "開始遷移",
+  "migrateConversationCount": "正在遷移對話 {current}/{total}",
+  "@migrateConversationCount": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "migrateConsistencyFailed": "一致性驗證失敗，請重試"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,10 +42,12 @@ import 'shared/widgets/app_overlays.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:system_fonts/system_fonts.dart';
 import 'dart:io'
-    show Platform; // kept for global override usage inside provider
+    show Platform, stderr; // kept for global override usage inside provider
 import 'core/services/android_background.dart';
 import 'core/services/notification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'core/services/migration/migration_service.dart';
+import 'features/migration/pages/migration_screen.dart';
 
 final RouteObserver<ModalRoute<dynamic>> routeObserver =
     RouteObserver<ModalRoute<dynamic>>();
@@ -53,7 +55,7 @@ bool _didCheckUpdates = false; // one-time update check flag
 bool _didEnsureAssistants = false; // ensure defaults after l10n ready
 
 Future<void> main() async {
-  await runZoned(
+  await runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
       FlutterLogger.installGlobalHandlers();
@@ -81,8 +83,14 @@ Future<void> main() async {
       await SandboxPathResolver.init();
       // Enable edge-to-edge to allow content under system bars (Android)
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      // Start app (Flutter log capture is toggleable and off by default)
+
+      // Start app (migration check happens inside app tree)
       runApp(const MyApp());
+    },
+    (Object error, StackTrace stack) {
+      stderr.writeln('=== UNHANDLED ZONE ERROR ===');
+      stderr.writeln(error);
+      stderr.writeln(stack);
     },
     zoneSpecification: ZoneSpecification(
       print: (self, parent, zone, line) {
@@ -365,7 +373,7 @@ class MyApp extends StatelessWidget {
                 darkTheme: themedDark,
                 themeMode: settings.themeMode,
                 navigatorObservers: <NavigatorObserver>[routeObserver],
-                home: _selectHome(),
+                home: const _BootPage(),
                 builder: (ctx, child) {
                   final bright = Theme.of(ctx).brightness;
                   final overlay = bright == Brightness.dark
@@ -451,6 +459,42 @@ class MyApp extends StatelessWidget {
         },
       ),
     );
+  }
+}
+
+// ── Boot page: checks migration before showing normal app ────────────────
+
+class _BootPage extends StatefulWidget {
+  const _BootPage();
+
+  @override
+  State<_BootPage> createState() => _BootPageState();
+}
+
+class _BootPageState extends State<_BootPage> {
+  bool _booted = false;
+  bool _needsMigration = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _check();
+  }
+
+  Future<void> _check() async {
+    final needs = await MigrationService.isMigrationRequired();
+    if (!mounted) return;
+    setState(() {
+      _needsMigration = needs;
+      _booted = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_booted) return const SizedBox.shrink();
+    if (_needsMigration) return const MigrationScreen();
+    return _selectHome();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,13 +113,17 @@ dependencies:
   cupertino_icons: ^1.0.8
   restart_app: ^1.8.3
 
+  # SQLite via drift
+  drift: ^2.23.0
+  sqlite3_flutter_libs: ^0.5.27+1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.4.0
-  hive_generator: ^2.0.0
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.6
+  drift_dev: ^2.23.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/core/providers/assistant_provider_cascade_delete_test.dart
+++ b/test/core/providers/assistant_provider_cascade_delete_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 // ignore: depend_on_referenced_packages
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -54,6 +53,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tempDir;
+  final services = <ChatService>[];
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp(
@@ -63,7 +63,10 @@ void main() {
   });
 
   tearDown(() async {
-    await Hive.close();
+    for (final s in services) {
+      await s.close();
+    }
+    services.clear();
     if (await tempDir.exists()) {
       await tempDir.delete(recursive: true);
     }
@@ -74,6 +77,7 @@ void main() {
       'deletes conversations and messages owned by the deleted assistant',
       () async {
         final chatService = ChatService();
+        services.add(chatService);
         await chatService.init();
         final provider = await _createLoadedAssistantProvider(
           chatService: chatService,
@@ -132,6 +136,7 @@ void main() {
       'deletes draft conversations owned by the deleted assistant',
       () async {
         final chatService = ChatService();
+        services.add(chatService);
         await chatService.init();
         final provider = await _createLoadedAssistantProvider(
           chatService: chatService,
@@ -159,6 +164,7 @@ void main() {
       'notifies once when deleting multiple assistant conversations',
       () async {
         final chatService = ChatService();
+        services.add(chatService);
         await chatService.init();
 
         final first = await chatService.createConversation(
@@ -202,6 +208,7 @@ void main() {
       'keeps conversations when deleting the last assistant is rejected',
       () async {
         final chatService = ChatService();
+        services.add(chatService);
         await chatService.init();
         final provider = await _createLoadedAssistantProvider(
           chatService: chatService,

--- a/test/core/services/backup/cherry_importer_test.dart
+++ b/test/core/services/backup/cherry_importer_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 // ignore: depend_on_referenced_packages
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -35,6 +34,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tempDir;
+  final services = <ChatService>[];
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('kelivo_cherry_test_');
@@ -43,7 +43,10 @@ void main() {
   });
 
   tearDown(() async {
-    await Hive.close();
+    for (final s in services) {
+      await s.close();
+    }
+    services.clear();
     if (await tempDir.exists()) {
       await tempDir.delete(recursive: true);
     }
@@ -80,6 +83,7 @@ void main() {
       });
 
       final chatService = ChatService();
+      services.add(chatService);
       final result = await CherryImporter.importFromCherryStudio(
         file: backup,
         mode: RestoreMode.overwrite,
@@ -179,6 +183,7 @@ void main() {
       });
 
       final chatService = ChatService();
+      services.add(chatService);
       final result = await CherryImporter.importFromCherryStudio(
         file: backup,
         mode: RestoreMode.overwrite,
@@ -205,12 +210,15 @@ void main() {
         ),
       });
 
+      final chatService = ChatService();
+      services.add(chatService);
+
       await expectLater(
         CherryImporter.importFromCherryStudio(
           file: backup,
           mode: RestoreMode.overwrite,
           settings: SettingsProvider(),
-          chatService: ChatService(),
+          chatService: chatService,
         ),
         throwsA(anything),
       );

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 // ignore: depend_on_referenced_packages
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
@@ -25,10 +24,17 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
   Future<String?> getTemporaryPath() async => '$path/tmp';
 }
 
+ChatService _createService() {
+  final service = ChatService();
+  // setUp is responsible for temp dir and path provider
+  return service;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tempDir;
+  final services = <ChatService>[];
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp(
@@ -38,7 +44,10 @@ void main() {
   });
 
   tearDown(() async {
-    await Hive.close();
+    for (final s in services) {
+      await s.close();
+    }
+    services.clear();
     if (await tempDir.exists()) {
       await tempDir.delete(recursive: true);
     }
@@ -46,7 +55,8 @@ void main() {
 
   group('ChatService temporary conversations', () {
     test('ordinary draft persists when its first message is added', () async {
-      final service = ChatService();
+      final service = _createService();
+      services.add(service);
       await service.init();
 
       final conversation = await service.createDraftConversation(title: 'Chat');
@@ -63,7 +73,8 @@ void main() {
     test(
       'temporary draft keeps messages in memory without entering history',
       () async {
-        final service = ChatService();
+        final service = _createService();
+        services.add(service);
         await service.init();
 
         final conversation = await service.createDraftConversation(
@@ -86,7 +97,8 @@ void main() {
     test(
       'temporary conversation supports range and recent message reads',
       () async {
-        final service = ChatService();
+        final service = _createService();
+        services.add(service);
         await service.init();
 
         final conversation = await service.createDraftConversation(
@@ -127,7 +139,8 @@ void main() {
     test(
       'temporary conversation is discarded when current conversation changes',
       () async {
-        final service = ChatService();
+        final service = _createService();
+        services.add(service);
         await service.init();
 
         final temporary = await service.createDraftConversation(
@@ -150,7 +163,8 @@ void main() {
     );
 
     test('temporary message deletion only affects memory', () async {
-      final service = ChatService();
+      final service = _createService();
+      services.add(service);
       await service.init();
 
       final conversation = await service.createDraftConversation(


### PR DESCRIPTION
## Motivation

此前发生过多起聊天记录大面积丢失事件：`conversations` 表（Hive Box）幸存，但 `messages` 表因进程异常退出（crash / force-quit）而损坏，导致用户看到对话列表正常但消息全部消失。Hive 作为纯键值存储，缺乏外键约束、事务写入保障和崩溃恢复能力。本次改用 **drift (SQLite)**，利用 SQLite 成熟的 ACID 特性和 `PRAGMA foreign_keys = ON` + WAL 日志模式，从根本上解决数据损坏问题。

## Change size note

代码统计 +5,761 / −333，其中 **~4,135 行（约 71%）** 来自 `lib/core/database/kelivo_database.g.dart`——这是 drift 代码生成器根据表定义自动产出的 DAO 层，开发者从不手写。排除生成代码后，实际手写变更约 **+1,700 行**。

## Changes

**基础设施** — 新增 Drift 数据库定义（`Conversations`、`Messages`、`ToolEvents`、`MigrationMeta` 四张表）、domain ↔ 表行映射器、Hive → SQLite 迁移服务（读取 → 写入 → 一致性校验）及深色主题迁移进度 UI。`pubspec.yaml` 添加 `drift` / `sqlite3_flutter_libs` / `drift_dev`，移除 `hive_generator`。

**核心替换** — `ChatService` 全面重写：`init()` 时一次性预加载所有数据到内存，读写走缓存，写入调用 drift 的 `insert`/`update`/`delete`；利用外键级联删除保障一致性；移除 Hive 特有的 crash-recovery 追踪逻辑。各 Controller 增加 `ensureMessagesLoaded()` 兜底调用。

**启动入口** — `main.dart` 新增 `_BootPage`，在应用启动前检测是否需要从 Hive 迁移数据；切换到 `runZonedGuarded` 并输出未捕获异常到 stderr。

**UI & 本地化** — 存储空间页新增 `Database` 条目展示 SQLite 文件大小，Hive 旧条目标注「(已废弃)」，Chat Data 分类增加迁移说明和「打开目录」按钮。4 个 ARB 文件同步新增 16 个本地化 key。

**测试适配** — 3 个测试文件移除 `hive_flutter` 依赖，改用 `ChatService.close()` 管理生命周期。

## Migration path

首次安装用户直接使用 SQLite，无迁移流程。已有 Hive 数据的用户启动时自动弹出迁移屏 → 读取 Hive → 写入 SQLite → 一致性校验 → 重启应用。迁移完成后 Hive 旧文件保留在磁盘上，用户可在设置 → 存储空间中查看并手动清理。

## Verification

`flutter analyze lib/ test/` → **No issues found**；`flutter test`（3 个修改文件，12 个用例）→ **All tests passed**。

---

目前只做了 Windows 真机实测通过。不指望这个变更能快速合并到稳定版，涉及数据库还是要慎之又慎的。辛苦作者有空审一下。