### PR TITLE
fix(home page): 处理无会话时的UI显示问题

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -589,6 +589,11 @@ class HomePageController extends ChangeNotifier {
         _restoreMessageUiState();
         notifyListeners();
         _scrollToBottomSoon(animate: false);
+      } else {
+        // No conversations exist — create a new empty one so the UI
+        // correctly shows the temporary-chat toggle button instead of
+        // falling back to "new conversation" button.
+        await _createNewConversation();
       }
     }
   }


### PR DESCRIPTION
当不存在会话时创建新会话，确保临时聊天切换按钮正确显示