### PR TITLE
feat: persist chat input draft across restarts

### DIFF
--- a/lib/features/home/services/input_draft_persistence.dart
+++ b/lib/features/home/services/input_draft_persistence.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../../core/models/chat_input_data.dart';
+
+class InputDraftPersistence {
+  // 全局草稿，不按 conversationId 隔离（有意为之）
+  static const String _draftKey = 'chat_draft_v1';
+  static const Duration _debounceDuration = Duration(milliseconds: 800);
+
+  Timer? _debounceTimer;
+  ChatInputData? _pending;
+  bool _disposed = false;
+
+  void scheduleSave(ChatInputData data) {
+    if (_disposed) return;
+    _pending = data;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_debounceDuration, _flush);
+  }
+
+  Future<void> saveImmediately() async {
+    if (_disposed) return;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    await _flush();
+  }
+
+  Future<ChatInputData?> restore() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_draftKey);
+    if (json == null || json.isEmpty) return null;
+    try {
+      final map = jsonDecode(json) as Map<String, dynamic>;
+      final text = map['text'] as String? ?? '';
+      final images =
+          (map['images'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+          [];
+      final docs =
+          (map['documents'] as List<dynamic>?)
+              ?.map(
+                (d) => DocumentAttachment(
+                  path: d['path'] as String? ?? '',
+                  fileName: d['fileName'] as String? ?? '',
+                  mime: d['mime'] as String? ?? '',
+                ),
+              )
+              .toList() ??
+          [];
+      if (text.isEmpty && images.isEmpty && docs.isEmpty) return null;
+      return ChatInputData(text: text, imagePaths: images, documents: docs);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> delete() async {
+    if (_disposed) return;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _pending = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_draftKey);
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    if (_pending != null) {
+      _write(_pending!);
+      _pending = null;
+    }
+  }
+
+  Future<void> _flush() async {
+    if (_disposed) return;
+    final data = _pending;
+    if (data == null) return;
+    _pending = null;
+    if (data.text.isEmpty &&
+        data.imagePaths.isEmpty &&
+        data.documents.isEmpty) {
+      await delete();
+      return;
+    }
+    await _write(data);
+  }
+
+  Future<void> _write(ChatInputData data) async {
+    final map = <String, dynamic>{
+      'text': data.text,
+      'images': data.imagePaths,
+      'documents': data.documents
+          .map(
+            (d) => <String, String>{
+              'path': d.path,
+              'fileName': d.fileName,
+              'mime': d.mime,
+            },
+          )
+          .toList(),
+    };
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_draftKey, jsonEncode(map));
+  }
+}

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -21,13 +21,14 @@ import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/search/search_service.dart';
 import '../../../core/services/api/builtin_tools.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../features/home/services/input_draft_persistence.dart';
 import '../../../core/utils/multimodal_input_utils.dart';
 import '../../../utils/brand_assets.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../utils/app_directories.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 import '../../../desktop/desktop_context_menu.dart';
-import 'package:Kelivo/theme/app_font_weights.dart';
+import '../../../theme/app_font_weights.dart';
 
 class ChatInputBarController {
   _ChatInputBarState? _state;
@@ -181,6 +182,9 @@ class _ChatInputBarState extends State<ChatInputBar>
   String? _imageModeModelKey;
   String? _lastImageModeModelKey;
   String? _dismissedImageModeModelKey;
+  bool _restorePending = true;
+
+  InputDraftPersistence? _draftPersistence;
 
   bool get _composerLocked => widget.hasQueuedInput;
 
@@ -250,24 +254,32 @@ class _ChatInputBarState extends State<ChatInputBar>
   bool get _hasDraftMedia => _images.isNotEmpty || _docs.isNotEmpty;
 
   // Instance method for onChanged to avoid recreating the callback on every build
-  void _onTextChanged(String _) => setState(() {});
+  void _onTextChanged(String _) {
+    setState(() {});
+    if (_restorePending) return;
+    _scheduleDraftSave();
+  }
 
   void _addImages(List<String> paths) {
     if (paths.isEmpty) return;
     setState(() => _images.addAll(paths));
+    _scheduleDraftSave();
   }
 
   void _clearImages() {
     setState(() => _images.clear());
+    _scheduleDraftSave();
   }
 
   void _addFiles(List<DocumentAttachment> docs) {
     if (docs.isEmpty) return;
     setState(() => _docs.addAll(docs));
+    _scheduleDraftSave();
   }
 
   void _clearFiles() {
     setState(() => _docs.clear());
+    _scheduleDraftSave();
   }
 
   void _restoreInput(ChatInputData input) {
@@ -296,14 +308,49 @@ class _ChatInputBarState extends State<ChatInputBar>
       _images.clear();
       _docs.clear();
     });
