### PR TITLE
feat: add image warning pill when draft images exceed model capability

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -514,7 +514,7 @@ class ChatApiService {
     return out;
   }
 
-  static bool _supportsImageInput(ProviderConfig config, String modelId) {
+  static bool supportsImageInput(ProviderConfig config, String modelId) {
     return _effectiveModelInfo(config, modelId).input.contains(Modality.image);
   }
 
@@ -587,7 +587,7 @@ class ChatApiService {
     final stripUnsupportedImageInputs =
         !ocrActive &&
         !useOpenAIImagesApi &&
-        !_supportsImageInput(config, modelId);
+        !supportsImageInput(config, modelId);
     final safeMessages = stripUnsupportedImageInputs
         ? await _stripImageInputsFromMessages(unicodeSafeMessages)
         : unicodeSafeMessages;

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -181,6 +181,9 @@ class _ChatInputBarState extends State<ChatInputBar>
   String? _imageModeModelKey;
   String? _lastImageModeModelKey;
   String? _dismissedImageModeModelKey;
+  String? _imageWarningModelKey;
+  String? _lastImageWarningModelKey;
+  String? _dismissedImageWarningModelKey;
 
   bool get _composerLocked => widget.hasQueuedInput;
 
@@ -237,6 +240,32 @@ class _ChatInputBarState extends State<ChatInputBar>
     return supported;
   }
 
+  void _checkImageWarning(BuildContext context) {
+    if (widget.ocrActive || _images.isEmpty) {
+      _imageWarningModelKey = null;
+      return;
+    }
+    final settings = context.watch<SettingsProvider>();
+    final ap = context.watch<AssistantProvider>();
+    final a = ap.currentAssistant;
+    final providerKey = a?.chatModelProvider ?? settings.currentModelProvider;
+    final modelId = a?.chatModelId ?? settings.currentModelId;
+    if (providerKey == null || modelId == null) {
+      _imageWarningModelKey = null;
+      return;
+    }
+    final cfg = settings.getProviderConfig(providerKey);
+    final supported = ChatApiService.supportsImageInput(cfg, modelId);
+    final nextKey = supported
+        ? null
+        : '${widget.conversationId ?? ''}::$providerKey::$modelId';
+    if (nextKey != _lastImageWarningModelKey) {
+      _dismissedImageWarningModelKey = null;
+      _lastImageWarningModelKey = nextKey;
+    }
+    _imageWarningModelKey = nextKey;
+  }
+
   bool get _imageModeActive {
     final key = _imageModeModelKey;
     return key != null && key != _dismissedImageModeModelKey;
@@ -245,6 +274,11 @@ class _ChatInputBarState extends State<ChatInputBar>
   bool get _allowImagesApiRouting {
     final key = _imageModeModelKey;
     return key == null || key != _dismissedImageModeModelKey;
+  }
+
+  bool get _showImageWarning {
+    final key = _imageWarningModelKey;
+    return key != null && key != _dismissedImageWarningModelKey;
   }
 
   bool get _hasDraftMedia => _images.isNotEmpty || _docs.isNotEmpty;
@@ -1675,6 +1709,7 @@ class _ChatInputBarState extends State<ChatInputBar>
     final hasImages = _images.isNotEmpty;
     final hasDocs = _docs.isNotEmpty;
     _supportsImagesApiRouting(context);
+    _checkImageWarning(context);
     final size = MediaQuery.sizeOf(context);
     final viewInsets = MediaQuery.viewInsetsOf(context);
     final bool isMobileLayout = size.width < AppBreakpoints.tablet;
@@ -2013,7 +2048,8 @@ class _ChatInputBarState extends State<ChatInputBar>
                   PositionedDirectional(
                     top: -12,
                     start: AppSpacing.sm,
-                    child: _ImageModePill(
+                    child: _DismissiblePill(
+                      icon: Lucide.Brush,
                       label: AppLocalizations.of(
                         context,
                       )!.chatInputBarImageMode,
@@ -2027,6 +2063,29 @@ class _ChatInputBarState extends State<ChatInputBar>
                               if (key == null) return;
                               setState(() {
                                 _dismissedImageModeModelKey = key;
+                              });
+                            },
+                    ),
+                  )
+                else if (_showImageWarning)
+                  PositionedDirectional(
+                    top: -12,
+                    start: AppSpacing.sm,
+                    child: _DismissiblePill(
+                      icon: Lucide.ImageOff,
+                      label: AppLocalizations.of(
+                        context,
+                      )!.chatInputBarImageWarning,
+                      closeTooltip: AppLocalizations.of(
+                        context,
+                      )!.chatInputBarDisableImageWarningTooltip,
+                      onClose: _composerLocked
+                          ? null
+                          : () {
+                              final key = _imageWarningModelKey;
+                              if (key == null) return;
+                              setState(() {
+                                _dismissedImageWarningModelKey = key;
                               });
                             },
                     ),
@@ -2137,13 +2196,15 @@ class _QueuedInputBanner extends StatelessWidget {
   }
 }
 
-class _ImageModePill extends StatelessWidget {
-  const _ImageModePill({
+class _DismissiblePill extends StatelessWidget {
+  const _DismissiblePill({
+    required this.icon,
     required this.label,
     required this.closeTooltip,
     required this.onClose,
   });
 
+  final IconData icon;
   final String label;
   final String closeTooltip;
   final VoidCallback? onClose;
@@ -2183,7 +2244,7 @@ class _ImageModePill extends StatelessWidget {
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(Lucide.Brush, size: 14, color: iconColor),
+                      Icon(icon, size: 14, color: iconColor),
                       const SizedBox(width: 5),
                       Flexible(
                         child: Text(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1096,6 +1096,8 @@
   "chatInputBarMoreTooltip": "Add",
   "chatInputBarImageMode": "Image mode",
   "chatInputBarDisableImageModeTooltip": "Turn off image mode",
+  "chatInputBarImageWarning": "Images will be ignored",
+  "chatInputBarDisableImageWarningTooltip": "Dismiss",
   "chatInputBarQueuedPending": "Queued to send",
   "chatInputBarQueuedCancel": "Cancel Queue",
   "chatInputBarInsertNewline": "Newline",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4805,6 +4805,18 @@ abstract class AppLocalizations {
   /// **'Turn off image mode'**
   String get chatInputBarDisableImageModeTooltip;
 
+  /// No description provided for @chatInputBarImageWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Images will be ignored'**
+  String get chatInputBarImageWarning;
+
+  /// No description provided for @chatInputBarDisableImageWarningTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get chatInputBarDisableImageWarningTooltip;
+
   /// No description provided for @chatInputBarQueuedPending.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2555,6 +2555,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatInputBarDisableImageModeTooltip => 'Turn off image mode';
 
   @override
+  String get chatInputBarImageWarning => 'Images will be ignored';
+
+  @override
+  String get chatInputBarDisableImageWarningTooltip => 'Dismiss';
+
+  @override
   String get chatInputBarQueuedPending => 'Queued to send';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2463,6 +2463,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chatInputBarDisableImageModeTooltip => '关闭绘图模式';
 
   @override
+  String get chatInputBarImageWarning => '将忽略图片';
+
+  @override
+  String get chatInputBarDisableImageWarningTooltip => '忽略';
+
+  @override
   String get chatInputBarQueuedPending => '排队中';
 
   @override
@@ -7781,6 +7787,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get chatInputBarDisableImageModeTooltip => '关闭绘图模式';
 
   @override
+  String get chatInputBarImageWarning => '将忽略图片';
+
+  @override
+  String get chatInputBarDisableImageWarningTooltip => '忽略';
+
+  @override
   String get chatInputBarQueuedPending => '排队中';
 
   @override
@@ -13096,6 +13108,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get chatInputBarDisableImageModeTooltip => '關閉繪圖模式';
+
+  @override
+  String get chatInputBarImageWarning => '將忽略圖片';
+
+  @override
+  String get chatInputBarDisableImageWarningTooltip => '忽略';
 
   @override
   String get chatInputBarQueuedPending => '排隊中';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -838,6 +838,8 @@
   "chatInputBarMoreTooltip": "更多",
   "chatInputBarImageMode": "绘图模式",
   "chatInputBarDisableImageModeTooltip": "关闭绘图模式",
+  "chatInputBarImageWarning": "将忽略图片",
+  "chatInputBarDisableImageWarningTooltip": "忽略",
   "chatInputBarQueuedPending": "排队中",
   "chatInputBarQueuedCancel": "取消排队",
   "chatInputBarInsertNewline": "换行",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -873,6 +873,8 @@
   "chatInputBarMoreTooltip": "更多",
   "chatInputBarImageMode": "绘图模式",
   "chatInputBarDisableImageModeTooltip": "关闭绘图模式",
+  "chatInputBarImageWarning": "将忽略图片",
+  "chatInputBarDisableImageWarningTooltip": "忽略",
   "chatInputBarQueuedPending": "排队中",
   "chatInputBarQueuedCancel": "取消排队",
   "chatInputBarInsertNewline": "换行",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -831,6 +831,8 @@
   "chatInputBarMoreTooltip": "更多",
   "chatInputBarImageMode": "繪圖模式",
   "chatInputBarDisableImageModeTooltip": "關閉繪圖模式",
+  "chatInputBarImageWarning": "將忽略圖片",
+  "chatInputBarDisableImageWarningTooltip": "忽略",
   "chatInputBarQueuedPending": "排隊中",
   "chatInputBarQueuedCancel": "取消排隊",
   "chatInputBarInsertNewline": "換行",


### PR DESCRIPTION
## Motivation

当输入草稿包含图片，但当前模型不支持视觉输入且 OCR 未开启时，图片会被 `ChatApiService` 静默剥离，体验不佳，如 #707 。

## Summary

本次新增一个可关闭的警告药丸，在发送前明确告知用户“将忽略图片”。

## Changes

### Core

- **`ChatApiService.supportsImageInput()`** — 原私有 `_supportsImageInput` 改为公开静态方法，供 UI 层复用模型能力检测

### Feature
- **`_DismissiblePill`** (原 `_ImageModePill`) — 新增 `icon` 参数，泛化为通用可关闭药丸组件，同时服务"绘图模式"和"图片忽略警告"两种场景
- **`_ChatInputBarState._checkImageWarning()`** — 触发条件：`_images.isNotEmpty && !ocrActive && !supportsImageInput(cfg, modelId)`
- 与 `_imageModeActive` 互斥（`else if`），绘图模式优先

### Localization

- 新增 `chatInputBarImageWarning` (EN: "Images will be ignored")
- 新增 `chatInputBarDisableImageWarningTooltip` (EN: "Dismiss")
- 同步更新 en / zh / zh_Hans / zh_Hant 四个 ARB 文件
