### PR TITLE
feat: query all keys' balance at once in multi-key manager

### DIFF
--- a/lib/core/services/provider_balance_service.dart
+++ b/lib/core/services/provider_balance_service.dart
@@ -99,7 +99,23 @@ class ProviderBalanceValueParser {
 class ProviderBalanceService {
   const ProviderBalanceService._();
 
-  static Future<String> fetchBalance(ProviderConfig config) async {
+  static Future<String> fetchBalance(ProviderConfig config) {
+    return _fetchBalance(config, _effectiveApiKey(config));
+  }
+
+  /// Fetch the balance for a specific API key, ignoring multi-key selection.
+  /// Used by the multi-key manager to query every key's balance at once.
+  static Future<String> fetchBalanceForKey(
+    ProviderConfig config,
+    String apiKey,
+  ) {
+    return _fetchBalance(config, apiKey);
+  }
+
+  static Future<String> _fetchBalance(
+    ProviderConfig config,
+    String apiKey,
+  ) async {
     final kind = ProviderConfig.classify(
       config.id,
       explicitType: config.providerType,
@@ -118,7 +134,6 @@ class ProviderBalanceService {
     final uri = _balanceUri(config.baseUrl, apiPath);
     final client = _clientFor(config);
     try {
-      final apiKey = _effectiveApiKey(config);
       final headers = <String, String>{
         if (apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
         ...providerDefaultHeaders(config),

--- a/lib/features/provider/pages/multi_key_manager_page.dart
+++ b/lib/features/provider/pages/multi_key_manager_page.dart
@@ -4,6 +4,7 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../core/providers/model_provider.dart';
 import '../../../core/models/api_keys.dart';
+import '../../../core/services/provider_balance_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../model/widgets/model_select_sheet.dart';
@@ -29,6 +30,10 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
   String? _detectModelId;
   bool _detecting = false;
   String? _testingKeyId;
+  bool _queryingBalance = false;
+  // Per-key balance results, keyed by ApiKeyConfig.id.
+  final Map<String, String> _balances = <String, String>{};
+  final Map<String, String> _balanceErrors = <String, String>{};
 
   @override
   Widget build(BuildContext context) {
@@ -69,6 +74,28 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
               onTap: _onDeleteAllErrorKeys,
             ),
           ),
+          if (_queryingBalance)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: cs.primary,
+                ),
+              ),
+            )
+          else
+            Tooltip(
+              message: l10n.multiKeyPageQueryBalance,
+              child: _TactileIconButton(
+                icon: Lucide.Coins,
+                color: cs.onSurface,
+                semanticLabel: l10n.multiKeyPageQueryBalance,
+                onTap: _onQueryBalances,
+              ),
+            ),
           if (_detecting)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -323,10 +350,23 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
                 ),
                 const SizedBox(width: 8),
                 Expanded(
-                  child: Text(
-                    name,
-                    style: TextStyle(fontWeight: AppFontWeights.semibold),
-                    overflow: TextOverflow.ellipsis,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        name,
+                        style: TextStyle(fontWeight: AppFontWeights.semibold),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                      ),
+                      if (_balances[k.id] != null ||
+                          _balanceErrors[k.id] != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 3),
+                          child: _balanceLine(k),
+                        ),
+                    ],
                   ),
                 ),
               ],
