### PR TITLE
fix: add metaso provider avatar icon option

### DIFF
--- a/lib/utils/brand_assets.dart
+++ b/lib/utils/brand_assets.dart
@@ -142,6 +142,11 @@ class BrandAssets {
       asset: 'assets/icons/mistral-color.svg',
     ),
     BrandIconOption(
+      id: 'metaso',
+      label: 'Metaso',
+      asset: 'assets/icons/metaso-color.svg',
+    ),
+    BrandIconOption(
       id: 'meta',
       label: 'Meta',
       asset: 'assets/icons/meta-color.svg',

--- a/test/utils/brand_assets_test.dart
+++ b/test/utils/brand_assets_test.dart
@@ -1,0 +1,13 @@
+import 'package:Kelivo/utils/brand_assets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BrandAssets', () {
+    test('mapped Metaso icon is selectable as a built-in provider avatar', () {
+      final asset = BrandAssets.assetForName('metaso');
+
+      expect(asset, 'assets/icons/metaso-color.svg');
+      expect(BrandAssets.selectableAssetOrNull(asset!), asset);
+    });
+  });
+}


### PR DESCRIPTION
## Summary\n- add Metaso to the built-in provider avatar icon list\n- add a focused test that the mapped Metaso icon is accepted by the selectable avatar list\n\n## Verification\n- dart format lib/utils/brand_assets.dart test/utils/brand_assets_test.dart\n- flutter test test/utils/brand_assets_test.dart\n- dart analyze lib/utils/brand_assets.dart test/utils/brand_assets_test.dart\n- mapping/selectable consistency script