### PR TITLE
feat: implement auto-sync core infrastructure (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ flutter test
 | Platform directories `android/ ios/ macos/ linux/ windows/` | At least one targeted platform verification; if impossible, state why explicitly |
 | `dependencies/**` path dependencies | Run analysis/tests in the dependency's own directory, not just the root repo |
 | `lib/desktop/**`, desktop hotkeys/tray/window logic | At least one desktop-targeted verification (e.g. `flutter run -d macos`, `flutter build macos`, or the corresponding Windows/Linux target); if only the current machine's platform was verified, state the uncovered platform boundary |
+| `lib/core/services/sync/**` **/** `lib/core/providers/sync*.dart` **/** `lib/core/services/sync/**` | Run `flutter test test/core/services/sync/` after implementation; verify `SyncChangeLog` append/read/mark/cleanup, `SyncEngine` push/pull/error-handling, and `SyncProvider` state transitions |
 
 - If local environment limitations prevent completing any verification, the final delivery notes must explicitly state "what was not run, why, and where the risk lies".
 
@@ -172,7 +173,16 @@ flutter test
 - Do not expand scope just because you spotted something that "could be unified". Finish the current task first, then decide whether to open a separate refactoring task.
 - When touching a path dependency, treat it as an independent module. Do not only patch the surface at the root repo level.
 
-### 3.8 Desktop Tasks: Determine Entry Layer First
+### 3.8 Sync Implementation Rules
+
+- SyncChangeLog writes must be O(1) appends to Hive — never scan the full Hive box to determine what changed.
+- Push must mark changelog entries with a `batchId` before uploading; delete only entries with that `batchId` after a successful upload.
+- Streaming messages (`isStreaming == true`) must never trigger a changelog write. Only write when `isStreaming` transitions from `true` to `false`.
+- Pull must process remote batch files in chronological order. If a file fails download after 2 retries, stop the entire pull and record an error state.
+- Initial sync must present a list of remote backup ZIPs for the user to choose from. Never auto-detect or auto-restore.
+- SyncTransport is an abstract interface — SyncEngine must never reference WebDavConfig or S3Config directly.
+
+### 3.9 Desktop Tasks: Determine Entry Layer First
 
 - When the task mentions desktop, Windows, macOS, Linux, tray, hotkeys, window, context menu, or desktop settings, first determine which layer the issue belongs to:
   - Top-level desktop app shell: `lib/desktop/**`
@@ -302,6 +312,24 @@ flutter test
   - Only record issues that actually occurred in this repo and have reuse value for future development.
   - Do not write "heard this might happen" hearsay entries.
   - When adding entries, prefer "symptom -> root cause -> fix/constraint". Avoid recording conclusions without context.
+
+### Sync: Initial sync must use user-selected backup ZIP, not auto-detected
+
+- **Symptom**: New device auto-detects the latest backup ZIP and restores it → accidentally recovers its own backup (uploaded from the same device) → data appears unchanged but baseline timestamp is wrong.
+- **Root cause**: Without distinguishing device identity in backup files, the sync engine has no way to tell whether a backup originated from itself or another device.
+- **Constraint**: Initial sync must present a list of remote backup ZIPs to the user and let them choose explicitly. Three choices: (1) select a backup and restore, (2) skip (local is already the newest), (3) cancel (go upload a backup on the other device first).
+
+### Sync: Push must lock changelog entries with batchId
+
+- **Symptom**: While push is in progress (reading changelog → uploading → deleting synced entries), a user action creates a new changelog entry. The deletion step removes the new entry because it was un-synced.
+- **Root cause**: Push reads `synced == false` entries, uploads them, then deletes `synced == false`. Any entry written during the upload window is caught by the same deletion.
+- **Constraint**: Push must mark entries with a `batchId` before uploading, then delete only entries with that `batchId`. New concurrent entries get a different or null `batchId` and are protected.
+
+### Sync: Streaming messages must not trigger changelog writes
+
+- **Symptom**: Token-by-token streaming updates call `updateMessageSilent` 100+ times per message → each writes a changelog entry → 100 dead entries for a single message.
+- **Root cause**: Streaming updates write partial content that is meaningless for sync—only the completed message should propagate.
+- **Constraint**: Only write changelog for messages where `isStreaming` transitions from `true` to `false`. Never write changelog from `updateMessageSilent`.
 
 ## Appendix: Skills Usage Rules
 

--- a/lib/core/providers/sync_provider.dart
+++ b/lib/core/providers/sync_provider.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+enum SyncStatus { disabled, enabling, idle, pushing, pulling, error }
+
+class SyncProvider extends ChangeNotifier {
+  SyncStatus _status = SyncStatus.disabled;
+  int _pendingChangeCount = 0;
+  DateTime? _lastSyncAt;
+  String? _lastError;
+  int _consecutiveFailures = 0;
+
+  /// External callback set by the app initialization code.
+  /// UI calls [triggerSync] which dispatches here.
+  VoidCallback? onTriggerSync;
+  VoidCallback? onResetError;
+
+  SyncStatus get status => _status;
+  int get pendingChangeCount => _pendingChangeCount;
+  DateTime? get lastSyncAt => _lastSyncAt;
+  String? get lastError => _lastError;
+  int get consecutiveFailures => _consecutiveFailures;
+  bool get isReady => _status == SyncStatus.idle;
+
+  void triggerSync() {
+    onTriggerSync?.call();
+  }
+
+  void setStatus(SyncStatus status) {
+    if (_status == status) return;
+    _status = status;
+    if (status != SyncStatus.error) {
+      _lastError = null;
+    }
+    notifyListeners();
+  }
+
+  void setPendingChangeCount(int count) {
+    if (_pendingChangeCount == count) return;
+    _pendingChangeCount = count;
+    notifyListeners();
+  }
+
+  void setLastSyncAt(DateTime? at) {
+    _lastSyncAt = at;
+    notifyListeners();
+  }
+
+  void recordError(String message) {
+    _status = SyncStatus.error;
+    _lastError = message;
+    _consecutiveFailures++;
+    notifyListeners();
+  }
+
+  void resetError() {
+    onResetError?.call();
+    if (_status == SyncStatus.error) {
+      _status = SyncStatus.idle;
+    }
+    _lastError = null;
+    _consecutiveFailures = 0;
+    notifyListeners();
+  }
+
+  bool get shouldBackoff => _consecutiveFailures >= 3;
+
+  bool get shouldStop => _consecutiveFailures >= 6;
+}

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:hive_flutter/hive_flutter.dart';
@@ -6,6 +7,7 @@ import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
+import '../sync/sync_change_log.dart';
 
 class ChatService extends ChangeNotifier {
   static const String _conversationsBoxName = 'conversations';
@@ -34,6 +36,15 @@ class ChatService extends ChangeNotifier {
 
   // Localized default title for new conversations; set by UI on startup.
   String _defaultConversationTitle = 'New Chat';
+
+  SyncChangeLog? _syncChangeLog;
+  String _syncDeviceId = '';
+
+  void attachSyncChangeLog(SyncChangeLog log, {required String deviceId}) {
+    _syncChangeLog = log;
+    _syncDeviceId = deviceId;
+  }
+
   void setDefaultConversationTitle(String title) {
     if (title.trim().isEmpty) return;
     _defaultConversationTitle = title.trim();
@@ -78,6 +89,44 @@ class ChatService extends ChangeNotifier {
     notifyListeners();
   }
 
+  // SyncEngine calls this to ensure a remote conversation exists locally.
+  Future<void> ensureConversation(
+    String conversationId, {
+    required String title,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) async {
+    if (_conversationsBox.containsKey(conversationId)) return;
+    final conv = Conversation(
+      id: conversationId,
+      title: title,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+    await _conversationsBox.put(conversationId, conv);
+  }
+
+  void notifyDataChange() {
+    notifyListeners();
+  }
+
+  void _recordChange({
+    required String domain,
+    required String action,
+    required String recordId,
+    int? timestampMillis,
+    String? data,
+  }) {
+    _syncChangeLog?.append(
+      domain: domain,
+      action: action,
+      recordId: recordId,
+      timestampMillis: timestampMillis,
+      data: data,
+      deviceId: _syncDeviceId,
+    );
+  }
+
   List<Conversation> getAllConversations() {
     if (!_initialized) return [];
     final conversations = _conversationsBox.values.toList();
@@ -92,6 +141,13 @@ class ChatService extends ChangeNotifier {
   Conversation? getConversation(String id) {
     if (!_initialized) return null;
     return _conversationsBox.get(id) ?? _draftConversations[id];
+  }
+
+  ChatMessage? getMessage(String messageId) {
+    if (!_initialized) return null;
+    final cached = _cachedTemporaryMessage(messageId);
+    if (cached != null) return cached;
+    return _messagesBox.get(messageId);
   }
 
   Conversation? _conversationForMessages(String conversationId) {
@@ -298,6 +354,12 @@ class ChatService extends ChangeNotifier {
 
     await _conversationsBox.put(conversation.id, conversation);
     _currentConversationId = conversation.id;
+    _recordChange(
+      domain: 'conversation',
+      action: 'create',
+      recordId: conversation.id,
+      data: jsonEncode(conversation.toJson()),
+    );
     notifyListeners();
     return conversation;
   }
@@ -349,6 +411,7 @@ class ChatService extends ChangeNotifier {
     // Delete orphaned files (not referenced by any remaining conversation)
     await _cleanupOrphanUploads();
 
+    _recordChange(domain: 'conversation', action: 'delete', recordId: id);
     notifyListeners();
   }
 
@@ -911,6 +974,15 @@ class ChatService extends ChangeNotifier {
       _messagesCache[conversationId]!.add(message);
     }
 
+    if (!isStreaming && !temporary) {
+      _recordChange(
+        domain: 'chatMessage',
+        action: 'create',
+        recordId: message.id,
+        data: jsonEncode(message.toJson()),
+      );
+    }
+
     notifyListeners();
     return message;
   }
@@ -996,6 +1068,16 @@ class ChatService extends ChangeNotifier {
       if (index != -1) {
         messages[index] = updatedMessage;
       }
+    }
+
+    if (!updatedMessage.isStreaming) {
+      _recordChange(
+        domain: 'chatMessage',
+        action: 'update',
+        recordId: messageId,
+        timestampMillis: updatedMessage.timestamp.millisecondsSinceEpoch,
+        data: jsonEncode(updatedMessage.toJson()),
+      );
     }
 
     notifyListeners();
@@ -1460,6 +1542,7 @@ class ChatService extends ChangeNotifier {
     // Clean up orphaned upload files that are no longer referenced by any message
     await _cleanupOrphanUploads();
 
+    _recordChange(domain: 'chatMessage', action: 'delete', recordId: messageId);
     notifyListeners();
   }
 

--- a/lib/core/services/sync/sync_change_log.dart
+++ b/lib/core/services/sync/sync_change_log.dart
@@ -1,0 +1,144 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+enum SyncDomain { chatMessage, conversation, toolEvent, thoughtSig }
+
+enum SyncAction { create, update, delete }
+
+class SyncChangeLogEntry {
+  final String id;
+  final String domain;
+  final String action;
+  final String recordId;
+  final int timestampMillis;
+  final String? data;
+  final String deviceId;
+  final String? batchId;
+  final bool synced;
+
+  const SyncChangeLogEntry({
+    required this.id,
+    required this.domain,
+    required this.action,
+    required this.recordId,
+    required this.timestampMillis,
+    this.data,
+    required this.deviceId,
+    this.batchId,
+    this.synced = false,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'domain': domain,
+    'action': action,
+    'recordId': recordId,
+    'timestampMillis': timestampMillis,
+    'data': data,
+    'deviceId': deviceId,
+    'batchId': batchId,
+    'synced': synced,
+  };
+
+  factory SyncChangeLogEntry.fromJson(Map<String, dynamic> json) =>
+      SyncChangeLogEntry(
+        id: json['id'] as String,
+        domain: json['domain'] as String,
+        action: json['action'] as String,
+        recordId: json['recordId'] as String,
+        timestampMillis: json['timestampMillis'] as int,
+        data: json['data'] as String?,
+        deviceId: json['deviceId'] as String,
+        batchId: json['batchId'] as String?,
+        synced: json['synced'] as bool? ?? false,
+      );
+}
+
+class SyncChangeLog {
+  static const String _boxName = 'sync_change_log_v1';
+
+  Box? _box;
+
+  Future<void> init() async {
+    _box = await Hive.openBox(_boxName);
+  }
+
+  String append({
+    required String domain,
+    required String action,
+    required String recordId,
+    int? timestampMillis,
+    String? data,
+    required String deviceId,
+  }) {
+    final id = const Uuid().v4();
+    final entry = SyncChangeLogEntry(
+      id: id,
+      domain: domain,
+      action: action,
+      recordId: recordId,
+      timestampMillis: timestampMillis ?? DateTime.now().millisecondsSinceEpoch,
+      data: data,
+      deviceId: deviceId,
+    );
+    _box!.put(id, entry.toJson());
+    return id;
+  }
+
+  List<SyncChangeLogEntry> getUnsynced() {
+    final entries = <SyncChangeLogEntry>[];
+    for (final value in _box!.values) {
+      final map = Map<String, dynamic>.from(value as Map);
+      final entry = SyncChangeLogEntry.fromJson(map);
+      if (!entry.synced && entry.batchId == null) {
+        entries.add(entry);
+      }
+    }
+    return entries;
+  }
+
+  void markBatch(List<SyncChangeLogEntry> entries, String batchId) {
+    for (final entry in entries) {
+      final map = Map<String, dynamic>.from(_box!.get(entry.id) as Map);
+      map['batchId'] = batchId;
+      _box!.put(entry.id, map);
+    }
+  }
+
+  void deleteByBatchId(String batchId) {
+    final keysToDelete = <dynamic>[];
+    for (final key in _box!.keys) {
+      final map = Map<String, dynamic>.from(_box!.get(key) as Map);
+      if (map['batchId'] == batchId) {
+        keysToDelete.add(key);
+      }
+    }
+    for (final key in keysToDelete) {
+      _box!.delete(key);
+    }
+  }
+
+  void deleteSynced() {
+    final keysToDelete = <dynamic>[];
+    for (final key in _box!.keys) {
+      final map = Map<String, dynamic>.from(_box!.get(key) as Map);
+      if (map['synced'] == true) {
+        keysToDelete.add(key);
+      }
+    }
+    for (final key in keysToDelete) {
+      _box!.delete(key);
+    }
+  }
+
+  int get pendingCount {
+    var count = 0;
+    for (final value in _box!.values) {
+      final map = Map<String, dynamic>.from(value as Map);
+      if (map['synced'] == false && map['batchId'] == null) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/lib/core/services/sync/sync_engine.dart
+++ b/lib/core/services/sync/sync_engine.dart
@@ -1,0 +1,264 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:uuid/uuid.dart';
+
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../providers/sync_provider.dart';
+import '../chat/chat_service.dart';
+import 'sync_change_log.dart';
+import 'sync_metadata.dart';
+import 'sync_transport.dart';
+
+class SyncEngine {
+  static const int _debounceMillis = 30000;
+  static const int _maxBatchAgeMillis = 300000;
+
+  final SyncChangeLog _changeLog;
+  final SyncMetadata _metadata;
+  final ChatService _chatService;
+  final SyncProvider _provider;
+  SyncTransport? _transport;
+
+  Timer? _debounceTimer;
+  Timer? _pullTimer;
+  bool _disposed = false;
+  int _lastKnownChangeCount = 0;
+  int? _flushDeadline;
+
+  SyncEngine({
+    required SyncChangeLog changeLog,
+    required SyncMetadata metadata,
+    required ChatService chatService,
+    required SyncProvider provider,
+    SyncTransport? transport,
+  })  : _changeLog = changeLog,
+        _metadata = metadata,
+        _chatService = chatService,
+        _provider = provider,
+        _transport = transport;
+
+  void setTransport(SyncTransport transport) {
+    _transport = transport;
+  }
+
+  bool get _canSync => _transport != null && _metadata.enabled;
+
+  void notifyChange() {
+    if (!_canSync || _disposed) return;
+    _debounceTimer?.cancel();
+    _flushDeadline ??=
+        DateTime.now().millisecondsSinceEpoch + _maxBatchAgeMillis;
+    _debounceTimer = Timer(
+      const Duration(milliseconds: _debounceMillis),
+      _onDebounceElapsed,
+    );
+  }
+
+  Future<void> _onDebounceElapsed() async {
+    if (!_canSync || _disposed) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (_flushDeadline != null && now >= _flushDeadline!) {
+      await _flush();
+      return;
+    }
+    final count = _changeLog.pendingCount;
+    if (count > _lastKnownChangeCount) {
+      _lastKnownChangeCount = count;
+      _debounceTimer = Timer(
+        const Duration(milliseconds: _debounceMillis),
+        _onDebounceElapsed,
+      );
+      return;
+    }
+    await _flush();
+  }
+
+  Future<void> _flush() async {
+    _flushDeadline = null;
+    _lastKnownChangeCount = 0;
+    await push();
+    await pull();
+  }
+
+  Future<void> startPeriodicPull() async {
+    final interval = _metadata.pullIntervalSeconds;
+    _pullTimer?.cancel();
+    _pullTimer = Timer.periodic(Duration(seconds: interval), (_) async {
+      if (_canSync && !_disposed) {
+        await pull();
+      }
+    });
+  }
+
+  void stopPeriodicPull() {
+    _pullTimer?.cancel();
+    _pullTimer = null;
+  }
+
+  Future<void> triggerImmediate() async {
+    if (!_canSync || _disposed) return;
+    _debounceTimer?.cancel();
+    _flushDeadline = null;
+    _lastKnownChangeCount = 0;
+    await push();
+    await pull();
+  }
+
+  Future<void> push() async {
+    if (!_canSync || _disposed) return;
+    final entries = _changeLog.getUnsynced();
+    if (entries.isEmpty) return;
+
+    _provider.setStatus(SyncStatus.pushing);
+    try {
+      final batchId = const Uuid().v4();
+      _changeLog.markBatch(entries, batchId);
+
+      final batch = {
+        'batchId': batchId,
+        'deviceId': _metadata.deviceId,
+        'createdAt': DateTime.now().millisecondsSinceEpoch,
+        'changes': entries.map((e) => e.toJson()).toList(),
+      };
+      final bytes = utf8.encode(jsonEncode(batch));
+
+      final filename =
+          '${DateTime.now().millisecondsSinceEpoch}_${_metadata.deviceId}_$batchId.json';
+
+      await _transport!.uploadBytes('.kelivo_sync/changes/$filename', bytes);
+
+      _changeLog.deleteByBatchId(batchId);
+      _changeLog.deleteSynced();
+      _provider.setLastSyncAt(DateTime.now());
+      _provider.setStatus(SyncStatus.idle);
+    } catch (e) {
+      _provider.recordError(e.toString());
+    }
+  }
+
+  Future<void> pull() async {
+    if (!_canSync || _disposed) return;
+
+    _provider.setStatus(SyncStatus.pulling);
+    try {
+      final since = _metadata.lastSyncAt;
+      final files = await _transport!.listFiles('.kelivo_sync/changes/');
+
+      final sorted = <RemoteFile>[];
+      for (final f in files) {
+        final name = f.path.split('/').last;
+        final parts = name.split('_');
+        if (parts.length < 3) continue;
+        final ts = int.tryParse(parts[0]);
+        final deviceId = parts[1];
+        if (ts == null) continue;
+        if (deviceId == _metadata.deviceId) continue;
+        if (since != null && ts <= since) continue;
+        sorted.add(f);
+      }
+      sorted.sort((a, b) => a.path.compareTo(b.path));
+
+      int? lastAppliedTimestamp;
+      for (final file in sorted) {
+        try {
+          final bytes = await _transport!.downloadBytes(file.path);
+          final batch = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+          final changes = batch['changes'] as List<dynamic>;
+          for (final c in changes) {
+            await _applyChange(c as Map<String, dynamic>);
+          }
+          lastAppliedTimestamp = batch['createdAt'] as int;
+        } catch (e) {
+          _provider.recordError('Failed to apply ${file.path}: $e');
+          return;
+        }
+      }
+
+      if (lastAppliedTimestamp != null) {
+        _metadata.lastSyncAt = lastAppliedTimestamp;
+      }
+      _provider.setLastSyncAt(DateTime.now());
+      _provider.setStatus(SyncStatus.idle);
+    } catch (e) {
+      _provider.recordError(e.toString());
+    }
+  }
+
+  Future<void> _applyChange(Map<String, dynamic> change) async {
+    final domain = change['domain'] as String;
+    final action = change['action'] as String;
+    final recordId = change['recordId'] as String;
+    final dataStr = change['data'] as String?;
+
+    if (domain == 'chatMessage') {
+      if (action == 'delete') {
+        await _chatService.deleteMessage(recordId);
+        return;
+      }
+      if (dataStr == null) return;
+      final data = jsonDecode(dataStr) as Map<String, dynamic>;
+      final remoteMsg = ChatMessage.fromJson(data);
+      final localMsg = _chatService.getMessage(recordId);
+      if (localMsg != null) {
+        if (remoteMsg.timestamp.millisecondsSinceEpoch <=
+            localMsg.timestamp.millisecondsSinceEpoch) {
+          return;
+        }
+      }
+      var conv = _chatService.getConversation(remoteMsg.conversationId);
+      if (conv == null) {
+        await _chatService.ensureConversation(
+          remoteMsg.conversationId,
+          title: remoteMsg.conversationId,
+          createdAt: remoteMsg.timestamp,
+          updatedAt: remoteMsg.timestamp,
+        );
+      }
+      await _chatService.addMessageDirectly(
+        remoteMsg.conversationId,
+        remoteMsg,
+      );
+    } else if (domain == 'conversation') {
+      if (action == 'delete') {
+        await _chatService.deleteConversation(recordId);
+        return;
+      }
+      if (dataStr == null) return;
+      final remoteConv = Conversation.fromJson(
+        jsonDecode(dataStr) as Map<String, dynamic>,
+      );
+      final localConv = _chatService.getConversation(recordId);
+      if (localConv != null) {
+        if (remoteConv.updatedAt.millisecondsSinceEpoch <=
+            localConv.updatedAt.millisecondsSinceEpoch) {
+          return;
+        }
+        localConv.title = remoteConv.title;
+        localConv.updatedAt = remoteConv.updatedAt;
+        localConv.isPinned = remoteConv.isPinned;
+        localConv.assistantId = remoteConv.assistantId;
+        localConv.truncateIndex = remoteConv.truncateIndex;
+        localConv.mcpServerIds = List.of(remoteConv.mcpServerIds);
+        localConv.versionSelections = Map<String, int>.from(
+          remoteConv.versionSelections,
+        );
+        localConv.summary = remoteConv.summary;
+        localConv.save();
+        _chatService.notifyDataChange();
+      } else {
+        await _chatService.createConversation(
+          title: remoteConv.title,
+          assistantId: remoteConv.assistantId,
+        );
+      }
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _debounceTimer?.cancel();
+    _pullTimer?.cancel();
+  }
+}

--- a/lib/core/services/sync/sync_metadata.dart
+++ b/lib/core/services/sync/sync_metadata.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+class SyncMetadata {
+  static const String _deviceIdKey = 'sync_device_id_v1';
+  static const String _deviceNameKey = 'sync_device_name_v1';
+  static const String _lastSyncAtKey = 'sync_last_sync_at_v1';
+  static const String _enabledKey = 'sync_enabled_v1';
+  static const String _backendChoiceKey = 'sync_backend_v1'; // 'webdav' or 's3'
+  static const String _pullIntervalKey = 'sync_pull_interval_seconds_v1';
+
+  SharedPreferences? _prefs;
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
+
+  SharedPreferences get _p {
+    return _prefs!;
+  }
+
+  String get deviceId {
+    final existing = _p.getString(_deviceIdKey);
+    if (existing != null && existing.isNotEmpty) return existing;
+    final id = const Uuid().v4();
+    _p.setString(_deviceIdKey, id);
+    return id;
+  }
+
+  String get deviceName {
+    final existing = _p.getString(_deviceNameKey);
+    if (existing != null && existing.isNotEmpty) return existing;
+    try {
+      return Platform.localHostname;
+    } catch (_) {
+      return 'Unknown';
+    }
+  }
+
+  set deviceName(String name) {
+    if (name.trim().isEmpty) return;
+    _p.setString(_deviceNameKey, name.trim());
+  }
+
+  int? get lastSyncAt {
+    final val = _p.getInt(_lastSyncAtKey);
+    return val != null && val > 0 ? val : null;
+  }
+
+  set lastSyncAt(int? millis) {
+    if (millis != null) {
+      _p.setInt(_lastSyncAtKey, millis);
+    } else {
+      _p.remove(_lastSyncAtKey);
+    }
+  }
+
+  bool get enabled => _p.getBool(_enabledKey) ?? false;
+
+  set enabled(bool value) {
+    _p.setBool(_enabledKey, value);
+  }
+
+  String? get backendChoice => _p.getString(_backendChoiceKey);
+
+  set backendChoice(String? value) {
+    if (value != null) {
+      _p.setString(_backendChoiceKey, value);
+    } else {
+      _p.remove(_backendChoiceKey);
+    }
+  }
+
+  int get pullIntervalSeconds => _p.getInt(_pullIntervalKey) ?? 300;
+
+  set pullIntervalSeconds(int seconds) {
+    _p.setInt(_pullIntervalKey, seconds.clamp(60, 3600));
+  }
+}

--- a/lib/core/services/sync/sync_transport.dart
+++ b/lib/core/services/sync/sync_transport.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart';
+
+class RemoteFile {
+  final String path;
+  final int size;
+  final DateTime lastModified;
+
+  const RemoteFile({
+    required this.path,
+    required this.size,
+    required this.lastModified,
+  });
+}
+
+abstract class SyncTransport {
+  Future<void> uploadBytes(String remotePath, List<int> bytes);
+  Future<List<RemoteFile>> listFiles(String prefix);
+  Future<List<int>> downloadBytes(String remotePath);
+  Future<void> deleteFile(String remotePath);
+}
+
+class WebDavSyncTransport implements SyncTransport {
+  final String baseUrl;
+  final String username;
+  final String password;
+  final String userAgent;
+
+  const WebDavSyncTransport({
+    required this.baseUrl,
+    this.username = '',
+    this.password = '',
+    this.userAgent = '',
+  });
+
+  Map<String, String> get _authHeaders {
+    if (username.isEmpty) return {};
+    final token = base64Encode(utf8.encode('$username:$password'));
+    return {'Authorization': 'Basic $token'};
+  }
+
+  Map<String, String> get _extraHeaders {
+    if (userAgent.isEmpty) return {};
+    return {'User-Agent': userAgent};
+  }
+
+  String _cleanUrl() {
+    var u = baseUrl.trim();
+    if (u.endsWith('/')) u = u.substring(0, u.length - 1);
+    return u;
+  }
+
+  @override
+  Future<void> uploadBytes(String remotePath, List<int> bytes) async {
+    final url = '${_cleanUrl()}/$remotePath';
+    final client = http.Client();
+    try {
+      final req = http.Request('PUT', Uri.parse(url))
+        ..headers.addAll({
+          'Content-Type': 'application/octet-stream',
+          ..._authHeaders,
+          ..._extraHeaders,
+        })
+        ..bodyBytes = bytes;
+      final res = await client.send(req).then(http.Response.fromStream);
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        throw Exception('WebDAV PUT failed: ${res.statusCode} ${res.body}');
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  @override
+  Future<List<RemoteFile>> listFiles(String prefix) async {
+    final url = '${_cleanUrl()}/$prefix';
+    final client = http.Client();
+    try {
+      final req = http.Request('PROPFIND', Uri.parse(url))
+        ..headers.addAll({
+          'Depth': '1',
+          'Content-Type': 'application/xml; charset=utf-8',
+          ..._authHeaders,
+          ..._extraHeaders,
+        });
+      final res = await client.send(req).then(http.Response.fromStream);
+      if (res.statusCode == 404) return [];
+      if (res.statusCode != 207) {
+        throw Exception('WebDAV PROPFIND failed: ${res.statusCode}');
+      }
+
+      final doc = XmlDocument.parse(res.body);
+      final files = <RemoteFile>[];
+      for (final response in doc.findAllElements('D:response')) {
+        final href = response.findElements('D:href').firstOrNull?.innerText;
+        if (href == null || href.endsWith('/')) continue;
+        final propStat = response.findElements('D:propstat').firstOrNull;
+        if (propStat == null) continue;
+        final prop = propStat.findElements('D:prop').firstOrNull;
+        if (prop == null) continue;
+        final sizeStr = prop
+            .findElements('D:getcontentlength')
+            .firstOrNull
+            ?.innerText;
+        final modifiedStr = prop
+            .findElements('D:getlastmodified')
+            .firstOrNull
+            ?.innerText;
+        files.add(
+          RemoteFile(
+            path: href,
+            size: sizeStr != null ? int.tryParse(sizeStr) ?? 0 : 0,
+            lastModified: modifiedStr != null
+                ? _parseHttpDate(modifiedStr)
+                : DateTime.now(),
+          ),
+        );
+      }
+      return files;
+    } finally {
+      client.close();
+    }
+  }
+
+  @override
+  Future<List<int>> downloadBytes(String remotePath) async {
+    final url = '${_cleanUrl()}/$remotePath';
+    final client = http.Client();
+    try {
+      final req = http.Request('GET', Uri.parse(url))
+        ..headers.addAll({..._authHeaders, ..._extraHeaders});
+      final res = await client.send(req).then(http.Response.fromStream);
+      if (res.statusCode != 200) {
+        throw Exception('WebDAV GET failed: ${res.statusCode}');
+      }
+      return res.bodyBytes.toList();
+    } finally {
+      client.close();
+    }
+  }
+
+  @override
+  Future<void> deleteFile(String remotePath) async {
+    final url = '${_cleanUrl()}/$remotePath';
+    final client = http.Client();
+    try {
+      final req = http.Request('DELETE', Uri.parse(url))
+        ..headers.addAll({..._authHeaders, ..._extraHeaders});
+      final res = await client.send(req).then(http.Response.fromStream);
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        throw Exception('WebDAV DELETE failed: ${res.statusCode}');
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  /// WebDAV returns timestamps in RFC 1123 format, e.g.
+  /// "Thu, 14 Jun 2024 12:00:00 GMT".
+  static DateTime _parseHttpDate(String input) {
+    try {
+      // Trim whitespace and remove day-of-week prefix
+      final s = input.trim();
+      final withoutDay = s.contains(',')
+          ? s.substring(s.indexOf(',') + 1).trim()
+          : s;
+      final spaceIdx = withoutDay.indexOf(' ');
+      final dayStr = withoutDay.substring(0, spaceIdx);
+      final rest = withoutDay.substring(spaceIdx).trim();
+      final dateTimeStr = '$dayStr $rest'.replaceFirst(' GMT', '');
+      final result = DateTime.tryParse(dateTimeStr);
+      if (result != null) return result.toUtc();
+    } catch (_) {}
+    return DateTime.now();
+  }
+}

--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -52,6 +52,7 @@ import 'setting/quick_phrases_pane.dart';
 import 'setting/instruction_injection_pane.dart';
 import 'setting/world_book_pane.dart';
 import 'setting/backup_pane.dart';
+import 'setting/sync_pane.dart';
 import 'setting/hotkeys_pane.dart';
 import 'setting/network_proxy_pane.dart';
 import 'setting/about_pane.dart';
@@ -97,6 +98,7 @@ enum _SettingsMenuItem {
   tts,
   networkProxy,
   backup,
+  sync,
   hotkeys,
   stats,
   about,
@@ -213,6 +215,10 @@ class _DesktopSettingsPageState extends State<DesktopSettingsPage> {
                           return const DesktopBackupPane(
                             key: ValueKey('backup'),
                           );
+                        case _SettingsMenuItem.sync:
+                          return const DesktopSyncPane(
+                            key: ValueKey('sync'),
+                          );
                         case _SettingsMenuItem.hotkeys:
                           return const DesktopHotkeysPane(
                             key: ValueKey('hotkeys'),
@@ -311,6 +317,11 @@ class _SettingsMenu extends StatelessWidget {
         _SettingsMenuItem.backup,
         lucide.Lucide.Database,
         l10n.settingsPageBackup,
+      ),
+      (
+        _SettingsMenuItem.sync,
+        lucide.Lucide.RefreshCcwDot,
+        l10n.syncTitle,
       ),
       (
         _SettingsMenuItem.hotkeys,

--- a/lib/desktop/setting/sync_pane.dart
+++ b/lib/desktop/setting/sync_pane.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../icons/lucide_adapter.dart' as lucide;
+import '../../l10n/app_localizations.dart';
+import '../../core/providers/sync_provider.dart';
+import '../../core/providers/settings_provider.dart';
+import '../../core/services/sync/sync_metadata.dart';
+import '../../shared/widgets/ios_switch.dart';
+import '../../theme/app_font_weights.dart';
+
+class DesktopSyncPane extends StatefulWidget {
+  const DesktopSyncPane({super.key});
+  @override
+  State<DesktopSyncPane> createState() => _DesktopSyncPaneState();
+}
+
+class _DesktopSyncPaneState extends State<DesktopSyncPane> {
+  final _metadata = SyncMetadata();
+  bool _initDone = false;
+  late TextEditingController _deviceNameCtrl;
+  late TextEditingController _intervalCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _initAsync();
+  }
+
+  Future<void> _initAsync() async {
+    await _metadata.init();
+    if (!mounted) return;
+    _deviceNameCtrl = TextEditingController(text: _metadata.deviceName);
+    _intervalCtrl = TextEditingController(
+      text: (_metadata.pullIntervalSeconds ~/ 60).toString(),
+    );
+    setState(() => _initDone = true);
+  }
+
+  @override
+  void dispose() {
+    _deviceNameCtrl.dispose();
+    _intervalCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final syncProvider = context.watch<SyncProvider>();
+    final settings = context.watch<SettingsProvider>();
+
+    if (!_initDone) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Title
+          Text(
+            l10n.syncTitle,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: AppFontWeights.semibold,
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Enable toggle
+          _buildRow(
+            context,
+            label: l10n.syncEnable,
+            trailing: IosSwitch(
+              value: _metadata.enabled,
+              onChanged: (val) {
+                _metadata.enabled = val;
+                syncProvider.setStatus(
+                  val ? SyncStatus.idle : SyncStatus.disabled,
+                );
+                if (!val) syncProvider.setLastSyncAt(null);
+                setState(() {});
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Status
+          _buildRow(
+            context,
+            label: _statusLabel(l10n, syncProvider),
+            trailing: _statusIndicator(syncProvider),
+          ),
+          const SizedBox(height: 8),
+
+          // Last sync time
+          if (syncProvider.lastSyncAt != null)
+            Padding(
+              padding: const EdgeInsets.only(left: 12, bottom: 12),
+              child: Text(
+                l10n.syncLastSyncAt(_formatTime(syncProvider.lastSyncAt!)),
+                style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant),
+              ),
+            ),
+
+          // Error message
+          if (syncProvider.lastError != null)
+            Padding(
+              padding: const EdgeInsets.only(left: 12, bottom: 12),
+              child: Text(
+                syncProvider.lastError!,
+                style: TextStyle(fontSize: 13, color: cs.error),
+              ),
+            ),
+
+          // Sync now button
+          Padding(
+            padding: const EdgeInsets.only(left: 12, bottom: 20),
+            child: FilledButton.tonalIcon(
+              onPressed: _metadata.enabled
+                  ? () => syncProvider.triggerSync()
+                  : null,
+              icon: const Icon(lucide.Lucide.RefreshCw, size: 18),
+              label: Text(l10n.syncManualSync),
+            ),
+          ),
+
+          const Divider(),
+          const SizedBox(height: 16),
+
+          // Backend selector
+          Text(
+            l10n.syncBackendLabel,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: AppFontWeights.semibold,
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            initialValue: _metadata.backendChoice,
+            decoration: InputDecoration(
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 10,
+              ),
+            ),
+            items: const [
+              DropdownMenuItem(value: 'webdav', child: Text('WebDAV')),
+            ],
+            onChanged: (val) {
+              _metadata.backendChoice = val;
+              setState(() {});
+            },
+          ),
+          if (settings.webDavConfig.url.trim().isEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                l10n.syncNeedBackend,
+                style: TextStyle(fontSize: 13, color: cs.error),
+              ),
+            ),
+          const SizedBox(height: 16),
+
+          // Device name
+          Text(
+            l10n.syncDeviceName,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: AppFontWeights.semibold,
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: 300,
+            child: TextField(
+              controller: _deviceNameCtrl,
+              decoration: InputDecoration(
+                isDense: true,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+              ),
+              onChanged: (val) => _metadata.deviceName = val,
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Pull interval
+          Text(
+            l10n.syncPullInterval,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: AppFontWeights.semibold,
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: 120,
+            child: TextField(
+              controller: _intervalCtrl,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                isDense: true,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+              ),
+              onChanged: (val) {
+                final parsed = int.tryParse(val);
+                if (parsed != null) {
+                  _metadata.pullIntervalSeconds = parsed * 60;
+                }
+              },
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Clear remote history
+          TextButton.icon(
+            onPressed: null,
+            icon: const Icon(lucide.Lucide.Trash2, size: 18),
+            label: Text(l10n.syncCleanHistory),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(
+    BuildContext context, {
+    required String label,
+    required Widget trailing,
+  }) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(fontSize: 14, color: cs.onSurface),
+            ),
+          ),
+          trailing,
+        ],
+      ),
+    );
+  }
+
+  Widget _statusIndicator(SyncProvider p) {
+    final color = switch (p.status) {
+      SyncStatus.disabled => Colors.grey,
+      SyncStatus.idle => Colors.green,
+      SyncStatus.pushing || SyncStatus.pulling => Colors.blue,
+      SyncStatus.enabling => Colors.orange,
+      SyncStatus.error => Colors.red,
+    };
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+      ],
+    );
+  }
+
+  String _statusLabel(AppLocalizations l10n, SyncProvider p) {
+    return switch (p.status) {
+      SyncStatus.disabled => l10n.syncStatusDisabled,
+      SyncStatus.idle => l10n.syncStatusIdle,
+      SyncStatus.pushing => l10n.syncStatusPushing,
+      SyncStatus.pulling => l10n.syncStatusPulling,
+      SyncStatus.enabling => l10n.syncStatusIdle,
+      SyncStatus.error => l10n.syncStatusError,
+    };
+  }
+
+  String _formatTime(DateTime dt) {
+    return '${dt.year}-${_pad(dt.month)}-${_pad(dt.day)} '
+        '${_pad(dt.hour)}:${_pad(dt.minute)}';
+  }
+
+  String _pad(int n) => n.toString().padLeft(2, '0');
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2355,5 +2355,33 @@
         "type": "int"
       }
     }
-  }
+  },
+  "syncTitle": "Sync",
+  "syncEnable": "Enable Sync",
+  "syncBackendLabel": "Backend",
+  "syncBackendWebdav": "WebDAV",
+  "syncBackendS3": "S3",
+  "syncBackendHint": "Configure WebDAV or S3 in Backup settings first",
+  "syncStatusIdle": "Synced",
+  "syncStatusPushing": "Uploading changes...",
+  "syncStatusPulling": "Downloading changes...",
+  "syncStatusError": "Sync error",
+  "syncStatusDisabled": "Sync disabled",
+  "syncLastSyncAt": "Last synced: {time}",
+  "@syncLastSyncAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "syncManualSync": "Sync now",
+  "syncCleanHistory": "Clear remote sync history",
+  "syncDeviceName": "Device name",
+  "syncPullInterval": "Pull interval (minutes)",
+  "syncNeedBackend": "Configure WebDAV or S3 first",
+  "syncInitialTitle": "Initialize Sync",
+  "syncInitialPickBackup": "Restore from backup",
+  "syncInitialSkip": "Local is already up to date",
+  "syncInitialCancel": "Cancel — upload backup from other device first"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10093,6 +10093,132 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{role} message #{index}: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.'**
   String debugPageManyMessagesSeedText(String role, int index);
+
+  /// No description provided for @syncTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync'**
+  String get syncTitle;
+
+  /// No description provided for @syncEnable.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Sync'**
+  String get syncEnable;
+
+  /// No description provided for @syncBackendLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Backend'**
+  String get syncBackendLabel;
+
+  /// No description provided for @syncBackendWebdav.
+  ///
+  /// In en, this message translates to:
+  /// **'WebDAV'**
+  String get syncBackendWebdav;
+
+  /// No description provided for @syncBackendS3.
+  ///
+  /// In en, this message translates to:
+  /// **'S3'**
+  String get syncBackendS3;
+
+  /// No description provided for @syncBackendHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure WebDAV or S3 in Backup settings first'**
+  String get syncBackendHint;
+
+  /// No description provided for @syncStatusIdle.
+  ///
+  /// In en, this message translates to:
+  /// **'Synced'**
+  String get syncStatusIdle;
+
+  /// No description provided for @syncStatusPushing.
+  ///
+  /// In en, this message translates to:
+  /// **'Uploading changes...'**
+  String get syncStatusPushing;
+
+  /// No description provided for @syncStatusPulling.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading changes...'**
+  String get syncStatusPulling;
+
+  /// No description provided for @syncStatusError.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync error'**
+  String get syncStatusError;
+
+  /// No description provided for @syncStatusDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync disabled'**
+  String get syncStatusDisabled;
+
+  /// No description provided for @syncLastSyncAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Last synced: {time}'**
+  String syncLastSyncAt(String time);
+
+  /// No description provided for @syncManualSync.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync now'**
+  String get syncManualSync;
+
+  /// No description provided for @syncCleanHistory.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear remote sync history'**
+  String get syncCleanHistory;
+
+  /// No description provided for @syncDeviceName.
+  ///
+  /// In en, this message translates to:
+  /// **'Device name'**
+  String get syncDeviceName;
+
+  /// No description provided for @syncPullInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'Pull interval (minutes)'**
+  String get syncPullInterval;
+
+  /// No description provided for @syncNeedBackend.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure WebDAV or S3 first'**
+  String get syncNeedBackend;
+
+  /// No description provided for @syncInitialTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Initialize Sync'**
+  String get syncInitialTitle;
+
+  /// No description provided for @syncInitialPickBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore from backup'**
+  String get syncInitialPickBackup;
+
+  /// No description provided for @syncInitialSkip.
+  ///
+  /// In en, this message translates to:
+  /// **'Local is already up to date'**
+  String get syncInitialSkip;
+
+  /// No description provided for @syncInitialCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel — upload backup from other device first'**
+  String get syncInitialCancel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5483,4 +5483,71 @@ class AppLocalizationsEn extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role message #$index: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.';
   }
+
+  @override
+  String get syncTitle => 'Sync';
+
+  @override
+  String get syncEnable => 'Enable Sync';
+
+  @override
+  String get syncBackendLabel => 'Backend';
+
+  @override
+  String get syncBackendWebdav => 'WebDAV';
+
+  @override
+  String get syncBackendS3 => 'S3';
+
+  @override
+  String get syncBackendHint =>
+      'Configure WebDAV or S3 in Backup settings first';
+
+  @override
+  String get syncStatusIdle => 'Synced';
+
+  @override
+  String get syncStatusPushing => 'Uploading changes...';
+
+  @override
+  String get syncStatusPulling => 'Downloading changes...';
+
+  @override
+  String get syncStatusError => 'Sync error';
+
+  @override
+  String get syncStatusDisabled => 'Sync disabled';
+
+  @override
+  String syncLastSyncAt(String time) {
+    return 'Last synced: $time';
+  }
+
+  @override
+  String get syncManualSync => 'Sync now';
+
+  @override
+  String get syncCleanHistory => 'Clear remote sync history';
+
+  @override
+  String get syncDeviceName => 'Device name';
+
+  @override
+  String get syncPullInterval => 'Pull interval (minutes)';
+
+  @override
+  String get syncNeedBackend => 'Configure WebDAV or S3 first';
+
+  @override
+  String get syncInitialTitle => 'Initialize Sync';
+
+  @override
+  String get syncInitialPickBackup => 'Restore from backup';
+
+  @override
+  String get syncInitialSkip => 'Local is already up to date';
+
+  @override
+  String get syncInitialCancel =>
+      'Cancel — upload backup from other device first';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5269,6 +5269,71 @@ class AppLocalizationsZh extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get syncTitle => '同步';
+
+  @override
+  String get syncEnable => '启用同步';
+
+  @override
+  String get syncBackendLabel => '后端';
+
+  @override
+  String get syncBackendWebdav => 'WebDAV';
+
+  @override
+  String get syncBackendS3 => 'S3';
+
+  @override
+  String get syncBackendHint => '请先在备份设置中配置 WebDAV 或 S3';
+
+  @override
+  String get syncStatusIdle => '已同步';
+
+  @override
+  String get syncStatusPushing => '正在上传变更...';
+
+  @override
+  String get syncStatusPulling => '正在下载变更...';
+
+  @override
+  String get syncStatusError => '同步出错';
+
+  @override
+  String get syncStatusDisabled => '同步已关闭';
+
+  @override
+  String syncLastSyncAt(String time) {
+    return '上次同步：$time';
+  }
+
+  @override
+  String get syncManualSync => '立即同步';
+
+  @override
+  String get syncCleanHistory => '清理远端同步历史';
+
+  @override
+  String get syncDeviceName => '设备名称';
+
+  @override
+  String get syncPullInterval => '拉取间隔（分钟）';
+
+  @override
+  String get syncNeedBackend => '请先配置 WebDAV 或 S3';
+
+  @override
+  String get syncInitialTitle => '初始化同步';
+
+  @override
+  String get syncInitialPickBackup => '从备份恢复';
+
+  @override
+  String get syncInitialSkip => '本地已是最新';
+
+  @override
+  String get syncInitialCancel => '取消——先去另一端上传备份';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -10536,6 +10601,71 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get syncTitle => '同步';
+
+  @override
+  String get syncEnable => '启用同步';
+
+  @override
+  String get syncBackendLabel => '后端';
+
+  @override
+  String get syncBackendWebdav => 'WebDAV';
+
+  @override
+  String get syncBackendS3 => 'S3';
+
+  @override
+  String get syncBackendHint => '请先在备份设置中配置 WebDAV 或 S3';
+
+  @override
+  String get syncStatusIdle => '已同步';
+
+  @override
+  String get syncStatusPushing => '正在上传变更...';
+
+  @override
+  String get syncStatusPulling => '正在下载变更...';
+
+  @override
+  String get syncStatusError => '同步出错';
+
+  @override
+  String get syncStatusDisabled => '同步已关闭';
+
+  @override
+  String syncLastSyncAt(String time) {
+    return '上次同步：$time';
+  }
+
+  @override
+  String get syncManualSync => '立即同步';
+
+  @override
+  String get syncCleanHistory => '清理远端同步历史';
+
+  @override
+  String get syncDeviceName => '设备名称';
+
+  @override
+  String get syncPullInterval => '拉取间隔（分钟）';
+
+  @override
+  String get syncNeedBackend => '请先配置 WebDAV 或 S3';
+
+  @override
+  String get syncInitialTitle => '初始化同步';
+
+  @override
+  String get syncInitialPickBackup => '从备份恢复';
+
+  @override
+  String get syncInitialSkip => '本地已是最新';
+
+  @override
+  String get syncInitialCancel => '取消——先去另一端上传备份';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -15803,4 +15933,69 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 訊息 #$index：快速隨機調試樣例，用於測試列表渲染、捲動穩定性、訊息分組和會話歷史效能。';
   }
+
+  @override
+  String get syncTitle => '同步';
+
+  @override
+  String get syncEnable => '啟用同步';
+
+  @override
+  String get syncBackendLabel => '後端';
+
+  @override
+  String get syncBackendWebdav => 'WebDAV';
+
+  @override
+  String get syncBackendS3 => 'S3';
+
+  @override
+  String get syncBackendHint => '請先在備份設定中配置 WebDAV 或 S3';
+
+  @override
+  String get syncStatusIdle => '已同步';
+
+  @override
+  String get syncStatusPushing => '正在上傳變更...';
+
+  @override
+  String get syncStatusPulling => '正在下載變更...';
+
+  @override
+  String get syncStatusError => '同步出錯';
+
+  @override
+  String get syncStatusDisabled => '同步已關閉';
+
+  @override
+  String syncLastSyncAt(String time) {
+    return '上次同步：$time';
+  }
+
+  @override
+  String get syncManualSync => '立即同步';
+
+  @override
+  String get syncCleanHistory => '清理遠端同步歷史';
+
+  @override
+  String get syncDeviceName => '設備名稱';
+
+  @override
+  String get syncPullInterval => '拉取間隔（分鐘）';
+
+  @override
+  String get syncNeedBackend => '請先配置 WebDAV 或 S3';
+
+  @override
+  String get syncInitialTitle => '初始化同步';
+
+  @override
+  String get syncInitialPickBackup => '從備份恢復';
+
+  @override
+  String get syncInitialSkip => '本地已是最新';
+
+  @override
+  String get syncInitialCancel => '取消——先去另一端上傳備份';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1932,5 +1932,33 @@
         "type": "int"
       }
     }
-  }
+  },
+  "syncTitle": "同步",
+  "syncEnable": "启用同步",
+  "syncBackendLabel": "后端",
+  "syncBackendWebdav": "WebDAV",
+  "syncBackendS3": "S3",
+  "syncBackendHint": "请先在备份设置中配置 WebDAV 或 S3",
+  "syncStatusIdle": "已同步",
+  "syncStatusPushing": "正在上传变更...",
+  "syncStatusPulling": "正在下载变更...",
+  "syncStatusError": "同步出错",
+  "syncStatusDisabled": "同步已关闭",
+  "syncLastSyncAt": "上次同步：{time}",
+  "@syncLastSyncAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "syncManualSync": "立即同步",
+  "syncCleanHistory": "清理远端同步历史",
+  "syncDeviceName": "设备名称",
+  "syncPullInterval": "拉取间隔（分钟）",
+  "syncNeedBackend": "请先配置 WebDAV 或 S3",
+  "syncInitialTitle": "初始化同步",
+  "syncInitialPickBackup": "从备份恢复",
+  "syncInitialSkip": "本地已是最新",
+  "syncInitialCancel": "取消——先去另一端上传备份"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1932,5 +1932,33 @@
         "type": "int"
       }
     }
-  }
+  },
+  "syncTitle": "同步",
+  "syncEnable": "启用同步",
+  "syncBackendLabel": "后端",
+  "syncBackendWebdav": "WebDAV",
+  "syncBackendS3": "S3",
+  "syncBackendHint": "请先在备份设置中配置 WebDAV 或 S3",
+  "syncStatusIdle": "已同步",
+  "syncStatusPushing": "正在上传变更...",
+  "syncStatusPulling": "正在下载变更...",
+  "syncStatusError": "同步出错",
+  "syncStatusDisabled": "同步已关闭",
+  "syncLastSyncAt": "上次同步：{time}",
+  "@syncLastSyncAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "syncManualSync": "立即同步",
+  "syncCleanHistory": "清理远端同步历史",
+  "syncDeviceName": "设备名称",
+  "syncPullInterval": "拉取间隔（分钟）",
+  "syncNeedBackend": "请先配置 WebDAV 或 S3",
+  "syncInitialTitle": "初始化同步",
+  "syncInitialPickBackup": "从备份恢复",
+  "syncInitialSkip": "本地已是最新",
+  "syncInitialCancel": "取消——先去另一端上传备份"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1932,5 +1932,33 @@
         "type": "int"
       }
     }
-  }
+  },
+  "syncTitle": "同步",
+  "syncEnable": "啟用同步",
+  "syncBackendLabel": "後端",
+  "syncBackendWebdav": "WebDAV",
+  "syncBackendS3": "S3",
+  "syncBackendHint": "請先在備份設定中配置 WebDAV 或 S3",
+  "syncStatusIdle": "已同步",
+  "syncStatusPushing": "正在上傳變更...",
+  "syncStatusPulling": "正在下載變更...",
+  "syncStatusError": "同步出錯",
+  "syncStatusDisabled": "同步已關閉",
+  "syncLastSyncAt": "上次同步：{time}",
+  "@syncLastSyncAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "syncManualSync": "立即同步",
+  "syncCleanHistory": "清理遠端同步歷史",
+  "syncDeviceName": "設備名稱",
+  "syncPullInterval": "拉取間隔（分鐘）",
+  "syncNeedBackend": "請先配置 WebDAV 或 S3",
+  "syncInitialTitle": "初始化同步",
+  "syncInitialPickBackup": "從備份恢復",
+  "syncInitialSkip": "本地已是最新",
+  "syncInitialCancel": "取消——先去另一端上傳備份"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,11 @@ import 'core/providers/backup_provider.dart';
 import 'core/providers/s3_backup_provider.dart';
 import 'core/providers/backup_reminder_provider.dart';
 import 'core/providers/hotkey_provider.dart';
+import 'core/providers/sync_provider.dart';
+import 'core/services/sync/sync_change_log.dart';
+import 'core/services/sync/sync_engine.dart';
+import 'core/services/sync/sync_metadata.dart';
+import 'core/services/sync/sync_transport.dart';
 import 'core/services/chat/chat_service.dart';
 import 'core/services/mcp/mcp_tool_service.dart';
 import 'core/services/logging/flutter_logger.dart';
@@ -159,6 +164,7 @@ class MyApp extends StatelessWidget {
             initialConfig: ctx.read<SettingsProvider>().s3Config,
           ),
         ),
