### PR TITLE
fix(macos): restore title bar double-click zoom behavior

### DIFF
--- a/lib/desktop/desktop_home_page.dart
+++ b/lib/desktop/desktop_home_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart'
 import 'desktop_nav_rail.dart';
 import 'desktop_chat_page.dart';
 import 'window_title_bar.dart';
+import 'macos_title_bar_drag_area.dart';
 import 'desktop_settings_page.dart';
 import 'desktop_translate_page.dart';
 import '../features/settings/pages/storage_space_page.dart';
@@ -161,6 +162,7 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
     const minHeight = 640.0;
 
     final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+    final isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -256,6 +258,19 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
                         if (_tabIndex == 3) const SizedBox.shrink(),
                       ],
                     ),
+                  ),
+                ],
+              )
+            : isMacOS
+            ? Stack(
+                children: [
+                  body,
+                  const Positioned(
+                    top: 0,
+                    left: 78,
+                    right: 0,
+                    height: MacOSTitleBarDragArea.defaultHeight,
+                    child: MacOSTitleBarDragArea(),
                   ),
                 ],
               )

--- a/lib/desktop/macos_title_bar_drag_area.dart
+++ b/lib/desktop/macos_title_bar_drag_area.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// Transparent macOS title-bar interaction strip.
+///
+/// Restores native title-bar behavior under [fullSizeContentView]:
+/// drag to move, double-click to zoom (maximize/unmaximize).
+class MacOSTitleBarDragArea extends StatelessWidget {
+  const MacOSTitleBarDragArea({
+    super.key,
+    this.height = defaultHeight,
+    this.onDoubleTapZoom,
+  });
+
+  static const double defaultHeight = 40;
+
+  final double height;
+  final Future<void> Function()? onDoubleTapZoom;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = SizedBox(height: height, width: double.infinity);
+
+    if (onDoubleTapZoom != null) {
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onPanStart: (_) {
+          windowManager.startDragging();
+        },
+        onDoubleTap: () {
+          onDoubleTapZoom!();
+        },
+        child: child,
+      );
+    }
+
+    return DragToMoveArea(child: child);
+  }
+}

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,6 +1,18 @@
 import Cocoa
 import FlutterMacOS
 
+private class TitleBarInteractionView: NSView {
+  override var mouseDownCanMoveWindow: Bool { true }
+
+  override func mouseDown(with event: NSEvent) {
+    if event.clickCount >= 2 {
+      window?.performZoom(nil)
+      return
+    }
+    super.mouseDown(with: event)
+  }
+}
+
 class MainFlutterWindow: NSWindow {
   // Use Cocoa autosave to persist and restore window frame precisely on macOS.
   private let autosaveName = NSWindow.FrameAutosaveName("KelivoMainWindowFrame")
@@ -89,9 +101,12 @@ class MainFlutterWindow: NSWindow {
 
     // Add a transparent accessory view to reserve 40pt height in the title bar
     let customToolbar = NSTitlebarAccessoryViewController()
-    let newView = NSView()
-    newView.frame = NSRect(origin: CGPoint(), size: CGSize(width: 0, height: 40))
+    let newView = TitleBarInteractionView()
+    newView.frame = NSRect(origin: .zero, size: NSSize(width: 100, height: 40))
     customToolbar.view = newView
+    if #available(macOS 11.0, *) {
+      customToolbar.layoutAttribute = .right
+    }
     self.addTitlebarAccessoryViewController(customToolbar)
   }
 

--- a/test/desktop/macos_title_bar_drag_area_test.dart
+++ b/test/desktop/macos_title_bar_drag_area_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/desktop/macos_title_bar_drag_area.dart';
+import 'package:window_manager/window_manager.dart';
+
+void main() {
+  testWidgets('double tap triggers zoom handler', (tester) async {
+    var zoomCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MacOSTitleBarDragArea(
+            onDoubleTapZoom: () async {
+              zoomCount++;
+            },
+          ),
+        ),
+      ),
+    );
+
+    final center = tester.getCenter(find.byType(MacOSTitleBarDragArea));
+    await tester.tapAt(center);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(center);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.pumpAndSettle();
+
+    expect(zoomCount, 1);
+  });
+
+  testWidgets('uses DragToMoveArea in production mode', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: MacOSTitleBarDragArea())),
+    );
+
+    expect(find.byType(DragToMoveArea), findsOneWidget);
+  });
+
+  testWidgets('renders expected title bar height', (tester) async {
+    const customHeight = 36.0;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MacOSTitleBarDragArea(height: customHeight)),
+      ),
+    );
+
+    final sizedBox = tester.widget<SizedBox>(
+      find.descendant(
+        of: find.byType(MacOSTitleBarDragArea),
+        matching: find.byType(SizedBox),
+      ),
+    );
+
+    expect(sizedBox.height, customHeight);
+  });
+}


### PR DESCRIPTION
Add a macOS title-bar drag area in the desktop shell and handle double-click zoom in the native title bar accessory so fullSizeContentView no longer blocks system zoom interactions.
添加 macOS 标题栏拖动区域，并在原生标题栏附件中处理双击缩放，使得 fullSizeContentView 不再阻止系统缩放交互。