### PR TITLE
fix: broaden Qwen 3.5-3.7 and Doubao seed-2 model capability detection

### DIFF
--- a/lib/core/providers/model_provider.dart
+++ b/lib/core/providers/model_provider.dart
@@ -17,14 +17,14 @@ class ModelRegistry {
   // Vision-capable models (text + image input)
   static final RegExp vision = RegExp(
     // GPT family incl. 4o, 4.1, 5 (exclude gpt-5-chat), and OpenAI o* series
-    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3([-.])5|kimi-k2([-.])(?:5|6|7)|doubao.+1([-.])(?:6|8)|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
+    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|kimi-k2([-.])(?:5|6|7)|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
     caseSensitive: false,
   );
   // Tool-using models
   static final RegExp tool = RegExp(
     (r'(gpt-4o|gpt-4\.1|gpt-oss|gpt-5(?!-chat)|o\d|'
             r'gemini|claude|'
-            r'qwen-?3|doubao.+1([-.])(?:6|8)|grok-4|kimi-k2|'
+            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3|chat|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -40,7 +40,7 @@ class ModelRegistry {
             r'gemini-3-pro-image-preview|'
             r'gemma[-_]?4|'
             r'claude|'
-            r'qwen-?3|doubao.+1([-.])(?:6|8)|grok-4|kimi-k2|'
+            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'

--- a/test/model_registry_vision_test.dart
+++ b/test/model_registry_vision_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/model_provider.dart';
+
+void main() {
+  group('ModelRegistry.infer — Qwen 3.x vision detection', () {
+    test('qwen3.5-plus has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.5-plus', displayName: 'qwen3.5-plus'),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('qwen3.6-plus has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.6-plus', displayName: 'qwen3.6-plus'),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('qwen3.6-flash has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.6-flash', displayName: 'qwen3.6-flash'),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('qwen3.6-35b-a3b has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.6-35b-a3b', displayName: 'qwen3.6-35b-a3b'),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('qwen3.7-max does NOT have vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.7-max', displayName: 'qwen3.7-max'),
+      );
+      expect(info.input, isNot(contains(Modality.image)));
+    });
+
+    test('qwen3-plus does NOT have vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3-plus', displayName: 'qwen3-plus'),
+      );
+      expect(info.input, isNot(contains(Modality.image)));
+    });
+  });
+
+  group('ModelRegistry.infer — Doubao seed-2 vision/tool/reasoning', () {
+    test('doubao-seed-2.0-pro has vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'doubao-seed-2.0-pro',
+          displayName: 'doubao-seed-2.0-pro',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+
+    test('doubao-seed-2.1-turbo has vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'doubao-seed-2.1-turbo',
+          displayName: 'doubao-seed-2.1-turbo',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+  });
+
+  group('ModelRegistry.infer — existing 1.x doubao still works', () {
+    test('doubao-pro-1.6 keeps vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'doubao-pro-1.6',
+          displayName: 'doubao-pro-1.6',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+
+    test('doubao-seed-1.8 keeps vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'doubao-seed-1.8',
+          displayName: 'doubao-seed-1.8',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

1. `doubao-seed-2.1-pro` 和 `doubao-seed-2.1-turbo` 发布。
2. 回答 #707 时无意发现 `qwen-3.6` 系列模型图片能力识别遗漏。

## Summary

`ModelRegistry.infer()` 中三个能力正则（vision / tool / reasoning）存在遗漏，
导致部分模型的能力未被正确识别。

## Changes

### Qwen 3.x 视觉检测修复

`model_provider.dart:20` — vision 正则从 `qwen-?3([-.])5` 改为
`qwen-?3[.-][5-7](?!.*-max)`

- 新增识别：`qwen3.5-plus`, `qwen3.6-plus`, `qwen3.6-flash`,
  `qwen3.6-35b-a3b` 等 3.5/3.6/3.7 变体
- 正确排除：`qwen3.7-max`（-max 后缀不支持视觉）
- 不会误判：`qwen3-plus`（无版本号后缀）

### Doubao seed-2 能力检测修复

三条正则同步更新：`doubao.+1([-.])(?:6|8)` →
`doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)`

- vision 额外识别 `seed-2\.[01]`
- tool / reasoning 放宽至全部 `seed-2` 变体
- 原有 1.6/1.8 系列不受影响

## Tests

新增 `test/model_registry_vision_test.dart`，覆盖 10 个用例：
- Qwen 3.x：5 个含 vision + 2 个不含 vision
- Doubao seed-2：2 个含全套能力
- Doubao 1.x 回归：2 个
