### PR TITLE
feat: add emoji preset for title prompt with hash fingerprint matching

### DIFF
--- a/lib/core/prompts/constants/title_prompts.dart
+++ b/lib/core/prompts/constants/title_prompts.dart
@@ -1,0 +1,25 @@
+const String defaultTitlePrompt =
+    '''I will give you some dialogue content in the `<content>` block.
+You need to summarize the conversation between user and assistant into a short title.
+1. The title language should be consistent with the user's primary language
+2. Do not use punctuation or other special symbols
+3. Reply directly with the title
+4. Summarize using {locale} language
+5. The title should not exceed 10 characters
+
+<content>
+{content}
+</content>''';
+
+const String emojiTitlePrompt =
+    '''I will give you some dialogue content in the `<content>` block.
+You need to summarize the conversation between user and assistant into a short title.
+1. The title language should be consistent with the user's primary language
+2. You may start the title with ONE relevant emoji followed by a space, and use no other special characters or punctuation
+3. Reply directly with the title
+4. Summarize using {locale} language
+5. The title (excluding the emoji) should not exceed 10 characters
+
+<content>
+{content}
+</content>''';

--- a/lib/core/prompts/prompt_preset.dart
+++ b/lib/core/prompts/prompt_preset.dart
@@ -1,0 +1,6 @@
+class PromptPreset {
+  final String id;
+  final String prompt;
+
+  const PromptPreset({required this.id, required this.prompt});
+}

--- a/lib/core/prompts/title_presets.dart
+++ b/lib/core/prompts/title_presets.dart
@@ -1,0 +1,24 @@
+import 'constants/title_prompts.dart';
+import 'prompt_preset.dart';
+
+class TitlePresets {
+  static final List<PromptPreset> all = [
+    const PromptPreset(id: 'standard', prompt: defaultTitlePrompt),
+    const PromptPreset(id: 'emoji', prompt: emojiTitlePrompt),
+  ];
+
+  static String? detect(String text) {
+    final norm = text.trim();
+    for (final p in all) {
+      if (norm == p.prompt.trim()) return p.id;
+    }
+    return null;
+  }
+
+  static PromptPreset? byId(String id) {
+    for (final p in all) {
+      if (p.id == id) return p;
+    }
+    return null;
+  }
+}

--- a/lib/desktop/setting/default_model_pane.dart
+++ b/lib/desktop/setting/default_model_pane.dart
@@ -5,6 +5,8 @@ import '../../l10n/app_localizations.dart';
 import '../../core/providers/settings_provider.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../shared/widgets/ios_switch.dart';
+import '../../core/prompts/title_presets.dart';
+import '../widgets/preset_dropdown.dart';
 import '../../features/model/widgets/model_select_sheet.dart';
 import '../../features/model/utils/ocr_model_capability.dart';
 import '../../utils/brand_assets.dart';
