### PR TITLE
fix(vertex): read cachedContentTokenCount from Gemini usageMetadata

### DIFF
--- a/lib/core/models/token_usage.dart
+++ b/lib/core/models/token_usage.dart
@@ -11,6 +11,16 @@ class TokenUsage {
     this.totalTokens = 0,
   });
 
+  factory TokenUsage.fromGeminiUsageMetadata(Map<String, dynamic>? um) {
+    if (um == null) return const TokenUsage();
+    return TokenUsage(
+      promptTokens: (um['promptTokenCount'] as int? ?? 0),
+      completionTokens: (um['candidatesTokenCount'] as int? ?? 0),
+      cachedTokens: (um['cachedContentTokenCount'] as int? ?? 0),
+      totalTokens: (um['totalTokenCount'] as int? ?? 0),
+    );
+  }
+
   TokenUsage merge(TokenUsage other) {
     // For streaming responses:
     // - prompt tokens: take max (usually stays constant after initial value)

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -559,17 +559,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       final obj = jsonDecode(txt) as Map<String, dynamic>;
       try {
         final u = (obj['usageMetadata'] as Map?)?.cast<String, dynamic>();
-        if (u != null) {
-          final prompt = (u['promptTokenCount'] ?? 0) as int? ?? 0;
-          final completion = (u['candidatesTokenCount'] ?? 0) as int? ?? 0;
-          totalUsage = (totalUsage ?? const TokenUsage()).merge(
-            TokenUsage(
-              promptTokens: prompt,
-              completionTokens: completion,
-              cachedTokens: 0,
-            ),
-          );
-        }
+        totalUsage = (totalUsage ?? const TokenUsage()).merge(
+          TokenUsage.fromGeminiUsageMetadata(u),
+        );
       } catch (_) {}
       final candidates = (obj['candidates'] as List?) ?? const <dynamic>[];
       if (candidates.isEmpty) {
@@ -1151,11 +1143,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           final um = obj['usageMetadata'];
           if (um is Map<String, dynamic>) {
             usage = (usage ?? const TokenUsage()).merge(
-              TokenUsage(
-                promptTokens: (um['promptTokenCount'] ?? 0) as int,
-                completionTokens: (um['candidatesTokenCount'] ?? 0) as int,
-                totalTokens: (um['totalTokenCount'] ?? 0) as int,
-              ),
+              TokenUsage.fromGeminiUsageMetadata(um),
             );
             totalTokens = usage.totalTokens;
           }

--- a/test/core/models/token_usage_test.dart
+++ b/test/core/models/token_usage_test.dart
@@ -18,4 +18,73 @@ void main() {
       },
     );
   });
+
+  group('fromGeminiUsageMetadata', () {
+    test('null input returns zero TokenUsage', () {
+      final result = TokenUsage.fromGeminiUsageMetadata(null);
+
+      expect(result.promptTokens, 0);
+      expect(result.completionTokens, 0);
+      expect(result.cachedTokens, 0);
+      expect(result.totalTokens, 0);
+    });
+
+    test('empty map returns zero TokenUsage', () {
+      final result = TokenUsage.fromGeminiUsageMetadata(<String, dynamic>{});
+
+      expect(result.promptTokens, 0);
+      expect(result.completionTokens, 0);
+      expect(result.cachedTokens, 0);
+      expect(result.totalTokens, 0);
+    });
+
+    test('all fields present with cachedContentTokenCount > 0', () {
+      final result = TokenUsage.fromGeminiUsageMetadata({
+        'promptTokenCount': 100,
+        'candidatesTokenCount': 50,
+        'cachedContentTokenCount': 42,
+        'totalTokenCount': 192,
+      });
+
+      expect(result.promptTokens, 100);
+      expect(result.completionTokens, 50);
+      expect(result.cachedTokens, 42);
+      expect(result.totalTokens, 192);
+    });
+
+    test('cachedContentTokenCount is 0', () {
+      final result = TokenUsage.fromGeminiUsageMetadata({
+        'promptTokenCount': 100,
+        'candidatesTokenCount': 50,
+        'cachedContentTokenCount': 0,
+        'totalTokenCount': 150,
+      });
+
+      expect(result.cachedTokens, 0);
+    });
+
+    test('cachedContentTokenCount is missing', () {
+      final result = TokenUsage.fromGeminiUsageMetadata({
+        'promptTokenCount': 100,
+        'candidatesTokenCount': 50,
+        'totalTokenCount': 150,
+      });
+
+      expect(result.cachedTokens, 0);
+    });
+
+    test('all fields are zero', () {
+      final result = TokenUsage.fromGeminiUsageMetadata({
+        'promptTokenCount': 0,
+        'candidatesTokenCount': 0,
+        'cachedContentTokenCount': 0,
+        'totalTokenCount': 0,
+      });
+
+      expect(result.promptTokens, 0);
+      expect(result.completionTokens, 0);
+      expect(result.cachedTokens, 0);
+      expect(result.totalTokens, 0);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #743

Gemini / Vertex AI Gemini 响应的 `usageMetadata` 中包含 `cachedContentTokenCount`字段，用于标识从 Context Cache 命中的 token 数，但 Kelivo 此前完全忽略了它。与之相比，OpenAI 和 Anthropic 协议的接口实现是完善的。

本次修复将 `cachedContentTokenCount` 解析并汇入 `TokenUsage.cachedTokens`，通过已有的数据管道（`TokenUsage` → `ChatMessage.cachedTokens` → `TokenDetailPopup`）自动展示在 token 详情弹窗中。

## Changes

| File | Change |
|---|---|
| `lib/core/models/token_usage.dart` | 新增 `fromGeminiUsageMetadata()` factory，统一解析 Gemini `usageMetadata` 四字段（promptTokenCount / candidatesTokenCount / cachedContentTokenCount / totalTokenCount），使用 `as int? ?? 0` 防御性类型转换 |
| `lib/core/services/api/providers/google_common.dart` | 流式和非流式两处 `usageMetadata` 解析替换为 `TokenUsage.fromGeminiUsageMetadata()` 调用，消除重复代码和硬编码 `cachedTokens: 0` |
| `test/core/models/token_usage_test.dart` | 新增 6 个测试覆盖 factory 的各种输入场景（null、空 map、完整字段、cached=0、cached 缺失、全零） |
