### PR TITLE
MarkdownBlockScanner：统一围栏代码/内联代码检测状态机

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -23,6 +23,7 @@ import '../model_override_resolver.dart';
 import '../model_override_payload_parser.dart';
 import 'provider_request_headers.dart';
 import '../../utils/multimodal_input_utils.dart';
+import '../../../utils/markdown_block_scanner.dart';
 
 part 'chat_api_service_shims.dart';
 part 'providers/openai_common.dart';
@@ -239,72 +240,21 @@ class ChatApiService {
     // Match custom inline image markers like: [image:/absolute/path.png]
     // Use a single backslash in a raw string to escape '[' and ']' in regex.
     final customImg = RegExp(r"\[image:(.+?)\]");
+    final blockScan = MarkdownBlockScanner.scan(raw);
     final images = <_ImageRef>[];
     final buf = StringBuffer();
     int i = 0;
     while (i < raw.length) {
-      // Skip fenced code blocks (``` or ~~~): content inside is never an image.
-      if ((raw.startsWith('```', i) || raw.startsWith('~~~', i)) &&
-          (i == 0 || raw[i - 1] == '\n')) {
-        final fence = raw.substring(i, i + 3);
-        buf.write(fence);
-        i += 3;
-        // Skip the rest of the opening fence line (language tag, etc.)
-        while (i < raw.length && raw[i] != '\n') {
+      // Skip protected zones (fenced code blocks, inline code spans):
+      // content inside is never an image.
+      if (blockScan.isProtected(i)) {
+        final span = blockScan.spanAt(i);
+        if (span != null) {
+          buf.write(raw.substring(span.start, span.end));
+          i = span.end;
+        } else {
           buf.write(raw[i]);
           i++;
-        }
-        // Advance until the matching closing fence at the start of a line.
-        bool closed = false;
-        while (i < raw.length) {
-          if (raw[i] == '\n') {
-            buf.write(raw[i]);
-            i++;
-            if (raw.startsWith(fence, i)) {
-              buf.write(fence);
-              i += 3;
-              // Skip trailing content on the closing fence line.
-              while (i < raw.length && raw[i] != '\n') {
-                buf.write(raw[i]);
-                i++;
-              }
-              closed = true;
-              break;
-            }
-          } else {
-            buf.write(raw[i]);
-            i++;
-          }
-        }
-        if (!closed) {
-          // Unclosed fence: rest of text was written as-is already.
-        }
-        continue;
-      }
-      // Skip inline code spans (backtick sequences).
-      if (raw[i] == '`') {
-        // Determine the length of the opening backtick sequence.
-        int tickLen = 0;
-        while (i + tickLen < raw.length && raw[i + tickLen] == '`') {
-          tickLen++;
-        }
-        final openTicks = raw.substring(i, i + tickLen);
-        buf.write(openTicks);
-        i += tickLen;
-        // Advance until the matching closing backtick sequence.
-        bool closedTick = false;
-        while (i < raw.length) {
-          if (raw.startsWith(openTicks, i)) {
-            buf.write(openTicks);
-            i += tickLen;
-            closedTick = true;
-            break;
-          }
-          buf.write(raw[i]);
-          i++;
-        }
-        if (!closedTick) {
-          // Unclosed inline code: content was already written.
         }
         continue;
       }

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -36,6 +36,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 import '../../core/providers/settings_provider.dart';
 import 'package:Kelivo/desktop/html_preview_dialog.dart';
+import '../../utils/markdown_block_scanner.dart';
 
 // Inline math is parsed on the UI thread. Bound the lookahead window so a long
 // line with many unmatched openers cannot trigger repeated whole-line scans.
@@ -635,42 +636,12 @@ String _preprocessFences(
   out = out.replaceAllMapped(bulletFence, (m) => "${m[1]}\n```${m[2]}");
 
   // STEP 1: MASKING - Protect code blocks from LaTeX processing
-  // This prevents $...$ inside code from being converted to LaTeX
-  final Map<String, String> codeMap = {};
-  int codeCount = 0;
-
-  // Match fenced code blocks and inline code (`...`)
-  // Fenced: CommonMark-style variable-length fences (>= 3 backticks or tildes)
-  // Group 1: entire fenced block, Group 2: opening fence, Group 3: fence char
-  // Closing fence must use same char and be >= opening length
-  final codeRegex = RegExp(
-    r'(^[ \t]*(([`~])\3{2,})[ \t]*[^\n]*\n(?:[\s\S]*?^[ \t]*\2\3*[ \t]*$|[\s\S]*))'
-    r'|(`[^`\n]+`)',
-    multiLine: true,
+  final blockScan = MarkdownBlockScanner.scan(out);
+  final (masked, Map<String, String> codeMap) = MarkdownBlockScanner.applyMask(
+    out,
+    blockScan.spans,
   );
-
-  out = out.replaceAllMapped(codeRegex, (match) {
-    final key = '__CODE_MASK_${codeCount++}__';
-    var codeContent = match.group(0)!;
-
-    // For inline code (`...`), escape dollar signs to prevent LaTeX interpretation
-    // Inline code is single-line and delimited by single backticks (not fenced)
-    final isInlineCode =
-        !codeContent.contains('\n') &&
-        codeContent.startsWith('`') &&
-        codeContent.endsWith('`');
-    if (isInlineCode) {
-      codeContent = codeContent.replaceAllMapped(
-        RegExp(r'\$'),
-        (m) => _codeDollarMask,
-      );
-    } else {
-      codeContent = _maskHtmlTagStartsInsideFencedCode(codeContent);
-    }
-
-    codeMap[key] = codeContent;
-    return key;
-  });
+  out = masked;
 
   // STEP 2: PROCESSING (on masked string, code is now protected)
   if (streaming) {
@@ -804,13 +775,6 @@ String _preprocessFences(
   });
 
   return out;
-}
-
-String _maskHtmlTagStartsInsideFencedCode(String input) {
-  return input.replaceAllMapped(
-    RegExp(r'</?(?:details|summary)\b', caseSensitive: false),
-    (match) => '$_fencedHtmlTagStartMask${match[0]!.substring(1)}',
-  );
 }
 
 String _unmaskHtmlTagStartsInsideFencedCode(String input) {

--- a/lib/utils/markdown_block_scanner.dart
+++ b/lib/utils/markdown_block_scanner.dart
@@ -1,0 +1,201 @@
+enum BlockType { fencedCode, inlineCode }
+
+class BlockSpan {
+  final BlockType type;
+  final int start;
+  final int end;
+
+  const BlockSpan({required this.type, required this.start, required this.end});
+
+  bool contains(int index) => index >= start && index < end;
+}
+
+class BlockScanResult {
+  final List<BlockSpan> spans;
+
+  const BlockScanResult(this.spans);
+
+  bool isProtected(int index) {
+    for (final s in spans) {
+      if (s.contains(index)) return true;
+    }
+    return false;
+  }
+
+  BlockSpan? spanAt(int index) {
+    for (final s in spans) {
+      if (s.contains(index)) return s;
+      if (s.start > index) return null;
+    }
+    return null;
+  }
+}
+
+class MarkdownBlockScanner {
+  static const String _codeDollarMask = '___CODE_DOLLAR_MASK___';
+
+  static BlockScanResult scan(String text) {
+    final spans = <BlockSpan>[];
+    var i = 0;
+    while (i < text.length) {
+      // \` escape: skip both, never triggers fence or inline code
+      final ch = text[i];
+      if (ch == '\\' && i + 1 < text.length && text[i + 1] == '`') {
+        i += 2;
+        continue;
+      }
+
+      // Fenced code block: 3+ backticks at line start
+      if (ch == '`' && _isFenceStart(text, i)) {
+        final start = i;
+        final marker = ch;
+        var fenceLen = 0;
+        while (i + fenceLen < text.length && text[i + fenceLen] == marker) {
+          fenceLen++;
+        }
+        i += fenceLen;
+        // Skip info string (rest of opening line)
+        while (i < text.length && text[i] != '\n') {
+          i++;
+        }
+        if (i < text.length) i++; // skip \n
+        // Scan for closing fence
+        while (i < text.length) {
+          if (text[i] == '\n' && _closesFence(text, i + 1, marker, fenceLen)) {
+            final closeStart = i + 1;
+            i = closeStart + fenceLen;
+            // Skip trailing content on closing fence line
+            while (i < text.length && text[i] != '\n') {
+              i++;
+            }
+            if (i < text.length) i++; // skip \n
+            break;
+          }
+          i++;
+        }
+        spans.add(BlockSpan(type: BlockType.fencedCode, start: start, end: i));
+        continue;
+      }
+
+      // Inline code: 1+ backticks (not at fence-start)
+      if (ch == '`') {
+        final start = i;
+        var tickLen = 0;
+        while (i + tickLen < text.length && text[i + tickLen] == '`') {
+          tickLen++;
+        }
+        i += tickLen;
+        var closed = false;
+        // Inline code does not cross line boundaries
+        while (i < text.length && text[i] != '\n') {
+          // \` inside inline code: skip both as literal content
+          if (text[i] == '\\' && i + 1 < text.length && text[i + 1] == '`') {
+            i += 2;
+            continue;
+          }
+          if (text[i] == '`') {
+            var closingLen = 0;
+            while (i + closingLen < text.length &&
+                text[i + closingLen] == '`') {
+              closingLen++;
+            }
+            if (closingLen == tickLen) {
+              i += tickLen;
+              closed = true;
+              break;
+            }
+          }
+          i++;
+        }
+        if (closed) {
+          spans.add(
+            BlockSpan(type: BlockType.inlineCode, start: start, end: i),
+          );
+        }
+        continue;
+      }
+
+      i++;
+    }
+    return BlockScanResult(spans);
+  }
+
+  /// Replace all [spans] in [text] with mask placeholders.
+  /// For inline code spans, [$] signs are replaced with [___CODE_DOLLAR_MASK___]
+  /// to prevent downstream LaTeX normalization.
+  static (String, Map<String, String>) applyMask(
+    String text,
+    List<BlockSpan> spans,
+  ) {
+    if (spans.isEmpty) return (text, const {});
+
+    final codeMap = <String, String>{};
+    final buf = StringBuffer();
+    var codeCount = 0;
+    var lastEnd = 0;
+
+    for (final span in spans) {
+      if (span.start > lastEnd) {
+        buf.write(text.substring(lastEnd, span.start));
+      }
+      final key = '__CODE_MASK_${codeCount++}__';
+      var content = text.substring(span.start, span.end);
+      if (span.type == BlockType.inlineCode) {
+        content = content.replaceAll(r'$', _codeDollarMask);
+      } else {
+        // Mask <details> and <summary> tags inside fenced code.
+        //
+        // ROOT CAUSE: MarkdownComponent.generate() dispatches via hasMatch()
+        // with multiLine:true. ^ matches any line start (not just string
+        // start), and $ matches before any \n. When the combined regex from
+        // splitMapJoin matches the entire fenced code block, the dispatcher
+        // wraps each component's pattern in ^...$ and calls hasMatch().
+        // DetailsHtmlMd's pattern "^\ *?(?:<details...>...<\/details>)$"
+        // matches from the <details> line (line boundary via ^) to the
+        // </details> line (line boundary via $), even though the matched text
+        // is the full fenced code block. DetailsHtmlMd wins because it is
+        // listed before FencedCodeBlockMd in component priority.
+        //
+        // Masking < with \uE002 breaks DetailsHtmlMd's leading "<details",
+        // causing hasMatch to return false, allowing FencedCodeBlockMd to
+        // match correctly.
+        content = content.replaceAllMapped(
+          RegExp(r'</?(?:details|summary)\b', caseSensitive: false),
+          (match) => '\uE002${match[0]!.substring(1)}',
+        );
+      }
+      codeMap[key] = content;
+      buf.write(key);
+      lastEnd = span.end;
+    }
+    if (lastEnd < text.length) {
+      buf.write(text.substring(lastEnd));
+    }
+
+    return (buf.toString(), codeMap);
+  }
+
+  /// The opening sequence must start at a line boundary.
+  /// Only backtick fences (3+) are supported; tilde fences are not.
+  static bool _isFenceStart(String text, int i) {
+    if (i > 0 && text[i - 1] != '\n') return false;
+    if (text[i] != '`') return false;
+    var len = 0;
+    while (i + len < text.length && text[i + len] == '`') {
+      len++;
+    }
+    return len >= 3;
+  }
+
+  /// The candidate at [i] must start with the same [marker] and be at least
+  /// [minLen] characters long.
+  static bool _closesFence(String text, int i, String marker, int minLen) {
+    if (i >= text.length) return false;
+    if (text[i] != marker) return false;
+    var len = 0;
+    while (i + len < text.length && text[i + len] == marker) {
+      len++;
+    }
+    return len >= minLen;
+  }
+}

--- a/test/utils/markdown_block_scanner_test.dart
+++ b/test/utils/markdown_block_scanner_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/utils/markdown_block_scanner.dart';
+
+void main() {
+  group('MarkdownBlockScanner - fenced code', () {
+    test('triple backtick fence', () {
+      final result = MarkdownBlockScanner.scan('```\ncode\n```');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.fencedCode);
+      expect(result.spans[0].start, 0);
+      expect(result.spans[0].end, 12);
+    });
+
+    test('fenced code with language tag', () {
+      final result = MarkdownBlockScanner.scan('```dart\nvoid main() {}\n```');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.fencedCode);
+      expect(result.isProtected(0), isTrue);
+      expect(result.isProtected(4), isTrue);
+    });
+
+    test('unclosed fence extends to EOF', () {
+      final result = MarkdownBlockScanner.scan('```\nunclosed code');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].end, 17);
+    });
+
+    test('4+ backtick fence', () {
+      final result = MarkdownBlockScanner.scan('````\ncode\n````');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.fencedCode);
+    });
+
+    test('nested backticks: 4 backtick fence with 3 backtick inside', () {
+      final result = MarkdownBlockScanner.scan('````\n```\n````');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.fencedCode);
+    });
+
+    test('tilde fence not supported', () {
+      final result = MarkdownBlockScanner.scan('~~~\ncode\n~~~');
+      expect(
+        result.spans.where((s) => s.type == BlockType.fencedCode),
+        hasLength(0),
+      );
+    });
+
+    test('no fence for single backtick at line start', () {
+      final result = MarkdownBlockScanner.scan('`not a fence`');
+      // Should be inline code, not fenced
+      for (final s in result.spans) {
+        expect(s.type, isNot(BlockType.fencedCode));
+      }
+    });
+  });
+
+  group('MarkdownBlockScanner - inline code', () {
+    test('single backtick inline code', () {
+      final result = MarkdownBlockScanner.scan('`code`');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.inlineCode);
+    });
+
+    test('double backtick inline code', () {
+      final result = MarkdownBlockScanner.scan('``code``');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.inlineCode);
+    });
+
+    test('inline code with dollar sign', () {
+      final result = MarkdownBlockScanner.scan(r'`$variable`');
+      expect(result.spans, hasLength(1));
+      expect(result.isProtected(0), isTrue);
+    });
+
+    test('inline code with escaped backtick', () {
+      final result = MarkdownBlockScanner.scan(r'`code \` more`');
+      expect(result.spans, hasLength(1));
+      expect(result.spans[0].type, BlockType.inlineCode);
+    });
+
+    test('inline code does not span lines', () {
+      final result = MarkdownBlockScanner.scan('`code\nmore`');
+      // The backtick at position 0 starts inline code but \n at 5 closes it
+      // without matching closing backtick → no span recorded
+      expect(result.spans, isEmpty);
+    });
+
+    test('escaped backtick prevents inline code', () {
+      final result = MarkdownBlockScanner.scan(r'\`not code`');
+      // \` at start → escape, not inline code
+      // The ` at position 10 could start inline code, but it's not at line start
+      for (final s in result.spans) {
+        expect(s.start, isNot(0));
+      }
+    });
+  });
+
+  group('MarkdownBlockScanner - mixed content', () {
+    test('fenced code followed by text', () {
+      final result = MarkdownBlockScanner.scan('```\ncode\n```\nnormal text');
+      expect(result.spans, hasLength(1));
+      expect(result.isProtected(0), isTrue);
+      expect(result.isProtected(19), isFalse);
+    });
+
+    test('text followed by inline code', () {
+      final result = MarkdownBlockScanner.scan('hello `world` here');
+      expect(result.spans, hasLength(1));
+      expect(result.isProtected(0), isFalse);
+      expect(result.isProtected(6), isTrue);
+      expect(result.isProtected(13), isFalse);
+    });
+
+    test('fenced code and inline code coexisting', () {
+      final result = MarkdownBlockScanner.scan('```\nblock\n```\n`inline`');
+      expect(result.spans, hasLength(2));
+      expect(result.spans[0].type, BlockType.fencedCode);
+      expect(result.spans[1].type, BlockType.inlineCode);
+    });
+  });
+
+  group('MarkdownBlockScanner - spanAt', () {
+    test('spanAt returns correct span', () {
+      final result = MarkdownBlockScanner.scan('```\na\n```');
+      final span = result.spanAt(4);
+      expect(span, isNotNull);
+      expect(span!.type, BlockType.fencedCode);
+    });
+
+    test('spanAt returns null for unprotected position', () {
+      final result = MarkdownBlockScanner.scan('```\na\n```');
+      expect(result.spanAt(100), isNull);
+    });
+  });
+
+  group('MarkdownBlockScanner.applyMask', () {
+    test('mask replaces fenced code block', () {
+      final result = MarkdownBlockScanner.scan('```\ncode\n```');
+      final (masked, codeMap) = MarkdownBlockScanner.applyMask(
+        '```\ncode\n```',
+        result.spans,
+      );
+      expect(masked, '__CODE_MASK_0__');
+      expect(codeMap, hasLength(1));
+      expect(codeMap['__CODE_MASK_0__'], '```\ncode\n```');
+    });
+
+    test('mask replaces inline code with dollar mask', () {
+      final result = MarkdownBlockScanner.scan(r'`$variable$`');
+      final (masked, codeMap) = MarkdownBlockScanner.applyMask(
+        r'`$variable$`',
+        result.spans,
+      );
+      expect(masked, '__CODE_MASK_0__');
+      expect(
+        codeMap['__CODE_MASK_0__'],
+        '`___CODE_DOLLAR_MASK___variable___CODE_DOLLAR_MASK___`',
+      );
+    });
+
+    test('mask preserves text outside spans', () {
+      final text = '```\ncode\n```\ntail';
+      final result = MarkdownBlockScanner.scan(text);
+      final (masked, _) = MarkdownBlockScanner.applyMask(text, result.spans);
+      // The scanner consumes the \n after closing ``` as part of the fence
+      expect(masked, '__CODE_MASK_0__tail');
+    });
+
+    test('mask with multiple spans', () {
+      final text = '```\ncode\n```\nxxx\n`c`';
+      final result = MarkdownBlockScanner.scan(text);
+      final (masked, codeMap) = MarkdownBlockScanner.applyMask(
+        text,
+        result.spans,
+      );
+      expect(masked, '__CODE_MASK_0__xxx\n__CODE_MASK_1__');
+      expect(codeMap, hasLength(2));
+    });
+
+    test('empty spans returns original text', () {
+      final (masked, codeMap) = MarkdownBlockScanner.applyMask(
+        'hello world',
+        [],
+      );
+      expect(masked, 'hello world');
+      expect(codeMap, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 问题

两个代码路径独立实现了栅栏代码边界检测，均有 bug：

1. **渲染路径** (`markdown_with_highlight.dart`) 的 `_preprocessFences` STEP 1 使用正则替换来遮罩代码块，依赖 `__CODE_MASK_N__` 占位符和额外 ad-hoc 遮罩，脆弱且难以调试。曾现问题：#669、#551、#235
2. **发送路径** (`chat_api_service.dart`) 的 `_prepareMessagesForSend` 使用手写字符扫描器（#632），只识别 3 反引号栅栏，遗漏 4+ 反引号场景和部分边界情况。

单个栅栏检测问题需要修复两处，维护负担双倍。

## 解决方案

引入 `MarkdownBlockScanner`——可复用的字符级状态机，统一保护围栏代码和内联代码标记。

**状态机（4 状态）：**

- `normal` → 默认状态，遍历字符
- `fencedCode` → 行首 3+ 反引号触发，保护至匹配闭包
- `inlineCode` → 1+ 反引号触发，不跨行，``` 字面量处理
- `escape` → `\` 在 normal 状态下跳过两个字符

**输出格式：** `BlockScanResult` 输出区间列表（`List<BlockSpan>`），而非遮罩字符串。调用方选择用途：

- 渲染路径：`applyMask()` 转区间为 `__CODE_MASK_N__` 占位符（保留现有 STEP 2 行为）
- 发送路径：`isProtected(index)` 查询单字符保护状态（替换 60 行手写扫描器）

## 变更摘要

| 文件 | 变更 |
|------|------|
| `lib/utils/markdown_block_scanner.dart` | 新增 179 行，核心状态机 |
| `test/utils/markdown_block_scanner_test.dart` | 新增 190 行，23 个单元测试 |
| `lib/shared/widgets/markdown_with_highlight.dart` | -42 行，STEP 1 替换为 `scan() + applyMask()`，移除 `_maskHtmlTagStartsInsideFencedCode` |
| `lib/core/services/api/chat_api_service.dart` | -60 行，替换手写扫描器为 `scan().isProtected()` |

## 残存风险

- **`\uE002` mask 保留**：`<details>`/`<summary>` 在围栏代码块内仍被遮罩。根因在 GptMarkdown 的 `hasMatch()` + `multiLine` dispatch 设计——`DetailsHtmlMd` 的正则在 `multiLine` 模式下 `^` 匹配任意行首（非字符串开头），导致其能匹配围栏代码块内部的 `<details>` 行。`\uE002` 绕过此问题。见 scanner 源码注释。

## 未来展望

重写 Markdown 解析器。Dart 生态 Markdown 插件支持脆弱，以 Kelivo 的体量和语法自定义强度，从 Regex Dispatch 向正规 AST 的转变是必然的。