### PR TITLE
fix: retry success after first conversation failure now triggers title auto-generation

### DIFF
--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -65,6 +65,7 @@ class ChatActions {
     required this.messageGenerationService,
     required this.contextProvider,
     required this.viewModel,
+    required this.getTitleForLocale,
   });
 
   final HomeViewModel viewModel;
@@ -74,6 +75,7 @@ class ChatActions {
   final GenerationController generationController;
   final MessageGenerationService messageGenerationService;
   final BuildContext contextProvider;
+  final String Function(BuildContext context) getTitleForLocale;
 
   // ============================================================================
   // Callbacks for UI updates (set by HomeViewModel)
@@ -626,6 +628,9 @@ class ChatActions {
       regenAskUserService = contextProvider.read<AskUserInteractionService>();
     } catch (_) {}
 
+    final shouldGenerateTitleOnRetry =
+        conversation.title == getTitleForLocale(contextProvider);
+
     await cancelStreaming(conversation);
 
     final completeMessages = chatController.messagesForCompleteHistoryContext(
@@ -777,7 +782,7 @@ class ChatActions {
       settings: settings,
       supportsReasoning: supportsReasoning,
       enableReasoning: enableReasoning,
-      generateTitleOnFinish: false,
+      generateTitleOnFinish: shouldGenerateTitleOnRetry,
     );
 
     await _executeGeneration(ctx);

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -171,6 +171,7 @@ class HomeViewModel extends ChangeNotifier {
       messageGenerationService: _messageGenerationService,
       contextProvider: _contextProvider,
       viewModel: this,
+      getTitleForLocale: getTitleForLocale,
     );
 
     // Wire up callbacks


### PR DESCRIPTION
## Background

Fixes #710

首次对话失败后，用户点击重试，即使重试成功，对话标题仍保持为"新对话"，不会自动生成标题。

### Root Cause

`chat_actions.dart` 中 `regenerateAtMessage`（重试）硬编码了 `generateTitleOnFinish: false`，导致 `_finishStreaming` 永远不会触发 `onMaybeGenerateTitle` 回调，标题生成逻辑被静默跳过。

### Changes

**2 files, +7 / -1 lines**

- `lib/features/home/controllers/chat_actions.dart` (+6/-1)
  - 新增 `getTitleForLocale` 字段依赖
  - async gap 前捕获 `shouldGenerateTitleOnRetry`：重试时仅当标题仍是默认值（如"新对话"）时，才允许触发标题生成
  - `generateTitleOnFinish` 从 `false` 改为 `shouldGenerateTitleOnRetry`

- `lib/features/home/controllers/home_view_model.dart` (+1)
  - 创建 `ChatActions` 时传入 `getTitleForLocale`