@@ -325,12 +327,42 @@ class DesktopDefaultModelPane extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(height: 16),
-                      Text(
-                        l10n.defaultModelPagePromptLabel,
-                        style: TextStyle(
-                          fontSize: 13,
-                          fontWeight: AppFontWeights.semibold,
-                        ),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              l10n.defaultModelPagePromptLabel,
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: AppFontWeights.semibold,
+                              ),
+                            ),
+                          ),
+                          ListenableBuilder(
+                            listenable: ctrl,
+                            builder: (context, _) {
+                              final activeId = TitlePresets.detect(ctrl.text);
+                              return PresetDropdown<String>(
+                                value: activeId,
+                                customLabel: l10n.titlePresetCustom,
+                                options: [
+                                  DesktopSelectOption(
+                                    value: 'standard',
+                                    label: l10n.titlePresetStandard,
+                                  ),
+                                  DesktopSelectOption(
+                                    value: 'emoji',
+                                    label: l10n.titlePresetEmoji,
+                                  ),
+                                ],
+                                onSelected: (v) {
+                                  final p = TitlePresets.byId(v);
+                                  if (p != null) ctrl.text = p.prompt;
+                                },
+                              );
+                            },
+                          ),
+                        ],
                       ),
                       const SizedBox(height: 8),
                       _promptEditor(
@@ -341,6 +373,14 @@ class DesktopDefaultModelPane extends StatelessWidget {
                       const SizedBox(height: 6),
                       Text(
                         l10n.defaultModelPageTitleVars('{content}', '{locale}'),
+                        style: TextStyle(
+                          color: cs.onSurface.withValues(alpha: 0.6),
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        l10n.titlePresetUnsavedHint,
                         style: TextStyle(
                           color: cs.onSurface.withValues(alpha: 0.6),
                           fontSize: 12,

--- a/lib/desktop/widgets/preset_dropdown.dart
+++ b/lib/desktop/widgets/preset_dropdown.dart
@@ -1,0 +1,415 @@
+import 'dart:async';
+import 'package:Kelivo/theme/app_font_weights.dart';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/providers/settings_provider.dart';
+import '../../icons/lucide_adapter.dart' as lucide;
+import 'desktop_select_dropdown.dart';
+export 'desktop_select_dropdown.dart' show DesktopSelectOption;
+
+/// Dropdown for selecting prompt presets (title, translate, summary, etc.).
+///
+/// Derived from [DesktopSelectDropdown]
+/// (lib/desktop/widgets/desktop_select_dropdown.dart).
+///
+/// Key differences from the original:
+/// - `value` is nullable (null = custom/unmatched prompt).
+/// - `customLabel` is shown when `value` is null.
+/// - The trigger has a fixed width range via [minWidth]/[maxWidth] to avoid
+///   stretching across the parent layout while fitting Chinese text.
+class PresetDropdown<T> extends StatefulWidget {
+  const PresetDropdown({
+    super.key,
+    required this.value,
+    required this.customLabel,
+    required this.options,
+    required this.onSelected,
+    this.minWidth = 160,
+    this.maxWidth = 210,
+    this.minHeight = 34,
+    this.padding = const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
+    this.borderRadius = 10,
+    this.triggerFillColor,
+    this.menuBackgroundColor,
+  });
+
+  final T? value;
+  final String customLabel;
+  final List<DesktopSelectOption<T>> options;
+  final FutureOr<void> Function(T value) onSelected;
+
+  final double minWidth;
+  final double maxWidth;
+  final double minHeight;
+  final EdgeInsets padding;
+  final double borderRadius;
+  final Color? triggerFillColor;
+  final Color? menuBackgroundColor;
+
+  @override
+  State<PresetDropdown<T>> createState() => _PresetDropdownState<T>();
+}
+
+class _PresetDropdownState<T> extends State<PresetDropdown<T>> {
+  bool _hover = false;
+  bool _open = false;
+  final LayerLink _link = LayerLink();
+  final GlobalKey _triggerKey = GlobalKey();
+  OverlayEntry? _entry;
+
+  @override
+  void dispose() {
+    _removeEntry();
+    super.dispose();
+  }
+
+  void _removeEntry() {
+    _entry?.remove();
+    _entry = null;
+  }
+
+  void _toggle() {
+    if (_open) {
+      _close();
+    } else {
+      _openMenu();
+    }
+  }
+
+  void _close() {
+    _removeEntry();
+    if (mounted) setState(() => _open = false);
+  }
+
+  String _labelForValue(T? v) {
+    if (v == null) return widget.customLabel;
+    for (final opt in widget.options) {
+      if (opt.value == v) return opt.label;
+    }
+    return widget.customLabel;
+  }
+
+  Color _defaultMenuBackground(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    SettingsProvider? sp;
+    try {
+      sp = Provider.of<SettingsProvider>(context, listen: false);
+    } catch (_) {
+      sp = null;
+    }
+    final usePure = sp?.usePureBackground ?? false;
+    if (usePure) return isDark ? Colors.black : Colors.white;
+    return isDark ? const Color(0xFF1C1C1E) : Colors.white;
+  }
+
+  void _openMenu() {
+    if (_entry != null) return;
+    final rb = _triggerKey.currentContext?.findRenderObject() as RenderBox?;
+    if (rb == null) return;
+    final triggerSize = rb.size;
+    final triggerWidth = triggerSize.width;
+
+    _entry = OverlayEntry(
+      builder: (ctx) {
+        final bgColor =
+            widget.menuBackgroundColor ?? _defaultMenuBackground(ctx);
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: _close,
+                child: const SizedBox.expand(),
+              ),
+            ),
+            CompositedTransformFollower(
+              link: _link,
+              showWhenUnlinked: false,
+              offset: Offset(0, triggerSize.height + 6),
+              child: _PresetDropdownOverlay<T>(
+                width: triggerWidth,
+                backgroundColor: bgColor,
+                options: widget.options,
+                selected: widget.value,
+                onSelected: (v) async {
+                  _close();
+                  await widget.onSelected(v);
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    Overlay.of(context).insert(_entry!);
+    setState(() => _open = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final label = _labelForValue(widget.value);
+
+    final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
+    final hoverBorder = cs.primary;
+    final borderColor = _open || _hover ? hoverBorder : baseBorder;
+
+    final fillColor =
+        widget.triggerFillColor ??
+        (isDark ? const Color(0xFF141414) : Colors.white);
+
+    return CompositedTransformTarget(
+      link: _link,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _hover = true),
+        onExit: (_) => setState(() => _hover = false),
+        child: GestureDetector(
+          onTap: _toggle,
+          child: AnimatedContainer(
+            key: _triggerKey,
+            duration: const Duration(milliseconds: 120),
+            curve: Curves.easeOutCubic,
+            padding: widget.padding,
+            constraints: BoxConstraints(
+              minWidth: widget.minWidth,
+              maxWidth: widget.maxWidth,
+              minHeight: widget.minHeight,
+            ),
+            decoration: BoxDecoration(
+              color: fillColor,
+              borderRadius: BorderRadius.circular(widget.borderRadius),
+              border: Border.all(color: borderColor, width: 1),
+              boxShadow: _open
+                  ? [
+                      BoxShadow(
+                        color: cs.primary.withValues(alpha: 0.10),
+                        blurRadius: 0,
+                        spreadRadius: 2,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Stack(
+              alignment: Alignment.centerLeft,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: cs.onSurface.withValues(alpha: 0.88),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 24),
+                  ],
+                ),
+                Positioned.fill(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: AnimatedRotation(
+                      turns: _open ? 0.5 : 0.0,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeOutCubic,
+                      child: Icon(
+                        lucide.Lucide.ChevronDown,
+                        size: 16,
+                        color: cs.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetDropdownOverlay<T> extends StatefulWidget {
+  const _PresetDropdownOverlay({
+    required this.width,
+    required this.backgroundColor,
+    required this.options,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final double width;
+  final Color backgroundColor;
+  final List<DesktopSelectOption<T>> options;
+  final T? selected;
+  final ValueChanged<T> onSelected;
+
+  @override
+  State<_PresetDropdownOverlay<T>> createState() =>
+      _PresetDropdownOverlayState<T>();
+}
+
+class _PresetDropdownOverlayState<T> extends State<_PresetDropdownOverlay<T>>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _opacity;
+  late final Animation<Offset> _slide;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _opacity = CurvedAnimation(parent: _ctrl, curve: Curves.easeOutCubic);
+    _slide = Tween<Offset>(
+      begin: const Offset(0, -0.06),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeOutCubic));
+    WidgetsBinding.instance.addPostFrameCallback((_) => _ctrl.forward());
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final borderColor = cs.outlineVariant.withValues(alpha: 0.12);
+
+    return FadeTransition(
+      opacity: _opacity,
+      child: SlideTransition(
+        position: _slide,
+        child: Material(
+          color: Colors.transparent,
+          child: Container(
+            width: widget.width,
+            decoration: BoxDecoration(
+              color: widget.backgroundColor,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: borderColor, width: 0.5),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: isDark ? 0.32 : 0.08),
+                  blurRadius: 16,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final opt in widget.options)
+                  _DesktopSelectOptionTile(
+                    label: opt.label,
+                    selected:
+                        widget.selected != null && widget.selected == opt.value,
+                    onTap: () => widget.onSelected(opt.value),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopSelectOptionTile extends StatefulWidget {
+  const _DesktopSelectOptionTile({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_DesktopSelectOptionTile> createState() =>
+      _DesktopSelectOptionTileState();
+}
+
+class _DesktopSelectOptionTileState extends State<_DesktopSelectOptionTile> {
+  bool _hover = false;
+  bool _active = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = widget.selected
+        ? cs.primary.withValues(alpha: 0.12)
+        : (_hover
+              ? (isDark
+                    ? Colors.white.withValues(alpha: 0.08)
+                    : Colors.black.withValues(alpha: 0.04))
+              : Colors.transparent);
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => setState(() => _active = true),
+        onTapCancel: () => setState(() => _active = false),
+        onTapUp: (_) => setState(() => _active = false),
+        onTap: widget.onTap,
+        child: AnimatedScale(
+          scale: _active ? 0.98 : 1.0,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            curve: Curves.easeOutCubic,
+            margin: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    widget.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: cs.onSurface.withValues(alpha: 0.88),
+                      fontWeight: widget.selected
+                          ? AppFontWeights.semibold
+                          : AppFontWeights.regular,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Opacity(
+                  opacity: widget.selected ? 1 : 0,
+                  child: Icon(lucide.Lucide.Check, size: 14, color: cs.primary),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/model/pages/default_model_page.dart
+++ b/lib/features/model/pages/default_model_page.dart
@@ -4,6 +4,8 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../shared/widgets/ios_switch.dart';
+import '../../../core/prompts/title_presets.dart';
+import '../../../shared/widgets/ios_tactile.dart';
 import '../widgets/model_select_sheet.dart';
 import '../widgets/ocr_prompt_sheet.dart';
 import '../utils/ocr_model_capability.dart';
@@ -275,12 +277,64 @@ class DefaultModelPage extends StatelessWidget {
                       cs: cs,
                     ),
                     const SizedBox(height: 18),
-                    Text(
-                      l10n.defaultModelPagePromptLabel,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: AppFontWeights.semibold,
-                      ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            l10n.defaultModelPagePromptLabel,
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: AppFontWeights.semibold,
+                            ),
+                          ),
+                        ),
+                        ListenableBuilder(
+                          listenable: controller,
+                          builder: (context, _) {
+                            final activeId = TitlePresets.detect(
+                              controller.text,
+                            );
+                            final label = switch (activeId) {
+                              'standard' => l10n.titlePresetStandard,
+                              'emoji' => l10n.titlePresetEmoji,
+                              _ => l10n.titlePresetCustom,
+                            };
+                            return GestureDetector(
+                              onTap: () => _showTitlePresetSheet(
+                                context,
+                                controller,
+                                l10n,
+                                cs,
+                              ),
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 11,
+                                  vertical: 6,
+                                ),
+                                decoration: BoxDecoration(
+                                  border: Border.all(
+                                    color: cs.outlineVariant.withValues(
+                                      alpha: 0.18,
+                                    ),
+                                  ),
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Text(
+                                      label,
+                                      style: const TextStyle(fontSize: 13),
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Icon(Lucide.chevronDown, size: 16),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 8),
                     TextField(
@@ -320,6 +374,14 @@ class DefaultModelPage extends StatelessWidget {
                         fontSize: 12,
                       ),
                     ),
+                    const SizedBox(height: 2),
+                    Text(
+                      l10n.titlePresetUnsavedHint,
+                      style: TextStyle(
+                        color: cs.onSurface.withValues(alpha: 0.6),
+                        fontSize: 12,
+                      ),
+                    ),
                     const SizedBox(height: 8),
                     Row(
                       children: [
@@ -351,6 +413,102 @@ class DefaultModelPage extends StatelessWidget {
           },
         );
       },
+    );
+  }
+
+  Future<void> _showTitlePresetSheet(
+    BuildContext context,
+    TextEditingController controller,
+    AppLocalizations l10n,
+    ColorScheme cs,
+  ) async {
+    final activeId = TitlePresets.detect(controller.text);
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: cs.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: cs.onSurface.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _presetOption(
+                  ctx,
+                  id: 'standard',
+                  label: l10n.titlePresetStandard,
+                  selected: activeId == 'standard',
+                  onTap: () => Navigator.of(ctx).pop('standard'),
+                ),
+                const SizedBox(height: 4),
+                _presetOption(
+                  ctx,
+                  id: 'emoji',
+                  label: l10n.titlePresetEmoji,
+                  selected: activeId == 'emoji',
+                  onTap: () => Navigator.of(ctx).pop('emoji'),
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+    if (result != null) {
+      final p = TitlePresets.byId(result);
+      if (p != null) controller.text = p.prompt;
+    }
+  }
+
+  Widget _presetOption(
+    BuildContext context, {
+    required String id,
+    required String label,
+    required bool selected,
+    required VoidCallback onTap,
+  }) {
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 48,
+      child: IosCardPress(
+        borderRadius: BorderRadius.circular(14),
+        baseColor: cs.surface,
+        duration: const Duration(milliseconds: 260),
+        onTap: () {
+          Haptics.light();
+          onTap();
+        },
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: AppFontWeights.medium,
+                ),
+              ),
+            ),
+            if (selected) Icon(Lucide.Check, size: 18, color: cs.primary),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2378,5 +2378,21 @@
         "type": "int"
       }
     }
+  },
+  "titlePresetStandard": "Standard (Default)",
+  "@titlePresetStandard": {
+    "description": "Title preset option: standard (no emoji)"
+  },
+  "titlePresetEmoji": "Add Emoji",
+  "@titlePresetEmoji": {
+    "description": "Title preset option: emoji"
+  },
+  "titlePresetCustom": "Custom",
+  "@titlePresetCustom": {
+    "description": "Title preset label when custom prompt doesn't match any preset"
+  },
+  "titlePresetUnsavedHint": "Change or select a preset, then tap Save to apply",
+  "@titlePresetUnsavedHint": {
+    "description": "Hint shown in title prompt editor reminding user to save after changing preset"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10189,6 +10189,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{role} message #{index}: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.'**
   String debugPageManyMessagesSeedText(String role, int index);
+
+  /// Title preset option: standard (no emoji)
+  ///
+  /// In en, this message translates to:
+  /// **'Standard (Default)'**
+  String get titlePresetStandard;
+
+  /// Title preset option: emoji
+  ///
+  /// In en, this message translates to:
+  /// **'Add Emoji'**
+  String get titlePresetEmoji;
+
+  /// Title preset label when custom prompt doesn't match any preset
+  ///
+  /// In en, this message translates to:
+  /// **'Custom'**
+  String get titlePresetCustom;
+
+  /// Hint shown in title prompt editor reminding user to save after changing preset
+  ///
+  /// In en, this message translates to:
+  /// **'Change or select a preset, then tap Save to apply'**
+  String get titlePresetUnsavedHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5537,4 +5537,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role message #$index: quick random debug sample for testing list rendering, scrolling stability, message grouping, and conversation history performance.';
   }
+
+  @override
+  String get titlePresetStandard => 'Standard (Default)';
+
+  @override
+  String get titlePresetEmoji => 'Add Emoji';
+
+  @override
+  String get titlePresetCustom => 'Custom';
+
+  @override
+  String get titlePresetUnsavedHint =>
+      'Change or select a preset, then tap Save to apply';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5320,6 +5320,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get titlePresetStandard => '标准（默认）';
+
+  @override
+  String get titlePresetEmoji => '添加 Emoji';
+
+  @override
+  String get titlePresetCustom => '自定义';
+
+  @override
+  String get titlePresetUnsavedHint => '更改或选择预设后，需点击「保存」方可生效';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -10638,6 +10650,18 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 消息 #$index：快速随机调试样例，用于测试列表渲染、滚动稳定性、消息分组和会话历史性能。';
   }
+
+  @override
+  String get titlePresetStandard => '标准（默认）';
+
+  @override
+  String get titlePresetEmoji => '添加 Emoji';
+
+  @override
+  String get titlePresetCustom => '自定义';
+
+  @override
+  String get titlePresetUnsavedHint => '更改或选择预设后，需点击「保存」方可生效';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -15956,4 +15980,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String debugPageManyMessagesSeedText(String role, int index) {
     return '$role 訊息 #$index：快速隨機調試樣例，用於測試列表渲染、捲動穩定性、訊息分組和會話歷史效能。';
   }
+
+  @override
+  String get titlePresetStandard => '標準（預設）';
+
+  @override
+  String get titlePresetEmoji => '添加 Emoji';
+
+  @override
+  String get titlePresetCustom => '自定義';
+
+  @override
+  String get titlePresetUnsavedHint => '更改或選擇預設後，需點擊「儲存」方可生效';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1955,5 +1955,21 @@
         "type": "int"
       }
     }
+  },
+  "titlePresetStandard": "标准（默认）",
+  "@titlePresetStandard": {
+    "description": "标题预设选项：标准版（无 emoji）"
+  },
+  "titlePresetEmoji": "添加 Emoji",
+  "@titlePresetEmoji": {
+    "description": "标题预设选项：Emoji 版"
+  },
+  "titlePresetCustom": "自定义",
+  "@titlePresetCustom": {
+    "description": "当自定义提示词不匹配任何预设时显示的标签"
+  },
+  "titlePresetUnsavedHint": "更改或选择预设后，需点击「保存」方可生效",
+  "@titlePresetUnsavedHint": {
+    "description": "标题提示词编辑器中提醒用户在更改预设后保存的提示"
   }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1955,5 +1955,21 @@
         "type": "int"
       }
     }
+  },
+  "titlePresetStandard": "标准（默认）",
+  "@titlePresetStandard": {
+    "description": "标题预设选项：标准版（无 emoji）"
+  },
+  "titlePresetEmoji": "添加 Emoji",
+  "@titlePresetEmoji": {
+    "description": "标题预设选项：Emoji 版"
+  },
+  "titlePresetCustom": "自定义",
+  "@titlePresetCustom": {
+    "description": "当自定义提示词不匹配任何预设时显示的标签"
+  },
+  "titlePresetUnsavedHint": "更改或选择预设后，需点击「保存」方可生效",
+  "@titlePresetUnsavedHint": {
+    "description": "标题提示词编辑器中提醒用户在更改预设后保存的提示"
   }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1955,5 +1955,21 @@
         "type": "int"
       }
     }
+  },
+  "titlePresetStandard": "標準（預設）",
+  "@titlePresetStandard": {
+    "description": "標題預設選項：標準版（無 emoji）"
+  },
+  "titlePresetEmoji": "添加 Emoji",
+  "@titlePresetEmoji": {
+    "description": "標題預設選項：Emoji 版"
+  },
+  "titlePresetCustom": "自定義",
+  "@titlePresetCustom": {
+    "description": "當自定義提示詞不匹配任何預設時顯示的標籤"
+  },
+  "titlePresetUnsavedHint": "更改或選擇預設後，需點擊「儲存」方可生效",
+  "@titlePresetUnsavedHint": {
+    "description": "標題提示詞編輯器中提醒用戶在更改預設後儲存的提示"
   }
 }

--- a/test/core/title_presets_test.dart
+++ b/test/core/title_presets_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/prompts/title_presets.dart';
+import 'package:Kelivo/core/prompts/constants/title_prompts.dart';
+
+void main() {
+  group('TitlePresets.detect', () {
+    test('returns "standard" for exact defaultTitlePrompt', () {
+      expect(TitlePresets.detect(defaultTitlePrompt), 'standard');
+    });
+
+    test('returns "standard" for defaultTitlePrompt with trailing whitespace', () {
+      expect(TitlePresets.detect('$defaultTitlePrompt\n'), 'standard');
+      expect(TitlePresets.detect('  $defaultTitlePrompt  '), 'standard');
+    });
+
+    test('returns "emoji" for exact emojiTitlePrompt', () {
+      expect(TitlePresets.detect(emojiTitlePrompt), 'emoji');
+    });
+
+    test('returns "emoji" for emojiTitlePrompt with trailing whitespace', () {
+      expect(TitlePresets.detect('$emojiTitlePrompt\n'), 'emoji');
+    });
+
+    test('returns null for custom text that does not match any preset', () {
+      expect(TitlePresets.detect('this is a custom prompt'), isNull);
+    });
+
+    test('returns null for empty string', () {
+      expect(TitlePresets.detect(''), isNull);
+    });
+
+    test('returns null for text that almost matches but differs', () {
+      final modified = defaultTitlePrompt.replaceFirst(
+        'short title',
+        'short summary',
+      );
+      expect(TitlePresets.detect(modified), isNull);
+    });
+
+    test('matching is trim-only, not whitespace-collapsed', () {
+      final extraSpaces = defaultTitlePrompt.replaceAll('\n\n', '\n\n\n');
+      expect(TitlePresets.detect(extraSpaces), isNull);
+    });
+  });
+
+  group('TitlePresets.byId', () {
+    test('returns the standard preset', () {
+      final p = TitlePresets.byId('standard');
+      expect(p, isNotNull);
+      expect(p!.id, 'standard');
+      expect(p.prompt, defaultTitlePrompt);
+    });
+
+    test('returns the emoji preset', () {
+      final p = TitlePresets.byId('emoji');
+      expect(p, isNotNull);
+      expect(p!.id, 'emoji');
+      expect(p.prompt, emojiTitlePrompt);
+    });
+
+    test('returns null for unknown id', () {
+      expect(TitlePresets.byId('nonexistent'), isNull);
+      expect(TitlePresets.byId(''), isNull);
+    });
+  });
+
+  group('TitlePresets.all', () {
+    test('contains exactly two presets', () {
+      expect(TitlePresets.all.length, 2);
+    });
+
+    test('contains standard and emoji', () {
+      final ids = TitlePresets.all.map((p) => p.id).toSet();
+      expect(ids, contains('standard'));
+      expect(ids, contains('emoji'));
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

标题生成提示词只支持硬编码的默认文案和手动修改，想用 emoji 标题只能手动全量复制粘贴网络流传的提示词模板，用户体验有提升空间。

关联 PR：#681，此 PR 过大已关闭，但其他部分都已完成并推送至 1.1.17。本 PR 是补全最后一块拼图。

## 方案

**零新增持久化字段**，而是运行时 `trim()` 比对当前提示词是否匹配已知预设。新增 `PromptPreset` 数据类、`TitlePresets` 注册表 + `detect()` 方法、`emojiTitlePrompt` 常量。

## 变更说明

虽然增添了 895 行，但 415 行是基于原有代码的少量改造，~90 行是自动生成的 l10n 代码，78 行是测试代码。改动时尽可能保守克制不变动已有行为，实际改动量不算大，对原有逻辑侵入小。

## Screenshots

| | standard | emoji | custom |
| -- | -- | -- | -- |
| Windows | <img width="1118" height="1116" alt="image" src="https://github.com/user-attachments/assets/08b16ce6-8a44-44fc-b846-025a437a2406" /> | <img width="1114" height="1123" alt="image" src="https://github.com/user-attachments/assets/43a5cb37-d835-45cd-a50c-9d85ffcc614a" /> | <img width="1114" height="1112" alt="image" src="https://github.com/user-attachments/assets/c650e05a-8467-40b3-af32-e28519b740b1" /> |

## UI

- 桌面端：`PresetDropdown`（从 `DesktopSelectDropdown` 派生，`T? value` + `customLabel`），这部分代码虽然长但大部分是复制过来的，以免变更原有行为；不直接复用是因为哨兵值处理麻烦且引入不希望出现的“自定义”
- 移动端：触发条 → `showModalBottomSheet` + `IosCardPress`
- 两端均使用 `ListenableBuilder(controller)` 实现**下拉 label 实时更新**，但**持久化仍然需要手动点击“保存”**
- 「重置全部」按钮仍然同时重置提示词 + 思考预算开关，**保持默认行为**

## 测试

13 个单元测试覆盖 `detect()` 精确匹配、trim 边界、无匹配、`byId()` 查找、注册表完整性。