+    _draftPersistence?.delete();
+  }
+
+  void _scheduleDraftSave() {
+    final data = _snapshotInput(_controller.text);
+    _draftPersistence?.scheduleSave(data);
+  }
+
+  Future<void> _restoreDraft() async {
+    final data = await _draftPersistence?.restore();
+    _restorePending = false;
+    if (!mounted || data == null) return;
+    if (_controller.text.isNotEmpty) {
+      // 用户已输入文本，仅恢复附件，不覆盖文字
+      setState(() {
+        _images
+          ..clear()
+          ..addAll(data.imagePaths);
+        _docs
+          ..clear()
+          ..addAll(data.documents);
+      });
+      return;
+    }
+    _controller.text = data.text;
+    setState(() {
+      _images
+        ..clear()
+        ..addAll(data.imagePaths);
+      _docs
+        ..clear()
+        ..addAll(data.documents);
+    });
   }
 
   void _removeImageAt(int index) {
     setState(() => _images.removeAt(index));
+    _scheduleDraftSave();
   }
 
   void _removeDocumentAt(int index) {
     setState(() => _docs.removeAt(index));
+    _scheduleDraftSave();
   }
 
   @override
@@ -312,6 +359,10 @@ class _ChatInputBarState extends State<ChatInputBar>
     _controller = widget.controller ?? TextEditingController();
     widget.mediaController?._bind(this);
     WidgetsBinding.instance.addObserver(this);
+    _draftPersistence = InputDraftPersistence();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _restoreDraft();
+    });
   }
 
   @override
@@ -333,6 +384,7 @@ class _ChatInputBarState extends State<ChatInputBar>
       // When going to background, hide any open toolbar
       _suppressContextMenu = true;
       widget.focusNode?.unfocus();
+      _draftPersistence?.saveImmediately();
     }
   }
 
@@ -349,6 +401,7 @@ class _ChatInputBarState extends State<ChatInputBar>
     if (widget.controller == null) {
       _controller.dispose();
     }
+    _draftPersistence?.dispose();
     super.dispose();
   }
 
@@ -394,6 +447,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         _controller.clear();
         _images.clear();
         _docs.clear();