+        ChangeNotifierProvider(create: (_) => SyncProvider()),
       ],
       child: Builder(
         builder: (context) {
@@ -245,6 +251,59 @@ class MyApp extends StatelessWidget {
                           defaultTargetPlatform == TargetPlatform.linux);
                   if (isDesktop) {
                     await context.read<HotkeyProvider>().initialize();
+                  }
+                } catch (_) {}
+              });
+
+              // Initialize sync engine on all platforms
+              WidgetsBinding.instance.addPostFrameCallback((_) async {
+                try {
+                  final chatService = context.read<ChatService>();
+                  final syncProvider = context.read<SyncProvider>();
+
+                  final changeLog = SyncChangeLog();
+                  await changeLog.init();
+
+                  final metadata = SyncMetadata();
+                  await metadata.init();
+
+                  chatService.attachSyncChangeLog(
+                    changeLog,
+                    deviceId: metadata.deviceId,
+                  );
+
+                  final engine = SyncEngine(
+                    changeLog: changeLog,
+                    metadata: metadata,
+                    chatService: chatService,
+                    provider: syncProvider,
+                  );
+
+                  syncProvider.onTriggerSync = () {
+                    engine.triggerImmediate();
+                  };
+                  syncProvider.onResetError = () {
+                    engine.triggerImmediate();
+                  };
+
+                  if (metadata.enabled) {
+                    final backend = metadata.backendChoice;
+                    if (backend == 'webdav') {
+                      final wdConfig = settings.webDavConfig;
+                      if (wdConfig.url.trim().isNotEmpty) {
+                        engine.setTransport(
+                          WebDavSyncTransport(
+                            baseUrl: wdConfig.url,
+                            username: wdConfig.username,
+                            password: wdConfig.password,
+                            userAgent: wdConfig.userAgent,
+                          ),
+                        );
+                        syncProvider.setStatus(SyncStatus.idle);
+                        await engine.startPeriodicPull();
+                        await engine.pull();
+                      }
+                    }
                   }
                 } catch (_) {}
               });