@@ -379,6 +419,39 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _balanceLine(ApiKeyConfig k) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final err = _balanceErrors[k.id];
+    if (err != null) {
+      return Text(
+        l10n.providerDetailPageBalanceError(err),
+        style: TextStyle(fontSize: 11, color: cs.error),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+    final value = _balances[k.id]!;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Lucide.Coins, size: 12, color: cs.onSurface.withValues(alpha: 0.6)),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            l10n.providerDetailPageBalanceResult(value),
+            style: TextStyle(
+              fontSize: 11,
+              color: cs.onSurface.withValues(alpha: 0.7),
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 
@@ -646,6 +719,70 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
       await _detectAllForModel(_detectModelId!);
     } finally {
       if (mounted) setState(() => _detecting = false);
+    }
+  }
+
+  Future<void> _onQueryBalances() async {
+    if (_queryingBalance) return;
+    final settings = context.read<SettingsProvider>();
+    final cfg = settings.getProviderConfig(
+      widget.providerKey,
+      defaultName: widget.providerDisplayName,
+    );
+    final l10n = AppLocalizations.of(context)!;
+    // Balance query reuses the provider-level balance settings; it must be
+    // enabled and the provider must be OpenAI-compatible.
+    final kind = ProviderConfig.classify(
+      cfg.id,
+      explicitType: cfg.providerType,
+    );
+    if (kind != ProviderKind.openai || cfg.balanceEnabled != true) {
+      showAppSnackBar(
+        context,
+        message: l10n.multiKeyPageBalanceDisabled,
+        type: NotificationType.warning,
+      );
+      return;
+    }
+    final keys = List<ApiKeyConfig>.from(cfg.apiKeys ?? const <ApiKeyConfig>[]);
+    if (keys.isEmpty) return;
+
+    setState(() {
+      _queryingBalance = true;
+      _balances.clear();
+      _balanceErrors.clear();
+    });
+    try {
+      // Query every key's balance concurrently.
+      await Future.wait(
+        keys.map((k) async {
+          try {
+            final value = await ProviderBalanceService.fetchBalanceForKey(
+              cfg,
+              k.key,
+            );
+            if (!mounted) return;
+            setState(() {
+              _balances[k.id] = value;
+              _balanceErrors.remove(k.id);
+            });
+          } catch (e) {
+            if (!mounted) return;
+            setState(() {
+              _balanceErrors[k.id] = e.toString();
+              _balances.remove(k.id);
+            });
+          }
+        }),
+      );
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.multiKeyPageBalanceQueriedSnackbar(keys.length),
+        type: NotificationType.success,
+      );
+    } finally {
+      if (mounted) setState(() => _queryingBalance = false);
     }
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -486,6 +486,16 @@
   "providerDetailPageManageKeysButton": "Manage Keys",
   "multiKeyPageTitle": "Multi-Key Manager",
   "multiKeyPageDetect": "Detect",
