### PR TITLE
fix(home page): 修复编辑用户消息时的退出逻辑问题

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -630,9 +630,13 @@ class HomePageController extends ChangeNotifier {
     }
     final editState = _userMessageEditState;
     if (editState != null) {
-      final newMsg = await _saveEditedUserMessageVersion(input, editState);
+      ChatMessage? newMsg;
+      try {
+        newMsg = await _saveEditedUserMessageVersion(input, editState);
+      } finally {
+        _exitUserMessageEdit(clearDraft: false);
+      }
       if (newMsg == null) return ChatInputSubmissionResult.rejected;
-      _exitUserMessageEdit(clearDraft: false);
       await regenerateAtMessage(newMsg);
       return ChatInputSubmissionResult.sent;
     }
@@ -1043,15 +1047,17 @@ class HomePageController extends ChangeNotifier {
   Future<void> saveUserMessageEditOnly() async {
     final editState = _userMessageEditState;
     if (editState == null) return;
-    final input = _mediaController.snapshotInput(_inputController.text);
-    if (input.text.trim().isEmpty &&
-        input.imagePaths.isEmpty &&
-        input.documents.isEmpty) {
-      return;
+    try {
+      final input = _mediaController.snapshotInput(_inputController.text);
+      if (input.text.trim().isEmpty &&
+          input.imagePaths.isEmpty &&
+          input.documents.isEmpty) {
+        return;
+      }
+      await _saveEditedUserMessageVersion(input, editState);
+    } finally {
+      _exitUserMessageEdit(clearDraft: true);
     }
-    final newMsg = await _saveEditedUserMessageVersion(input, editState);
-    if (newMsg == null) return;
-    _exitUserMessageEdit(clearDraft: true);
   }
 
   void _enterUserMessageEdit(ChatMessage message) {


### PR DESCRIPTION
将退出编辑状态的逻辑移到finally块中，确保无论保存成功与否都会正确执行退出操作，同时调整了仅保存编辑消息的方法内的执行流程，统一异常安全的处理逻辑。

### 实际问题描述
当我们编辑一个对话时，在部分情况下可能出现点击发送无反应的情况