+        _draftPersistence?.delete();
         setState(() {});
         // Keep focus on desktop so user can continue typing
         try {

--- a/test/features/home/services/input_draft_persistence_test.dart
+++ b/test/features/home/services/input_draft_persistence_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Kelivo/core/models/chat_input_data.dart';
+import 'package:Kelivo/features/home/services/input_draft_persistence.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('InputDraftPersistence', () {
+    test('restore returns null when nothing saved', () async {
+      final p = InputDraftPersistence();
+      final result = await p.restore();
+      expect(result, isNull);
+    });
+
+    test('save text then restore returns same text', () async {
+      final p = InputDraftPersistence();
+      final data = ChatInputData(text: 'hello world');
+      p.scheduleSave(data);
+      await Future.delayed(const Duration(milliseconds: 900));
+      final result = await p.restore();
+      expect(result, isNotNull);
+      expect(result!.text, 'hello world');
+      expect(result.imagePaths, isEmpty);
+      expect(result.documents, isEmpty);
+    });
+
+    test('save text with images and documents roundtrip', () async {
+      final p = InputDraftPersistence();
+      final data = ChatInputData(
+        text: 'multi modal',
+        imagePaths: ['/path/a.png', '/path/b.jpg'],
+        documents: [
+          DocumentAttachment(
+            path: '/doc.pdf',
+            fileName: 'doc.pdf',
+            mime: 'application/pdf',
+          ),
+        ],
+      );
+      p.scheduleSave(data);
+      await Future.delayed(const Duration(milliseconds: 900));
+      final result = await p.restore();
+      expect(result, isNotNull);
+      expect(result!.text, 'multi modal');
+      expect(result.imagePaths, ['/path/a.png', '/path/b.jpg']);
+      expect(result.documents.length, 1);
+      expect(result.documents[0].path, '/doc.pdf');
+      expect(result.documents[0].fileName, 'doc.pdf');
+      expect(result.documents[0].mime, 'application/pdf');
+    });
+
+    test(
+      'empty content (no text, no media) is not saved and restore returns null',
+      () async {
+        final p = InputDraftPersistence();
+        final data = ChatInputData(text: '');
+        p.scheduleSave(data);
+        await Future.delayed(const Duration(milliseconds: 900));
+        final result = await p.restore();
+        expect(result, isNull);
+      },
+    );
+
+    test('delete removes saved draft', () async {
+      final p = InputDraftPersistence();
+      p.scheduleSave(ChatInputData(text: 'to delete'));
+      await Future.delayed(const Duration(milliseconds: 900));
+      await p.delete();
+      final result = await p.restore();
+      expect(result, isNull);
+    });
+
+    test('debounce: multiple scheduleSave only writes the last one', () async {
+      final p = InputDraftPersistence();
+      p.scheduleSave(ChatInputData(text: 'first'));
+      await Future.delayed(const Duration(milliseconds: 100));
+      p.scheduleSave(ChatInputData(text: 'second'));
+      await Future.delayed(const Duration(milliseconds: 100));
+      p.scheduleSave(ChatInputData(text: 'third'));
+      await Future.delayed(const Duration(milliseconds: 900));
+      final result = await p.restore();
+      expect(result, isNotNull);
+      expect(result!.text, 'third');
+    });
+
+    test('saveImmediately skips debounce delay', () async {
+      final p = InputDraftPersistence();
+      p.scheduleSave(ChatInputData(text: 'immediate'));
+      await p.saveImmediately();
+      final result = await p.restore();
+      expect(result, isNotNull);
+      expect(result!.text, 'immediate');
+    });
+
+    test('dispose with pending data does not throw', () async {
+      final p = InputDraftPersistence();
+      p.scheduleSave(ChatInputData(text: 'dispose test'));
+      // no delay — pending is still active
+      expect(() => p.dispose(), returnsNormally);
+      // After dispose, further calls are no-ops
+      expect(
+        () => p.scheduleSave(ChatInputData(text: 'after dispose')),
+        returnsNormally,
+      );
+      final result = await p.restore();
+      // The pending write may or may not have completed; just ensure no crash
+      expect(
+        result,
+        isNull,
+      ); // nothing was flushed since dispose fires write async
+    });
+
+    test('dispose after flush saves pending data', () async {
+      final p = InputDraftPersistence();
+      p.scheduleSave(ChatInputData(text: 'flush before dispose'));
+      await p.saveImmediately();
+      p.dispose();
+      final result = await p.restore();
+      expect(result, isNotNull);
+      expect(result!.text, 'flush before dispose');
+    });
+
+    test('restore with corrupted JSON returns null', () async {
+      SharedPreferences.setMockInitialValues({
+        'chat_draft_v1': 'this is not valid json',
+      });
+      final p = InputDraftPersistence();
+      final result = await p.restore();
+      expect(result, isNull);
+    });
+
+    test('restore with malformed structure returns null', () async {
+      SharedPreferences.setMockInitialValues({
+        'chat_draft_v1': '{"notText": 123}',
+      });
+      final p = InputDraftPersistence();
+      final result = await p.restore();
+      expect(result, isNull);
+    });
+
+    test('delete after dispose is no-op', () async {
+      final p = InputDraftPersistence();
+      p.dispose();
+      await expectLater(p.delete(), completes);
+    });
+
+    test('saveImmediately after dispose is no-op', () async {
+      final p = InputDraftPersistence();
+      p.dispose();
+      await expectLater(p.saveImmediately(), completes);
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

有时用户输入大段文本后，在突发闪退/置于后台过久后，应用关闭即丢失。

新增 `InputDraftPersistence` 组件，以 debounce 方式将输入文本、图片和附件持久化到 SharedPreferences，冷启动时自动恢复。

## Changes

- **`lib/features/home/services/input_draft_persistence.dart`** — 新组件。封装了 800ms debounce 写入 + 生命周期立即写入 + 读取 + 删除。单 key `chat_draft_v1`，JSON blob 结构。
- **`lib/features/home/widgets/chat_input_bar.dart`** — 集成到 `_ChatInputBarState`：initState 中创建 persistence，postFrameCallback 中恢复；`_onTextChanged` 和媒体变更方法中触发 `scheduleSave()`；`didChangeAppLifecycleState` 中 `saveImmediately()`；发送成功或清空时 `delete()`。
- **`test/features/home/services/input_draft_persistence_test.dart`** — 13 个测试用例。

## Design Decisions

| 决策 | 选项 | 理由 |
|---|---|---|
| 作用域 | 全局单份 | 当前 `_inputController` 跨会话共享，不存在多份草稿并发场景 |
| 写入策略 | debounce 800ms | 用户打字是爆发式的。800ms 停顿后落盘，避免中间态无用写入 |
| 生命周期兜底 | paused/inactive 时立即写 | 防 OS 强杀丢最后几秒内容 |
| 存储后端 | SharedPreferences | 与 `WindowSizeManager`、`SettingsProvider` 同一模式，异步原子写入，崩溃安全 |
| key 命名 | `chat_draft_v1` | 与仓库惯例一致 |
| 序列化 | 单 JSON key | 图片/文档总是需要 JSON，统一 JSON 更原子 |
| 恢复时机 | 仅冷启动 | 全局草稿，每次启动恢复一次即可 |
| 用户输入保护 | `text.isNotEmpty` 时不覆盖 | 慢设备上用户可能已在恢复完成前打字，保留用户输入（已知问题和取舍） |
