### PR TITLE
fix(backup): inject current timestamp into settings.json in ZIP (#717)

### DIFF
--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -148,10 +148,15 @@ class DataSync {
       // --- Step 1: Prepare temp files that need ChatService (main isolate) ---
       // settings.json
       final settingsJson = await _exportSettingsJson();
+      final map = jsonDecode(settingsJson) as Map<String, dynamic>;
+      map['backup_reminder_last_backup_at_v1'] = DateTime.now()
+          .toIso8601String();
+      final patchedJson = jsonEncode(map);
+
       settingsTmp = await _writeTempText(
         workDir,
         '_bk_settings.json',
-        settingsJson,
+        patchedJson,
       );
 
       // chats.json — stream to file to avoid huge string in memory

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -109,6 +109,52 @@ void main() {
       },
     );
 
+    test(
+      'settings.json in backup ZIP contains current backup_reminder_last_backup_at_v1',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'backup_reminder_last_backup_at_v1': '2020-01-01T00:00:00.000',
+          'other_setting': 'should still be present',
+        });
+
+        final sync = DataSync(chatService: ChatService());
+        final before = DateTime.now();
+        final backupFile = await sync.prepareBackupFile(
+          const WebDavConfig(includeChats: false, includeFiles: false),
+        );
+        final after = DateTime.now();
+
+        final input = InputFileStream(backupFile.path);
+        try {
+          final archive = ZipDecoder().decodeStream(input);
+          final settingsEntry = archive.findFile('settings.json');
+          expect(settingsEntry, isNotNull);
+
+          final rawBytes = settingsEntry!.readBytes();
+          final content = jsonDecode(utf8.decode(rawBytes!)) as Map;
+          final ts = content['backup_reminder_last_backup_at_v1'] as String;
+          final parsed = DateTime.parse(ts);
+
+          expect(
+            parsed.isAfter(before) || parsed.isAtSameMomentAs(before),
+            isTrue,
+            reason: 'timestamp should be >= backup start time',
+          );
+          expect(
+            parsed.isBefore(after) || parsed.isAtSameMomentAs(after),
+            isTrue,
+            reason: 'timestamp should be <= backup end time',
+          );
+
+          expect(content['other_setting'], 'should still be present');
+        } finally {
+          input.closeSync();
+        }
+
+        await DataSync.cleanupTemporaryBackupFile(backupFile);
+      },
+    );
+
     test('restores managed font files in overwrite and merge modes', () async {
       final sourceDir = Directory('${root.path}/source_fonts');
       await sourceDir.create(recursive: true);


### PR DESCRIPTION
## 问题

Fixes #717 

跨设备备份恢复时 `lastBackupAt` 时间戳回退。

**根因：** `_exportSettingsJson()` 在 `recordBackupCompleted()` 之前读取 SharedPreferences，导致 ZIP 内的 `backup_reminder_last_backup_at_v1` 恒为上一次备份的时间，而非本次。

## 修复

`lib/core/services/backup/data_sync.dart` — 在 `_exportSettingsJson()` 返回后、写入 temp 文件前，用 `DateTime.now()` 覆盖 `backup_reminder_last_backup_at_v1`。影响面控制在最小，且在创建过程中更改，保证备份中断不会更新最近备份时间。

## 测试

新增 `settings.json in backup ZIP contains current backup_reminder_last_backup_at_v1`：

- 预设 `backup_reminder_last_backup_at_v1` 为旧值 `2020-01-01T00:00:00.000`
- 调用 `prepareBackupFile()` 生成 ZIP
- 解压并断言 `settings.json` 内的时间戳为当前时间（介于备份开始前/后之间）
