### PR TITLE
feat: parse cc_bridge_event for native tool cards and multi-segment thinking

### DIFF
--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -3094,6 +3094,65 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           if (usage != null) totalTokens = usage.totalTokens;
         }
 
+        // cc_bridge (bridge.py) tool events → native tool card + thinking segment split
+        // tool_use closes current thinking segment; tool_result fills the card content.
+        final ccBridgeEvent = json['cc_bridge_event'] as Map<String, dynamic>?;
+        if (ccBridgeEvent != null && config.useResponseApi != true) {
+          final ccType = (ccBridgeEvent['type'] ?? '').toString();
+          if (ccType == 'tool_use') {
+            final ccId = (ccBridgeEvent['id'] ?? 'cc_call').toString();
+            final ccName = (ccBridgeEvent['name'] ?? 'tool').toString();
+            final ccInputRaw =
+                ccBridgeEvent['input'] ?? ccBridgeEvent['input_preview'];
+            Map<String, dynamic> ccArgs;
+            try {
+              if (ccInputRaw is String && ccInputRaw.isNotEmpty) {
+                ccArgs =
+                    (jsonDecode(ccInputRaw) as Map).cast<String, dynamic>();
+              } else if (ccInputRaw is Map) {
+                ccArgs = ccInputRaw.cast<String, dynamic>();
+              } else {
+                ccArgs = const <String, dynamic>{};
+              }
+            } catch (_) {
+              ccArgs = const <String, dynamic>{};
+            }
+            yield ChatStreamChunk(
+              content: '',
+              isDone: false,
+              totalTokens: totalTokens,
+              toolCalls: [
+                ToolCallInfo(id: ccId, name: ccName, arguments: ccArgs),
+              ],
+            );
+          } else if (ccType == 'tool_result') {
+            final ccId = (ccBridgeEvent['id'] ?? '').toString();
+            final ccName = (ccBridgeEvent['name'] ?? '').toString();
+            final ccContent =
+                (ccBridgeEvent['content_preview'] ??
+                        ccBridgeEvent['content'] ??
+                        '')
+                    .toString();
+            final ccIsError = ccBridgeEvent['is_error'] == true;
+            yield ChatStreamChunk(
+              content: '',
+              isDone: false,
+              totalTokens: totalTokens,
+              toolResults: [
+                ToolResultInfo(
+                  id: ccId,
+                  name: ccName,
+                  arguments: const <String, dynamic>{},
+                  content: ccContent,
+                  metadata: ccIsError
+                      ? const <String, dynamic>{'is_error': true}
+                      : null,
+                ),
+              ],
+            );
+          }
+        }
+
         if (content.isNotEmpty || (reasoning?.isNotEmpty ?? false)) {
           final approxTotal =
               approxPromptTokens + approxTokensFromChars(approxCompletionChars);

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -885,6 +885,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
 }) async* {
   final upstreamModelId = _apiModelId(config, modelId);
   final url = _openAICompatibleUrl(config);
+  // id → args cache: tool_use stores args here; tool_result retrieves & removes them
+  final _ccBridgeToolArgs = <String, Map<String, dynamic>>{};
 
   final effectiveInfo = _effectiveModelInfo(config, modelId);
   final isReasoning = effectiveInfo.abilities.contains(ModelAbility.reasoning);
@@ -3117,6 +3119,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             } catch (_) {
               ccArgs = const <String, dynamic>{};
             }
+            // cache args so tool_result can reuse them
+            _ccBridgeToolArgs[ccId] = ccArgs;
             yield ChatStreamChunk(
               content: '',
               isDone: false,
@@ -3128,12 +3132,16 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           } else if (ccType == 'tool_result') {
             final ccId = (ccBridgeEvent['id'] ?? '').toString();
             final ccName = (ccBridgeEvent['name'] ?? '').toString();
+            // prefer full content over preview (Codex P2 fix)
             final ccContent =
-                (ccBridgeEvent['content_preview'] ??
-                        ccBridgeEvent['content'] ??
+                (ccBridgeEvent['content'] ??
+                        ccBridgeEvent['content_preview'] ??
                         '')
                     .toString();
             final ccIsError = ccBridgeEvent['is_error'] == true;
+            // reuse args from matching tool_use so upsertToolEvent doesn't wipe them (Codex P2 fix)
+            final ccArgs =
+                _ccBridgeToolArgs.remove(ccId) ?? const <String, dynamic>{};
             yield ChatStreamChunk(
               content: '',
               isDone: false,
@@ -3142,7 +3150,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 ToolResultInfo(
                   id: ccId,
                   name: ccName,
-                  arguments: const <String, dynamic>{},
+                  arguments: ccArgs,
                   content: ccContent,
                   metadata: ccIsError
                       ? const <String, dynamic>{'is_error': true}


### PR DESCRIPTION
## What this does

When using [cc-bridge](https://github.com/Chevey339/kelivo) (a local Claude CLI bridge), tool events arrive as a `cc_bridge_event` field at the JSON root of each SSE chunk — since the bridge handles all tool execution internally and never uses Kelivo's `onToolCall` mechanism.

Without this patch, Kelivo ignores `cc_bridge_event` entirely, so all thinking appears as **one big blob** with tool info mixed in, and the multi-segment thinking UI never triggers.

## How it works

This patch adds ~55 lines to the SSE parsing loop in `openai_common.dart`:

- **`tool_use` event** → yields `ChatStreamChunk(toolCalls: [...])` → triggers `handleToolCallsChunk` → closes the current thinking segment + creates a native tool UI card
- **`tool_result` event** → yields `ChatStreamChunk(toolResults: [...])` → fills the tool card with the result content

## Result

Before:
> One thinking bubble containing all reasoning + tool calls mixed together

After:
> **Thinking bubble 1** — pure pre-tool reasoning  
> **[Tool card: name + input + result]**  
> **Thinking bubble 2** — post-tool reasoning  
> **[Tool card 2: ...]** ...and so on  
> Final response

## Compatibility

- No effect on normal providers (only fires when `cc_bridge_event` is present in the JSON)
- No effect on Response API path (`config.useResponseApi != true` guard)
- No changes to any other files