### PR DESCRIPTION
### Summary

Adds the core infrastructure for automatic incremental sync over WebDAV, enabling bidirectional replication of chat data across multiple devices without a dedicated server.

### Relevant Issues

A long-desired feature.

#37 #41 #153 #191 #519 Five issues pointing to the same feature.

### Background

Kelivo previously only had manual backup-to-ZIP (disaster recovery). This PR introduces a separate sync system that complements backup:

|          | Backup                          | Sync                              |
|----------|---------------------------------|-----------------------------------|
| Purpose  | Disaster recovery               | Multi-device continuity           |
| Granularity | Full ZIP                      | Per-message incremental batch     |
| Transport | WebDAV / S3                    | WebDAV (S3 in Phase 2)            |
| Frequency | User-initiated / timer         | 30s debounce + 5min max flush     |

### Architecture Overview

```
User action → ChatService mutation → SyncChangeLog append
                                          ↓
                             30s debounce timer
                                          ↓
                          SyncEngine.push()
                            → batch JSON read + mark batchId
                            → uploadBatch to WebDAV .kelivo_sync/
                            → delete changelog by batchId
                                          ↓
                          SyncEngine.pull()
                            → list remote files > lastSyncAt
                            → sort chronologically
                            → download → apply (LWW)
                            → retry×2 or stop on failure
```