+  "multiKeyPageQueryBalance": "Query Balances",
+  "multiKeyPageBalanceDisabled": "Enable balance query in Balance settings first",
+  "multiKeyPageBalanceQueriedSnackbar": "Queried balance for {n} keys",
+  "@multiKeyPageBalanceQueriedSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
   "multiKeyPageAdd": "Add",
   "multiKeyPageAddHint": "Enter API keys, separated by comma or space",
   "multiKeyPageImportedSnackbar": "Imported {n} keys",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2231,6 +2231,24 @@ abstract class AppLocalizations {
   /// **'Detect'**
   String get multiKeyPageDetect;
 
+  /// No description provided for @multiKeyPageQueryBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Query Balances'**
+  String get multiKeyPageQueryBalance;
+
+  /// No description provided for @multiKeyPageBalanceDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable balance query in Balance settings first'**
+  String get multiKeyPageBalanceDisabled;
+
+  /// No description provided for @multiKeyPageBalanceQueriedSnackbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Queried balance for {n} keys'**
+  String multiKeyPageBalanceQueriedSnackbar(int n);
+
   /// No description provided for @multiKeyPageAdd.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1160,6 +1160,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get multiKeyPageDetect => 'Detect';
 
   @override
+  String get multiKeyPageQueryBalance => 'Query Balances';
+
+  @override
+  String get multiKeyPageBalanceDisabled =>
+      'Enable balance query in Balance settings first';
+
+  @override
+  String multiKeyPageBalanceQueriedSnackbar(int n) {
+    return 'Queried balance for $n keys';
+  }
+
+  @override
   String get multiKeyPageAdd => 'Add';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1116,6 +1116,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get multiKeyPageDetect => '检测';
 
   @override
+  String get multiKeyPageQueryBalance => '查询余额';
+
+  @override
+  String get multiKeyPageBalanceDisabled => '请先在余额设置中开启余额查询';
+
+  @override
+  String multiKeyPageBalanceQueriedSnackbar(int n) {
+    return '已查询 $n 个 key 的余额';
+  }
+
+  @override
   String get multiKeyPageAdd => '添加';
 
   @override
@@ -6434,6 +6445,17 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get multiKeyPageDetect => '检测';
 
   @override
+  String get multiKeyPageQueryBalance => '查询余额';
+
+  @override
+  String get multiKeyPageBalanceDisabled => '请先在余额设置中开启余额查询';
+
+  @override
+  String multiKeyPageBalanceQueriedSnackbar(int n) {
+    return '已查询 $n 个 key 的余额';
+  }
+
+  @override
   String get multiKeyPageAdd => '添加';
 
   @override
@@ -11750,6 +11772,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get multiKeyPageDetect => '檢測';
+
+  @override
+  String get multiKeyPageQueryBalance => '查詢餘額';
+
+  @override
+  String get multiKeyPageBalanceDisabled => '請先在餘額設定中開啟餘額查詢';
+
+  @override
+  String multiKeyPageBalanceQueriedSnackbar(int n) {
+    return '已查詢 $n 個 key 的餘額';
+  }
 
   @override
   String get multiKeyPageAdd => '新增';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -313,6 +313,16 @@
   "providerDetailPageManageKeysButton": "多Key管理",
   "multiKeyPageTitle": "多Key管理",
   "multiKeyPageDetect": "检测",
+  "multiKeyPageQueryBalance": "查询余额",
+  "multiKeyPageBalanceDisabled": "请先在余额设置中开启余额查询",
+  "multiKeyPageBalanceQueriedSnackbar": "已查询 {n} 个 key 的余额",
+  "@multiKeyPageBalanceQueriedSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
   "multiKeyPageAdd": "添加",
   "multiKeyPageAddHint": "请输入API Key（多个用逗号或空格分隔）",
   "multiKeyPageImportedSnackbar": "已导入{n}个key",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -318,6 +318,16 @@
   "providerDetailPageManageKeysButton": "多Key管理",
   "multiKeyPageTitle": "多Key管理",
   "multiKeyPageDetect": "检测",
+  "multiKeyPageQueryBalance": "查询余额",
+  "multiKeyPageBalanceDisabled": "请先在余额设置中开启余额查询",
+  "multiKeyPageBalanceQueriedSnackbar": "已查询 {n} 个 key 的余额",
+  "@multiKeyPageBalanceQueriedSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
   "multiKeyPageAdd": "添加",
   "multiKeyPageAddHint": "请输入API Key（多个用逗号或空格分隔）",
   "multiKeyPageImportedSnackbar": "已导入{n}个key",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1612,6 +1612,16 @@
   "providerDetailPageManageKeysButton": "多Key管理",
   "multiKeyPageTitle": "多Key管理",
   "multiKeyPageDetect": "檢測",
+  "multiKeyPageQueryBalance": "查詢餘額",
+  "multiKeyPageBalanceDisabled": "請先在餘額設定中開啟餘額查詢",
+  "multiKeyPageBalanceQueriedSnackbar": "已查詢 {n} 個 key 的餘額",
+  "@multiKeyPageBalanceQueriedSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
   "multiKeyPageAdd": "新增",
   "multiKeyPageAddHint": "請輸入 API Key（多個以逗號或空格分隔）",
   "multiKeyPageImportedSnackbar": "已匯入 {n} 個 key",


### PR DESCRIPTION
## What
Add a one-tap action in the Multi-Key Manager to query the balance of **all** API keys concurrently, shown per-key.
在多 Key 管理页新增「查询余额」按钮，一次并发查询所有 Key 的余额并逐行显示。

## Changes
- `ProviderBalanceService.fetchBalanceForKey(config, apiKey)` — query balance for a specific key (existing `fetchBalance` unchanged).
- Multi-Key Manager: Coins button → concurrent balance query for every key; per-key result / error line.
- i18n: new keys for en / zh / zh-Hans / zh-Hant, regenerated localizations.

Reuses existing balance settings (`balanceApiPath`/`balanceResultPath`). `flutter analyze` clean.