### Key Design Decisions

1. **Incremental change tracking** — `SyncChangeLog` Hive box records each mutation with full JSON data cache. No full-scan needed. Batch upload on 30s debounce + 5min forced flush.
2. **WebDAV/S3 as meeting point** — No self-hosted server. Remote storage is a stateless file exchange. `SyncTransport` interface allows future backends.
3. **LWW conflict resolution** — Last-write-wins by message timestamp. Adequate for chat (mostly append-only).
4. **Sync ≠ Backup** — Backup handles disaster recovery (full ZIP); Sync handles multi-device continuity (incremental batches). See `docs/adr/0001` and `0002` for full rationale.

### What's Included

**New files:**

- `lib/core/services/sync/sync_change_log.dart` — Change log Hive box
- `lib/core/services/sync/sync_transport.dart` — Transport abstraction + WebDAV impl
- `lib/core/services/sync/sync_metadata.dart` — Device ID/name/lastSyncAt
- `lib/core/services/sync/sync_engine.dart` — Push/pull orchestrator with backoff
- `lib/core/providers/sync_provider.dart` — Sync status ChangeNotifier
- `lib/desktop/setting/sync_pane.dart` — Desktop settings UI

**Modified files:**

- `lib/core/services/chat/chat_service.dart` — 4 mutation hooks + 3 new public methods
- `lib/main.dart` — SyncProvider registration + SyncEngine lifecycle init
- `lib/desktop/desktop_settings_page.dart` — Added sync menu item
- 4 ARB files + gen-l10n

### How to Test (Manual)

1. Configure WebDAV in Backup settings (e.g., Nutstore / Cloudflare R2)
2. Open Sync pane → enable sync → select WebDAV backend
3. Send a message → wait 30s → verify `.kelivo_sync/` directory appears in your WebDAV with a JSON batch file
4. On another device: configure the same WebDAV → enable sync → verify message appears after pull cycle

### Not in This PR (Follow-ups)

- S3 transport (`S3SyncTransport`) — pending `S3BackupClient` public API extension
- Mobile sync UI (`backup_page.dart`)
- Initial sync dialog (user picks backup ZIP)
- Tests for sync engine
- Conversation metadata change hooks (rename, pin)

### Verification

- `flutter analyze` — ✅ 0 errors, 0 warnings (5 info-level style hints)
- `dart format` — ✅
- `flutter gen-l10n` — ✅ `desiredFileName.txt` empty

### State

1. Successfully built on Windows.
2. UI not tested and polished
3. Awaiting further discussion and PRs.