### PR TITLE
feat(l10n): add Russian (ru) translation

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -1840,26 +1840,31 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   String _localeToTag(Locale l) {
-    final lc = l.languageCode.toLowerCase();
-    if (lc == 'zh') {
-      final script = (l.scriptCode ?? '').toLowerCase();
-      if (script == 'hant') return 'zh_Hant';
-      return 'zh_CN';
-    }
-    return 'en_US';
+  final lc = l.languageCode.toLowerCase();
+  if (lc == 'zh') {
+    final script = (l.scriptCode ?? '').toLowerCase();
+    if (script == 'hant') return 'zh_Hant';
+    return 'zh_CN';
   }
+  if (lc == 'ru') {
+    return 'ru_RU';
+  }
+  return 'en_US';
+}
 
-  Locale _parseLocaleTag(String tag) {
-    switch (tag) {
-      case 'zh_CN':
-        return const Locale('zh', 'CN');
-      case 'zh_Hant':
-        return const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
-      case 'en_US':
-      default:
-        return const Locale('en', 'US');
-    }
+Locale _parseLocaleTag(String tag) {
+  switch (tag) {
+    case 'zh_CN':
+      return const Locale('zh', 'CN');
+    case 'zh_Hant':
+      return const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
+    case 'ru_RU':
+      return const Locale('ru', 'RU');
+    case 'en_US':
+    default:
+      return const Locale('en', 'US');
   }
+}
 
   // ===== Backup & WebDAV settings =====
   WebDavConfig _webDavConfig = const WebDavConfig();

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,0 +1,2382 @@
+{
+"helloWorld": "Привет, мир!",
+  "settingsPageBackButton": "Назад",
+  "settingsPageTitle": "Настройки",
+  "settingsPageDarkMode": "Тёмная",
+  "settingsPageLightMode": "Светлая",
+  "settingsPageSystemMode": "Системная",
+  "settingsPageWarningMessage": "Некоторые сервисы не настроены; функции могут быть ограничены.",
+  "settingsPageGeneralSection": "Общие",
+  "settingsPageColorMode": "Цветовая схема",
+  "settingsPageDisplay": "Отображение",
+  "settingsPageDisplaySubtitle": "Внешний вид, поведение и настройки взаимодействия",
+  "settingsPageAssistant": "Ассистент",
+  "settingsPageAssistantSubtitle": "Ассистент по умолчанию и стиль",
+  "settingsPageModelsServicesSection": "Модели и сервисы",
+  "settingsPageDefaultModel": "Модель по умолчанию",
+  "settingsPageProviders": "Провайдеры",
+  "settingsPageHotkeys": "Горячие клавиши",
+  "settingsPageSearch": "Поиск",
+  "settingsPageTts": "TTS",
+  "settingsPageMcp": "MCP",
+  "settingsPageQuickPhrase": "Быстрые фразы",
+  "settingsPageInstructionInjection": "Внедрение инструкций",
+  "settingsPageDataSection": "Данные",
+  "settingsPageBackup": "Резервное копирование",
+  "settingsPageChatStorage": "Хранилище чатов",
+  "settingsPageCalculating": "Вычисление…",
+  "settingsPageFilesCount": "{count} файлов · {size}",
+  "@settingsPageFilesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpacePageTitle": "Место на диске",
+  "storageSpaceRefreshTooltip": "Обновить",
+  "storageSpaceLoadFailed": "Не удалось загрузить данные о хранилище",
+  "storageSpaceTotalLabel": "Использовано",
+  "storageSpaceClearableLabel": "Можно очистить: {size}",
+  "@storageSpaceClearableLabel": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpaceClearableHint": "Безопасно для очистки: {size}",
+  "@storageSpaceClearableHint": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpaceCategoryImages": "Изображения",
+  "storageSpaceCategoryFiles": "Файлы",
+  "storageSpaceCategoryChatData": "Записи чатов",
+  "storageSpaceCategoryAssistantData": "Ассистенты",
+  "storageSpaceCategoryCache": "Кэш",
+  "storageSpaceCategoryLogs": "Логи",
+  "storageSpaceCategoryOther": "Приложение",
+  "storageSpaceFilesCount": "{count} файлов",
+  "@storageSpaceFilesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "storageSpaceSafeToClearHint": "Безопасно для очистки. Это не повлияет на историю чатов.",
+  "storageSpaceNotSafeToClearHint": "Может повлиять на историю чатов. Удаляйте осторожно.",
+  "storageSpaceBreakdownTitle": "Детализация",
+  "storageSpaceSubChatMessages": "Сообщения",
+  "storageSpaceSubChatConversations": "Диалоги",
+  "storageSpaceSubChatToolEvents": "События инструментов",
+  "storageSpaceSubAssistantAvatars": "Аватары",
+  "storageSpaceSubAssistantImages": "Изображения",
+  "storageSpaceSubCacheAvatars": "Кэш аватаров",
+  "storageSpaceSubCacheOther": "Прочий кэш",
+  "storageSpaceSubCacheSystem": "Системный кэш",
+  "storageSpaceSubLogsFlutter": "Логи Flutter",
+  "storageSpaceSubLogsRequests": "Сетевые логи",
+  "storageSpaceSubLogsOther": "Прочие логи",
+  "storageSpaceClearConfirmTitle": "Подтвердить очистку",
+  "storageSpaceClearConfirmMessage": "Очистить {targetName}?",
+  "@storageSpaceClearConfirmMessage": {
+    "placeholders": {
+      "targetName": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpaceClearButton": "Очистить",
+  "storageSpaceClearDone": "{targetName} очищено",
+  "@storageSpaceClearDone": {
+    "placeholders": {
+      "targetName": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpaceClearFailed": "Очистка не удалась: {error}",
+  "@storageSpaceClearFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "storageSpaceClearAvatarCacheButton": "Очистить кэш аватаров",
+  "storageSpaceClearCacheButton": "Очистить кэш",
+  "storageSpaceClearLogsButton": "Очистить логи",
+  "storageSpaceViewLogsButton": "Просмотр логов",
+  "storageSpaceDeleteConfirmTitle": "Подтвердить удаление",
+  "storageSpaceDeleteUploadsConfirmMessage": "Удалить {count} элементов? Вложения в истории чатов могут стать недоступными.",
+  "@storageSpaceDeleteUploadsConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "storageSpaceDeletedUploadsDone": "Удалено {count} элементов",
+  "@storageSpaceDeletedUploadsDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "storageSpaceNoUploads": "Нет элементов",
+  "storageSpaceSelectAll": "Выбрать всё",
+  "storageSpaceClearSelection": "Очистить выбор",
+  "storageSpaceSelectedCount": "Выбрано: {count}",
+  "@storageSpaceSelectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "storageSpaceUploadsCount": "{count} элементов",
+  "@storageSpaceUploadsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsPageAboutSection": "О программе",
+  "settingsPageAbout": "О программе",
+  "settingsPageStatistics": "Статистика",
+  "settingsPageDocs": "Документация",
+  "settingsPageLogs": "Логи",
+  "settingsPageSponsor": "Поддержать",
+  "settingsPageShare": "Поделиться",
+  "statsPageTitle": "Статистика",
+  "statsPageRangeAllTime": "За всё время",
+  "statsPageRangeLast30Days": "Последние 30 дней",
+  "statsPageRangePreviousMonth": "Прошлый месяц",
+  "statsPageRangePreviousQuarter": "Прошлый квартал",
+  "statsPageRangeCustom": "Настраиваемый",
+  "statsPageHeatmapTitle": "Тепловая карта чатов",
+  "statsPageHeatmapLess": "Меньше",
+  "statsPageHeatmapMore": "Больше",
+  "statsPageSummaryTitle": "Обзор",
+  "statsPageTotalConversations": "Всего диалогов",
+  "statsPageTotalMessages": "Всего сообщений",
+  "statsPageInputTokens": "Входящие токены",
+  "statsPageOutputTokens": "Исходящие токены",
+  "statsPageCachedTokens": "Кэшированные токены",
+  "statsPageLaunchCount": "Запуски приложения",
+  "statsPageUsageTrendTitle": "Тренд использования",
+  "statsPageModelUsageTitle": "Использование моделей",
+  "statsPageAssistantUsageTitle": "Использование ассистентов",
+  "statsPageTopicVolumeTitle": "Объём тем",
+  "statsPageModelColumn": "Модель",
+  "statsPageAssistantColumn": "Ассистент",
+  "statsPageTopicColumn": "Тема",
+  "statsPageMessagesColumn": "Сообщения",
+  "statsPageTopicsColumn": "Темы",
+  "statsPageEmptyTitle": "Статистики пока нет",
+  "statsPageShowAllTooltip": "Показать всё",
+  "statsPageClose": "Закрыть",
+  "statsPageUnknownProvider": "Неизвестный провайдер",
+  "statsPageUnknownAssistant": "Ассистент по умолчанию",
+  "statsPageUnknownModel": "Неизвестная модель",
+  "statsPageUnknownTopic": "Тема без названия",
+  "statsPageCustomRangeTitle": "Настраиваемый период",
+  "statsPageCustomRangeStart": "Начало",
+  "statsPageCustomRangeEnd": "Конец",
+  "statsPageCustomRangeCancel": "Отмена",
+  "statsPageCustomRangeApply": "Применить",
+  "sponsorPageMethodsSectionTitle": "Способы поддержки",
+  "sponsorPageSponsorsSectionTitle": "Спонсоры",
+  "sponsorPageEmpty": "Спонсоров пока нет",
+  "sponsorPageAfdianTitle": "Afdian",
+  "sponsorPageAfdianSubtitle": "afdian.com/a/kelivo",
+  "sponsorPageWeChatTitle": "Спонсорство WeChat",
+  "sponsorPageWeChatSubtitle": "Код спонсорства WeChat",
+  "sponsorPageScanQrHint": "Отсканируйте QR-код для поддержки",
+  "languageDisplaySimplifiedChinese": "Упрощённый китайский",
+  "languageDisplayEnglish": "Английский",
+  "languageDisplayTraditionalChinese": "Традиционный китайский",
+  "languageDisplayJapanese": "Японский",
+  "languageDisplayKorean": "Корейский",
+  "languageDisplayFrench": "Французский",
+  "languageDisplayGerman": "Немецкий",
+  "languageDisplayItalian": "Итальянский",
+  "languageDisplaySpanish": "Испанский",
+  "languageSelectSheetTitle": "Выберите язык перевода",
+  "languageSelectSheetClearButton": "Очистить перевод",
+  "homePageClearContext": "Очистить контекст",
+  "homePageClearContextWithCount": "Очистить контекст ({actual}/{configured})",
+  "@homePageClearContextWithCount": {
+    "placeholders": {
+      "actual": {
+        "type": "String"
+      },
+      "configured": {
+        "type": "String"
+      }
+    }
+  },
+  "homePageDefaultAssistant": "Ассистент по умолчанию",
+  "mermaidExportPng": "Экспорт PNG",
+  "mermaidExportFailed": "Экспорт не удался",
+  "mermaidImageTab": "Изображение",
+  "mermaidCodeTab": "Код",
+  "mermaidFullScreen": "Полный экран",
+  "mermaidGeneratingImage": "Генерация изображения",
+  "mermaidGenerationFailedHint": "Генерация не удалась. Попробуйте спросить по-другому.",
+  "mermaidPreviewOpen": "Открыть предпросмотр",
+  "mermaidPreviewOpenFailed": "Не удалось открыть предпросмотр",
+  "assistantProviderDefaultAssistantName": "Ассистент по умолчанию",
+  "assistantProviderSampleAssistantName": "Пример ассистента",
+  "assistantProviderNewAssistantName": "Новый ассистент",
+  "assistantProviderSampleAssistantSystemPrompt": "Вы {model_name}, ИИ-ассистент, который с радостью предоставляет точную и полезную помощь. Текущее время {cur_datetime}, язык устройства {locale}, часовой пояс {timezone}, пользователь использует {device_info}, версия {system_version}. Если пользователь явно не указывает иное, пожалуйста, используйте язык устройства пользователя при ответе.",
+  "@assistantProviderSampleAssistantSystemPrompt": {
+    "placeholders": {
+      "model_name": {
+        "type": "String"
+      },
+      "cur_datetime": {
+        "type": "String"
+      },
+      "locale": {
+        "type": "String"
+      },
+      "timezone": {
+        "type": "String"
+      },
+      "device_info": {
+        "type": "String"
+      },
+      "system_version": {
+        "type": "String"
+      }
+    }
+  },
+  "displaySettingsPageLanguageTitle": "Язык приложения",
+  "displaySettingsPageLanguageSubtitle": "Выберите язык интерфейса",
+  "assistantTagsManageTitle": "Управление тегами",
+  "assistantTagsCreateButton": "Создать",
+  "assistantTagsCreateDialogTitle": "Создать тег",
+  "assistantTagsCreateDialogOk": "Создать",
+  "assistantTagsCreateDialogCancel": "Отмена",
+  "assistantTagsNameHint": "Название тега",
+  "assistantTagsRenameButton": "Переименовать",
+  "assistantTagsRenameDialogTitle": "Переименовать тег",
+  "assistantTagsRenameDialogOk": "Переименовать",
+  "assistantTagsDeleteButton": "Удалить",
+  "assistantTagsDeleteConfirmTitle": "Удалить тег",
+  "assistantTagsDeleteConfirmContent": "Вы уверены, что хотите удалить этот тег?",
+  "assistantTagsDeleteConfirmOk": "Удалить",
+  "assistantTagsDeleteConfirmCancel": "Отмена",
+  "assistantTagsContextMenuEditAssistant": "Редактировать ассистента",
+  "assistantTagsContextMenuManageTags": "Управление тегами",
+  "mcpTransportOptionStdio": "STDIO",
+  "mcpTransportTagStdio": "STDIO",
+  "mcpTransportTagInmemory": "Встроенный",
+  "mcpTransportTagSse": "SSE",
+  "mcpTransportTagHttp": "HTTP",
+  "mcpServerEditSheetStdioOnlyDesktop": "STDIO доступен только на десктопе",
+  "mcpServerEditSheetStdioCommandLabel": "Команда",
+  "mcpServerEditSheetStdioArgumentsLabel": "Аргументы",
+  "mcpServerEditSheetStdioWorkingDirectoryLabel": "Рабочая директория (необязательно)",
+  "mcpServerEditSheetStdioEnvironmentTitle": "Окружение",
+  "mcpServerEditSheetStdioEnvNameLabel": "Имя",
+  "mcpServerEditSheetStdioEnvValueLabel": "Значение",
+  "mcpServerEditSheetStdioAddEnv": "Добавить переменную",
+  "mcpServerEditSheetStdioCommandRequired": "Команда обязательна для STDIO",
+  "assistantTagsContextMenuDeleteAssistant": "Удалить ассистента",
+  "assistantTagsClearTag": "Очистить тег",
+  "displaySettingsPageLanguageChineseLabel": "Упрощённый китайский",
+  "displaySettingsPageLanguageEnglishLabel": "Английский",
+  "homePagePleaseSelectModel": "Сначала выберите модель",
+  "homePageAudioAttachmentUnsupported": "Текущая модель не поддерживает аудиовложения. Переключитесь на модель с поддержкой аудиовхода или удалите аудиофайл и попробуйте снова.",
+  "homePagePleaseSetupTranslateModel": "Сначала настройте модель перевода",
+  "homePageTranslating": "Перевод...",
+  "homePageTranslateFailed": "Перевод не удался: {error}",
+  "@homePageTranslateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "chatServiceDefaultConversationTitle": "Новый чат",
+  "userProviderDefaultUserName": "Пользователь",
+  "homePageDeleteMessage": "Удалить эту версию",
+  "homePageDeleteMessageConfirm": "Вы уверены, что хотите удалить эту версию? Это действие нельзя отменить.",
+  "homePageDeleteAllVersions": "Удалить все версии",
+  "homePageDeleteAllVersionsConfirm": "Вы уверены, что хотите удалить все версии этого сообщения? Это действие нельзя отменить.",
+  "homePageCancel": "Отмена",
+  "homePageDelete": "Удалить",
+  "homePageSelectMessagesToShare": "Выберите сообщения для отправки",
+  "homePageDone": "Готово",
+  "homePageDropToUpload": "Перетащите файлы для загрузки",
+  "assistantEditPageTitle": "Ассистент",
+  "assistantEditPageNotFound": "Ассистент не найден",
+  "assistantEditPageBasicTab": "Основные",
+  "assistantEditPagePromptsTab": "Промпты",
+  "assistantEditPageMcpTab": "MCP",
+  "assistantEditPageQuickPhraseTab": "Быстрые фразы",
+  "assistantEditPageCustomTab": "Настраиваемые",
+  "assistantEditPageRegexTab": "Regex замены",
+  "assistantEditPageLocalToolsTab": "Локальные инструменты",
+  "assistantEditTabLayoutTooltip": "Настроить вкладки",
+  "assistantEditTabLayoutTitle": "Настроить вкладки",
+  "assistantEditTabLayoutSubtitle": "Перетаскивайте вкладки для изменения порядка. Отключите ненужные вкладки.",
+  "assistantEditOutlineModeTitle": "Стиль списка разделов",
+  "assistantEditOutlineModeSubtitle": "Сначала показать обзор ассистента, затем открывать каждый раздел настроек из списка.",
+  "assistantEditTabLayoutResetTooltip": "Сбросить макет вкладок",
+  "assistantEditTabLayoutAtLeastOneVisible": "Оставьте хотя бы одну видимую вкладку",
+  "assistantEditTabLayoutDragHandle": "Перетащите для изменения порядка {tab}",
+  "@assistantEditTabLayoutDragHandle": {
+    "placeholders": {
+      "tab": {
+        "type": "String"
+      }
+    }
+  },
+  "assistantEditRegexDescription": "Создавайте regex правила для переписывания или визуальной настройки сообщений пользователя/ассистента.",
+  "assistantEditAddRegexButton": "Добавить Regex правило",
+  "assistantRegexAddTitle": "Добавить Regex правило",
+  "assistantRegexEditTitle": "Редактировать Regex правило",
+  "assistantRegexNameLabel": "Название правила",
+  "assistantRegexPatternLabel": "Регулярное выражение",
+  "assistantRegexReplacementLabel": "Строка замены",
+  "assistantRegexScopeLabel": "Область применения",
+  "assistantRegexScopeUser": "Пользователь",
+  "assistantRegexScopeAssistant": "Ассистент",
+  "assistantRegexScopeVisualOnly": "Только визуально",
+  "assistantRegexScopeReplaceOnly": "Только замена",
+  "assistantRegexAddAction": "Добавить",
+  "assistantRegexSaveAction": "Сохранить",
+  "assistantRegexDeleteButton": "Удалить",
+  "assistantRegexValidationError": "Заполните название, regex и выберите хотя бы одну область применения.",
+  "assistantRegexInvalidPattern": "Неверное регулярное выражение",
+  "assistantRegexCancelButton": "Отмена",
+  "assistantRegexUntitled": "Правило без названия",
+  "assistantEditCustomHeadersTitle": "Пользовательские заголовки",
+  "assistantEditCustomHeadersAdd": "Добавить заголовок",
+  "assistantEditCustomHeadersEmpty": "Заголовки не добавлены",
+  "assistantEditCustomBodyTitle": "Пользовательское тело",
+  "assistantEditCustomBodyAdd": "Добавить тело",
+  "assistantEditCustomBodyEmpty": "Элементы тела не добавлены",
+  "assistantEditHeaderNameLabel": "Название заголовка",
+  "assistantEditHeaderValueLabel": "Значение заголовка",
+  "assistantEditBodyKeyLabel": "Ключ тела",
+  "assistantEditBodyValueLabel": "Значение тела (JSON)",
+  "assistantEditDeleteTooltip": "Удалить",
+  "assistantEditAssistantNameLabel": "Имя ассистента",
+  "assistantEditUseAssistantAvatarTitle": "Использовать аватар ассистента",
+  "assistantEditUseAssistantAvatarSubtitle": "Использовать аватар ассистента вместо аватара модели",
+  "assistantEditUseAssistantNameTitle": "Использовать имя ассистента",
+  "assistantEditChatModelTitle": "Модель чата",
+  "assistantEditChatModelSubtitle": "Модель чата по умолчанию для этого ассистента (резерв к глобальной)",
+  "assistantEditTemperatureDescription": "Контролирует случайность, диапазон 0–2",
+  "assistantEditTopPDescription": "Не изменяйте, если не знаете, что делаете",
+  "assistantEditParameterDisabled": "Отключено (использует настройки провайдера)",
+  "assistantEditParameterDisabled2": "Отключено (без ограничений)",
+  "assistantEditContextMessagesTitle": "Контекстные сообщения",
+  "assistantEditContextMessagesDescription": "Сколько последних сообщений сохранять в контексте",
+  "assistantEditStreamOutputTitle": "Потоковый вывод",
+  "assistantEditStreamOutputDescription": "Включить потоковые ответы",
+  "assistantEditThinkingBudgetTitle": "Бюджет размышлений",
+  "assistantEditConfigureButton": "Настроить",
+  "assistantEditMaxTokensTitle": "Максимум токенов",
+  "assistantEditMaxTokensDescription": "Оставьте пустым для неограниченного",
+  "assistantEditMaxTokensHint": "Неограниченно",
+  "assistantEditChatBackgroundTitle": "Фон чата",
+  "assistantEditChatBackgroundDescription": "Установить фоновое изображение для этого ассистента",
+  "assistantEditChooseImageButton": "Выбрать изображение",
+  "assistantEditClearButton": "Очистить",
+  "desktopNavChatTooltip": "Чат",
+  "desktopNavTranslateTooltip": "Перевод",
+  "desktopNavStorageTooltip": "Хранилище",
+  "desktopNavGlobalSearchTooltip": "Глобальный поиск",
+  "desktopNavThemeToggleTooltip": "Тема",
+  "desktopNavSettingsTooltip": "Настройки",
+  "desktopAvatarMenuUseEmoji": "Использовать эмодзи",
+  "cameraPermissionDeniedMessage": "Камера недоступна: разрешение не предоставлено.",
+  "openSystemSettings": "Открыть настройки",
+  "desktopAvatarMenuChangeFromImage": "Изменить из изображения…",
+  "desktopAvatarMenuReset": "Сбросить аватар",
+  "assistantEditAvatarChooseImage": "Выбрать изображение",
+  "assistantEditAvatarChooseEmoji": "Выбрать эмодзи",
+  "assistantEditAvatarEnterLink": "Ввести ссылку",
+  "assistantEditAvatarImportQQ": "Импорт из QQ",
+  "assistantEditAvatarReset": "Сбросить",
+  "displaySettingsPageChatMessageBackgroundTitle": "Фон сообщений чата",
+  "displaySettingsPageChatMessageBackgroundDefault": "По умолчанию",
+  "displaySettingsPageChatMessageBackgroundFrosted": "Матовое стекло",
+  "displaySettingsPageChatMessageBackgroundSolid": "Сплошной цвет",
+  "displaySettingsPageAndroidBackgroundChatTitle": "Фоновая генерация (Android)",
+  "displaySettingsPageIosBackgroundChatTitle": "Фоновая генерация (iOS)",
+  "iosBackgroundSettingsPageTitle": "Фоновая генерация iOS",
+  "iosBackgroundStatusOn": "Включено",
+  "iosBackgroundStatusOff": "Выключено",
+  "iosBackgroundGenerationEnableTitle": "Фоновая генерация",
+  "iosBackgroundGenerationEnableSubtitle": "Использовать фоновое время iOS для продолжения текущего ответа после сворачивания приложения.",
+  "iosBackgroundTaskRefreshTitle": "Восстановление фоновых задач",
+  "iosBackgroundTaskRefreshSubtitle": "Запрашивать у iOS возможности обновления и обработки при подходящих системных условиях.",
+  "iosLiveActivityTitle": "Live Activity",
+  "iosLiveActivitySubtitle": "Показывать фоновые ответы на экране блокировки и Dynamic Island при поддержке.",
+  "iosBackgroundNotificationsTitle": "Уведомления о задачах",
+  "iosBackgroundNotificationsSubtitle": "Отправлять локальное уведомление при завершении или прерывании фонового ответа.",
+  "iosBackgroundLimitNoticeTitle": "iOS может всё равно приостановить работу",
+  "iosBackgroundLimitNoticeBody": "Эти опции используют поддерживаемое Apple фоновое время, BackgroundTasks, уведомления и Live Activities. Они улучшают непрерывность, но не могут заставить iOS держать Kelivo работающим вечно.",
+  "iosBackgroundUnsupportedLiveActivity": "Требует iOS 16.1 или новее и включённые Live Activities в настройках.",
+  "iosBackgroundNativeStatusTitle": "Статус системы",
+  "iosBackgroundNativeStatusUnavailable": "Недоступно до запуска на iOS",
+  "iosBackgroundLiveActivityAvailable": "Live Activities доступны",
+  "iosBackgroundLiveActivityUnavailable": "Live Activities недоступны",
+  "iosBackgroundNotificationsAuthorized": "Уведомления разрешены",
+  "iosBackgroundNotificationsNotAuthorized": "Уведомления не разрешены",
+  "iosBackgroundGenerationActiveTitle": "Kelivo генерирует",
+  "iosBackgroundGenerationActiveDetail": "Ассистент отвечает в фоне",
+  "iosBackgroundGenerationStreamingDetail": "Получение ответа ассистента",
+  "iosBackgroundGenerationTokenCount": "{count} токенов",
+  "@iosBackgroundGenerationTokenCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "iosBackgroundGenerationCompleteTitle": "Генерация завершена",
+  "iosBackgroundGenerationCompleteDetail": "Ответ ассистента готов",
+  "iosBackgroundGenerationInterruptedTitle": "Генерация прервана",
+  "iosBackgroundGenerationInterruptedDetail": "Фоновый ответ остановился до завершения",
+  "iosBackgroundGenerationCancelledDetail": "Генерация остановлена",
+  "androidBackgroundStatusOn": "Включено",
+  "androidBackgroundStatusOff": "Выключено",
+  "androidBackgroundStatusOther": "Включено с уведомлениями",
+  "androidBackgroundOptionOn": "Включено",
+  "androidBackgroundOptionOnNotify": "Включено с уведомлением о завершении",
+  "androidBackgroundOptionOff": "Выключено",
+  "notificationChatCompletedTitle": "Генерация завершена",
+  "notificationChatCompletedBody": "Ответ ассистента сгенерирован",
+  "androidBackgroundNotificationTitle": "Kelivo работает",
+  "androidBackgroundNotificationText": "Поддержание генерации чата в фоне",
+  "assistantEditEmojiDialogTitle": "Выбрать эмодзи",
+  "assistantEditEmojiDialogHint": "Введите или вставьте любой эмодзи",
+  "assistantEditEmojiDialogCancel": "Отмена",
+  "assistantEditEmojiDialogSave": "Сохранить",
+  "assistantEditImageUrlDialogTitle": "Ввести URL изображения",
+  "assistantEditImageUrlDialogHint": "например, https://example.com/avatar.png",
+  "assistantEditImageUrlDialogCancel": "Отмена",
+  "assistantEditImageUrlDialogSave": "Сохранить",
+  "assistantEditQQAvatarDialogTitle": "Импорт из QQ",
+  "assistantEditQQAvatarDialogHint": "Введите номер QQ (5-12 цифр)",
+  "assistantEditQQAvatarRandomButton": "Случайный",
+  "assistantEditQQAvatarFailedMessage": "Не удалось получить случайный аватар QQ. Попробуйте снова.",
+  "assistantEditQQAvatarDialogCancel": "Отмена",
+  "assistantEditQQAvatarDialogSave": "Сохранить",
+  "assistantEditGalleryErrorMessage": "Не удалось открыть галерею. Попробуйте ввести URL изображения.",
+  "assistantEditGeneralErrorMessage": "Что-то пошло не так. Попробуйте ввести URL изображения.",
+  "providerDetailPageMultiKeyModeTitle": "Режим множественных ключей",
+  "providerDetailPageManageKeysButton": "Управление ключами",
+  "multiKeyPageTitle": "Менеджер множественных ключей",
+  "multiKeyPageDetect": "Обнаружить",
+  "multiKeyPageAdd": "Добавить",
+  "multiKeyPageAddHint": "Введите API ключи, разделённые запятой или пробелом",
+  "multiKeyPageImportedSnackbar": "Импортировано {n} ключей",
+  "@multiKeyPageImportedSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "multiKeyPagePleaseAddModel": "Сначала добавьте модель",
+  "multiKeyPageTotal": "Всего",
+  "multiKeyPageNormal": "Нормальный",
+  "multiKeyPageError": "Ошибка",
+  "multiKeyPageAccuracy": "Точность",
+  "multiKeyPageStrategyTitle": "Стратегия балансировки нагрузки",
+  "multiKeyPageStrategyRoundRobin": "По кругу",
+  "multiKeyPageStrategyPriority": "По приоритету",
+  "multiKeyPageStrategyLeastUsed": "Наименее используемый",
+  "multiKeyPageStrategyRandom": "Случайный",
+  "multiKeyPageNoKeys": "Нет API ключей",
+  "multiKeyPageStatusActive": "Активный",
+  "multiKeyPageStatusDisabled": "Отключён",
+  "multiKeyPageStatusError": "Ошибка",
+  "multiKeyPageStatusRateLimited": "Ограничен по частоте",
+  "multiKeyPageEditAlias": "Редактировать псевдоним",
+  "multiKeyPageEdit": "Редактировать",
+  "multiKeyPageKey": "API ключ",
+  "multiKeyPagePriority": "Приоритет (1–10)",
+  "multiKeyPageDuplicateKeyWarning": "Этот ключ уже существует",
+  "multiKeyPageAlias": "Псевдоним",
+  "multiKeyPageCancel": "Отмена",
+  "multiKeyPageSave": "Сохранить",
+  "multiKeyPageDelete": "Удалить",
+  "assistantEditSystemPromptTitle": "Системный промпт",
+  "assistantEditSystemPromptHint": "Введите системный промпт…",
+  "assistantEditSystemPromptImportButton": "Импорт файла",
+  "assistantEditSystemPromptImportSuccess": "Системный промпт обновлён из файла",
+  "assistantEditSystemPromptImportFailed": "Не удалось импортировать файл",
+  "assistantEditSystemPromptImportEmpty": "Файл пуст",
+  "assistantEditAvailableVariables": "Доступные переменные:",
+  "assistantEditVariableDate": "Дата",
+  "assistantEditVariableTime": "Время",
+  "assistantEditVariableDatetime": "Дата и время",
+  "assistantEditVariableModelId": "ID модели",
+  "assistantEditVariableModelName": "Название модели",
+  "assistantEditVariableLocale": "Локаль",
+  "assistantEditVariableTimezone": "Часовой пояс",
+  "assistantEditVariableSystemVersion": "Версия системы",
+  "assistantEditVariableDeviceInfo": "Информация об устройстве",
+  "assistantEditVariableBatteryLevel": "Уровень батареи",
+  "assistantEditVariableNickname": "Никнейм",
+  "assistantEditVariableAssistantName": "Имя ассистента",
+  "assistantEditMessageTemplateTitle": "Шаблон сообщения",
+  "assistantEditVariableRole": "Роль",
+  "assistantEditVariableMessage": "Сообщение",
+  "assistantEditPreviewTitle": "Предпросмотр",
+  "codeBlockPreviewButton": "Предпросмотр",
+  "codeBlockSaveAsButton": "Сохранить как файл",
+  "codeBlockCollapseButton": "Свернуть",
+  "codeBlockExpandButton": "Развернуть",
+  "codeBlockDefaultFileNameStem": "код",
+  "markdownTableLabel": "Таблица",
+  "markdownTableExportCsvTooltip": "Экспорт CSV",
+  "markdownTableSaveImageTooltip": "Сохранить в галерею",
+  "markdownTableDefaultFileNameStem": "таблица",
+  "markdownTableCopiedCsvSnackbar": "CSV скопирован. Долгое нажатие на Копировать для копирования как изображение.",
+  "markdownTableCopiedMarkdownSnackbar": "Таблица скопирована.",
+  "codeBlockCollapsedLines": "… {n} строк свёрнуто",
+  "@codeBlockCollapsedLines": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "htmlPreviewNotSupportedOnLinux": "Предпросмотр HTML не поддерживается в Linux",
+  "assistantEditSampleUser": "Пользователь",
+  "assistantEditSampleMessage": "Привет",
+  "assistantEditSampleReply": "Привет, как дела?",
+  "assistantEditMcpNoServersMessage": "Нет запущенных MCP серверов",
+  "assistantEditMcpConnectedTag": "Подключён",
+  "assistantEditMcpToolsCountTag": "Инструменты: {enabled}/{total}",
+  "@assistantEditMcpToolsCountTag": {
+    "placeholders": {
+      "enabled": {
+        "type": "String"
+      },
+      "total": {
+        "type": "String"
+      }
+    }
+  },
+  "assistantEditModelUseGlobalDefault": "Использовать глобальные настройки",
+  "assistantSettingsPageTitle": "Настройки ассистента",
+  "assistantSettingsCopyButton": "Копировать",
+  "assistantSettingsCopySuccess": "Ассистент скопирован",
+  "assistantSettingsCopySuffix": "Копия",
+  "assistantSettingsDeleteButton": "Удалить",
+  "assistantSettingsEditButton": "Редактировать",
+  "assistantSettingsAddSheetTitle": "Имя ассистента",
+  "assistantSettingsAddSheetHint": "Введите имя",
+  "assistantSettingsAddSheetCancel": "Отмена",
+  "assistantSettingsAddSheetSave": "Сохранить",
+  "desktopAssistantsListTitle": "Ассистенты",
+  "desktopSidebarTabAssistants": "Ассистенты",
+  "desktopSidebarTabTopics": "Темы",
+  "desktopTrayMenuShowWindow": "Показать окно",
+  "desktopTrayMenuExit": "Выход",
+  "hotkeyToggleAppVisibility": "Показать/скрыть приложение",
+  "hotkeyCloseWindow": "Закрыть окно",
+  "hotkeyOpenSettings": "Открыть настройки",
+  "hotkeyNewTopic": "Новая тема",
+  "hotkeySwitchModel": "Переключить модель",
+  "hotkeyToggleAssistantPanel": "Переключить панель ассистентов",
+  "hotkeyToggleTopicPanel": "Переключить панель тем",
+  "hotkeysPressShortcut": "Нажмите сочетание клавиш",
+  "hotkeysResetDefault": "Сбросить по умолчанию",
+  "hotkeysClearShortcut": "Очистить сочетание",
+  "hotkeysResetAll": "Сбросить все по умолчанию",
+  "assistantEditTemperatureTitle": "Температура",
+  "assistantEditTopPTitle": "Top-p",
+  "assistantSettingsDeleteDialogTitle": "Удалить ассистента",
+  "assistantSettingsDeleteDialogContent": "Вы уверены, что хотите удалить этого ассистента? Это действие нельзя отменить.",
+  "assistantSettingsDeleteDialogCancel": "Отмена",
+  "assistantSettingsDeleteDialogConfirm": "Удалить",
+  "assistantSettingsAtLeastOneAssistantRequired": "Требуется хотя бы один ассистент",
+  "mcpAssistantSheetTitle": "MCP серверы",
+  "mcpAssistantSheetSubtitle": "Серверы, включённые для этого ассистента",
+  "mcpAssistantSheetSelectAll": "Выбрать всё",
+  "mcpAssistantSheetClearAll": "Очистить",
+  "backupPageTitle": "Резервное копирование и восстановление",
+  "backupPageWebDavTab": "WebDAV",
+  "backupPageImportExportTab": "Импорт/Экспорт",
+  "backupPageWebDavServerUrl": "URL сервера WebDAV",
+  "backupPageUsername": "Имя пользователя",
+  "backupPagePassword": "Пароль",
+  "backupPagePath": "Путь",
+  "backupPageChatsLabel": "Чаты",
+  "backupPageFilesLabel": "Файлы",
+  "backupPageTestDone": "Тест завершён",
+  "backupPageTestConnection": "Тест",
+  "backupPageRestartRequired": "Требуется перезапуск",
+  "backupPageRestartContent": "Восстановление завершено. Пожалуйста, перезапустите приложение.",
+  "backupPageOK": "ОК",
+  "backupPageCancel": "Отмена",
+  "backupPageSelectImportMode": "Выберите режим импорта",
+  "backupPageSelectImportModeDescription": "Выберите, как импортировать данные резервной копии:",
+  "backupPageOverwriteMode": "Полная перезапись",
+  "backupPageOverwriteModeDescription": "Очистить все локальные данные и восстановить из резервной копии",
+  "backupPageMergeMode": "Умное слияние",
+  "backupPageMergeModeDescription": "Добавить только несуществующие данные (интеллектуальная дедупликация)",
+  "backupPageRestore": "Восстановить",
+  "backupPageBackupUploaded": "Резервная копия загружена",
+  "backupPageBackup": "Резервная копия",
+  "backupPageExporting": "Экспорт...",
+  "backupPageExportToFile": "Экспорт в файл",
+  "backupPageExportToFileSubtitle": "Экспорт данных приложения в файл",
+  "backupPageImportBackupFile": "Импорт файла резервной копии",
+  "backupPageImportBackupFileSubtitle": "Импорт локального файла резервной копии",
+  "backupPageImportFromOtherApps": "Импорт из других приложений",
+  "backupPageImportFromRikkaHub": "Импорт из RikkaHub",
+  "backupPageNotSupportedYet": "Пока не поддерживается",
+  "backupPageRemoteBackups": "Удалённые резервные копии",
+  "backupPageNoBackups": "Нет резервных копий",
+  "backupPageRestoreTooltip": "Восстановить",
+  "backupPageDeleteTooltip": "Удалить",
+  "backupPageDeleteConfirmTitle": "Подтвердить удаление",
+  "backupPageDeleteConfirmContent": "Вы уверены, что хотите удалить удалённую резервную копию \"{name}\"? Это действие нельзя отменить.",
+  "backupPageBackupManagement": "Управление резервными копиями",
+  "backupPageWebDavBackup": "Резервная копия WebDAV",
+  "backupPageWebDavServerSettings": "Настройки сервера WebDAV",
+  "backupPageS3Backup": "Резервная копия S3",
+  "backupPageS3ServerSettings": "Настройки S3",
+  "backupPageS3Endpoint": "Конечная точка",
+  "backupPageS3Region": "Регион",
+  "backupPageS3Bucket": "Корзина",
+  "backupPageS3AccessKeyId": "ID ключа доступа",
+  "backupPageS3SecretAccessKey": "Секретный ключ доступа",
+  "backupPageS3SessionToken": "Токен сессии (необязательно)",
+  "backupPageS3Prefix": "Префикс",
+  "backupPageS3PathStyle": "Адресация в стиле пути",
+  "backupPageUserAgent": "User-Agent",
+  "backupPageUserAgentHint": "Необязательно",
+  "backupPageSave": "Сохранить",
+  "backupPageBackupNow": "Создать резервную копию сейчас",
+  "backupPageLocalBackup": "Локальная резервная копия",
+  "backupPageImportFromCherryStudio": "Импорт из Cherry Studio",
+  "backupPageImportFromChatbox": "Импорт из Chatbox",
+  "backupReminderSectionTitle": "Напоминание о резервном копировании",
+  "backupReminderEnableTitle": "Напоминать о резервном копировании",
+  "backupReminderFrequencyTitle": "Частота",
+  "backupReminderTimeTitle": "Время напоминания",
+  "backupReminderTimeInputHint": "ЧЧ:мм",
+  "backupReminderTimeInvalid": "Введите время от 00:00 до 23:59.",
+  "backupReminderLastBackupTitle": "Последняя резервная копия",
+  "backupReminderNextReminderTitle": "Следующее напоминание",
+  "backupReminderNever": "Никогда",
+  "backupReminderDisabled": "Выключено",
+  "backupReminderDueNow": "Сейчас",
+  "backupReminderEveryDay": "Каждый день",
+  "backupReminderEveryThreeDays": "Каждые 3 дня",
+  "backupReminderEveryWeek": "Каждую неделю",
+  "backupReminderEveryFourteenDays": "Каждые 14 дней",
+  "backupReminderEveryMonth": "Каждый месяц",
+  "backupReminderCustomDays": "Каждые {days} дней",
+  "@backupReminderCustomDays": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
+  "backupReminderCustomOption": "Настраиваемый...",
+  "backupReminderCustomDialogTitle": "Настраиваемая частота",
+  "backupReminderCustomDialogDescription": "Введите, сколько дней ждать между напоминаниями о резервном копировании.",
+  "backupReminderCustomDaysLabel": "Дни",
+  "backupReminderCustomDaysInvalid": "Введите число от 1 до 365.",
+  "backupReminderSidebarTitle": "Напоминание о резервном копировании",
+  "backupReminderSidebarSubtitle": "Пришло время резервного копирования.",
+  "backupReminderSidebarAction": "Перейти к резервному копированию",
+  "backupReminderSnoozeTooltip": "Напомнить позже",
+  "chatHistoryPageTitle": "История чатов",
+  "chatHistoryPageSearchTooltip": "Поиск",
+  "chatHistoryPageDeleteAllTooltip": "Удалить незакреплённые",
+  "chatHistoryPageDeleteAllDialogTitle": "Удалить незакреплённые диалоги",
+  "chatHistoryPageDeleteAllDialogContent": "Удалить все незакреплённые диалоги для этого ассистента? Закреплённые чаты останутся на месте.",
+  "chatHistoryPageCancel": "Отмена",
+  "chatHistoryPageDelete": "Удалить",
+  "chatHistoryPageDeletedAllSnackbar": "Незакреплённые диалоги удалены",
+  "chatHistoryPageSearchHint": "Поиск диалогов",
+  "chatHistoryPageNoConversations": "Нет диалогов",
+  "chatHistoryPagePinnedSection": "Закреплённые",
+  "chatHistoryPagePin": "Закрепить",
+  "chatHistoryPagePinned": "Закреплено",
+  "messageEditPageTitle": "Редактировать сообщение",
+  "messageEditPageSave": "Сохранить",
+  "messageEditPageSaveAndSend": "Сохранить и отправить",
+  "messageEditPageHint": "Введите сообщение…",
+  "userMessageEditSaveOnly": "Только сохранить",
+  "userMessageEditUnsupportedSnackbar": "Этот контент не поддерживает редактирование",
+  "userMessageEditOverwriteTitle": "Уведомление",
+  "userMessageEditOverwriteContent": "Редактирование перезапишет существующий ввод. Перезаписать?",
+  "selectCopyPageTitle": "Выбрать и скопировать",
+  "selectCopyPageCopyAll": "Копировать всё",
+  "selectCopyPageCopiedAll": "Всё скопировано",
+  "bottomToolsSheetCamera": "Камера",
+  "bottomToolsSheetPhotos": "Фото",
+  "bottomToolsSheetUpload": "Загрузить",
+  "bottomToolsSheetClearContext": "Очистить контекст",
+  "compressContext": "Сжать контекст",
+  "compressContextDesc": "Резюмировать и начать новый чат",
+  "clearContextDesc": "Отметить границу контекста",
+  "contextManagement": "Управление контекстом",
+  "compressingContext": "Сжатие контекста...",
+  "compressContextFailed": "Не удалось сжать контекст",
+  "compressContextNoMessages": "Нет сообщений для сжатия",
+  "compressContextNoConversation": "Нет диалога для сжатия",
+  "compressContextNoModel": "Модель сжатия не настроена",
+  "compressContextEmptySummary": "Сжатие вернуло пустое резюме",
+  "compressContextOptionsTitle": "Сжать контекст",
+  "compressContextOptionsDesc": "Выберите, какая часть текущего чата отправляется модели сжатия.",
+  "compressContextKeepStart": "Начало",
+  "compressContextKeepRecent": "Недавние",
+  "compressContextUnlimited": "Неограниченно",
+  "compressContextMaxCharsLabel": "Символы",
+  "compressContextInvalidLimit": "Введите положительное количество символов",
+  "compressContextStartButton": "Сжать",
+  "bottomToolsSheetLearningMode": "Режим обучения",
+  "bottomToolsSheetLearningModeDescription": "Поможет вам учиться шаг за шагом",
+  "bottomToolsSheetConfigurePrompt": "Настроить промпт",
+  "bottomToolsSheetPrompt": "Промпт",
+  "bottomToolsSheetPromptHint": "Введите текст промпта для внедрения",
+  "bottomToolsSheetResetDefault": "Сбросить по умолчанию",
+  "bottomToolsSheetSave": "Сохранить",
+  "bottomToolsSheetOcr": "OCR изображения",
+  "messageMoreSheetTitle": "Дополнительные действия",
+  "messageMoreSheetSelectCopy": "Выбрать и скопировать",
+  "messageMoreSheetRenderWebView": "Отобразить в WebView",
+  "messageMoreSheetNotImplemented": "Пока не реализовано",
+  "messageMoreSheetEdit": "Редактировать",
+  "messageMoreSheetShare": "Поделиться",
+  "messageMoreSheetSelectMessages": "Выбрать сообщения",
+  "messageMoreSheetCreateBranch": "Создать ветку",
+  "messageMoreSheetDelete": "Удалить эту версию",
+  "messageMoreSheetDeleteAllVersions": "Удалить все версии",
+  "reasoningBudgetSheetOff": "Выключено",
+  "reasoningBudgetSheetAuto": "Авто",
+  "reasoningBudgetSheetLight": "Лёгкие размышления",
+  "reasoningBudgetSheetMedium": "Средние размышления",
+  "reasoningBudgetSheetHeavy": "Глубокие размышления",
+  "reasoningBudgetSheetXhigh": "Экстремальные размышления",
+  "reasoningBudgetSheetMax": "Максимальные размышления",
+  "reasoningBudgetSheetTitle": "Сила цепочки размышлений",
+  "reasoningBudgetSheetCurrentLevel": "Текущий уровень: {level}",
+  "@reasoningBudgetSheetCurrentLevel": {
+    "placeholders": {
+      "level": {
+        "type": "String"
+      }
+    }
+  },
+  "reasoningBudgetSheetOffSubtitle": "Отключить размышления, отвечать напрямую",
+  "reasoningBudgetSheetAutoSubtitle": "Позволить модели автоматически выбирать уровень размышлений",
+  "reasoningBudgetSheetLightSubtitle": "Использовать лёгкие размышления для ответов на вопросы",
+  "reasoningBudgetSheetMediumSubtitle": "Использовать умеренные размышления для ответов на вопросы",
+  "reasoningBudgetSheetHeavySubtitle": "Использовать глубокие размышления для сложных вопросов",
+  "reasoningBudgetSheetXhighSubtitle": "Использовать максимальную глубину размышлений для самых сложных проблем",
+  "reasoningBudgetSheetCustomLabel": "Настраиваемый бюджет размышлений",
+  "reasoningBudgetSheetCustomHint": "например, 2048 (-1 авто, 0 выкл)",
+  "chatMessageWidgetFileNotFound": "Файл не найден: {fileName}",
+  "@chatMessageWidgetFileNotFound": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetCannotOpenFile": "Не удалось открыть файл: {message}",
+  "@chatMessageWidgetCannotOpenFile": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetOpenFileError": "Не удалось открыть файл: {error}",
+  "@chatMessageWidgetOpenFileError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetCopiedToClipboard": "Скопировано в буфер обмена",
+  "chatMessageWidgetResendTooltip": "Отправить повторно",
+  "chatMessageWidgetMoreTooltip": "Ещё",
+  "chatMessageWidgetThinking": "Размышляю...",
+  "chatMessageWidgetTranslation": "Перевод",
+  "chatMessageWidgetTranslating": "Перевожу...",
+  "chatMessageWidgetCitationNotFound": "Источник цитаты не найден",
+  "chatMessageWidgetCannotOpenUrl": "Не удалось открыть ссылку: {url}",
+  "@chatMessageWidgetCannotOpenUrl": {
+    "placeholders": {
+      "url": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetOpenLinkError": "Не удалось открыть ссылку",
+  "chatMessageWidgetCitationsTitle": "Цитаты ({count})",
+  "@chatMessageWidgetCitationsTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "chatMessageWidgetSearchResultsTitle": "Результаты поиска",
+  "chatMessageWidgetCitationSourcesTitle": "Источники цитат",
+  "chatMessageWidgetRegenerateTooltip": "Перегенерировать",
+  "chatMessageWidgetRegenerateConfirmTitle": "Подтвердить перегенерацию",
+  "chatMessageWidgetRegenerateConfirmContent": "Перегенерация обновит только это сообщение и сохранит сообщения ниже. Продолжить?",
+  "chatMessageWidgetRegenerateConfirmDeleteTrailingContent": "Перегенерация удалит все сообщения ниже этого сообщения и не может быть отменена. Продолжить?",
+  "chatMessageWidgetRegenerateConfirmCancel": "Отмена",
+  "chatMessageWidgetRegenerateConfirmOk": "Перегенерировать",
+  "chatMessageWidgetStopTooltip": "Остановить",
+  "chatMessageWidgetSpeakTooltip": "Озвучить",
+  "chatMessageWidgetTranslateTooltip": "Перевести",
+  "chatMessageWidgetBuiltinSearchHideNote": "Скрыть карточки встроенного поискового инструмента",
+  "chatMessageWidgetDeepThinking": "Глубокие размышления",
+  "chatMessageWidgetCreateMemory": "Создать память",
+  "chatMessageWidgetEditMemory": "Редактировать память",
+  "chatMessageWidgetDeleteMemory": "Удалить память",
+  "chatMessageWidgetWebSearch": "Веб-поиск: {query}",
+  "@chatMessageWidgetWebSearch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetBuiltinSearch": "Встроенный поиск",
+  "chatMessageWidgetReadClipboard": "Чтение буфера обмена",
+  "chatMessageWidgetWriteClipboard": "Запись в буфер обмена",
+  "chatMessageWidgetSpeakingTitle": "Озвучивание:",
+  "chatMessageWidgetSpeakText": "Озвучивание: {text}",
+  "@chatMessageWidgetSpeakText": {
+    "placeholders": {
+      "text": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetToolCall": "Вызов инструмента: {name}",
+  "@chatMessageWidgetToolCall": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetToolResult": "Результат инструмента: {name}",
+  "@chatMessageWidgetToolResult": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "chatMessageWidgetNoResultYet": "(Результата пока нет)",
+  "chatMessageWidgetArguments": "Аргументы",
+  "chatMessageWidgetResult": "Результат",
+  "chatMessageWidgetImages": "Изображения",
+  "chatMessageWidgetCitationsCount": "{count} цитат",
+  "@chatMessageWidgetCitationsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "chatSelectionSelectedCountTitle": "Выбрано {count} сообщений",
+  "@chatSelectionSelectedCountTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "chatSelectionExportTxt": "TXT",
+  "chatSelectionExportMd": "MD",
+  "chatSelectionExportImage": "Изображение",
+  "chatSelectionThinkingTools": "Инструменты размышлений",
+  "chatSelectionThinkingContent": "Содержимое размышлений",
+  "chatSelectionDeleteSelected": "Удалить выбранные",
+  "chatSelectionSelectMessagesToDelete": "Выберите сообщения для удаления",
+  "chatSelectionDeleteSelectedConfirm": "Удалить {count} выбранных версий? Это действие нельзя отменить.",
+  "@chatSelectionDeleteSelectedConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "chatSelectionDeleteSelectedAllVersionsConfirm": "Удалить все версии {count} выбранных сообщений? Это действие нельзя отменить.",
+  "@chatSelectionDeleteSelectedAllVersionsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "messageExportSheetAssistant": "Ассистент",
+  "messageExportSheetDefaultTitle": "Новый чат",
+  "messageExportSheetExporting": "Экспорт…",
+  "messageExportSheetExportFailed": "Экспорт не удался: {error}",
+  "@messageExportSheetExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "messageExportSheetExportedAs": "Экспортировано как {filename}",
+  "@messageExportSheetExportedAs": {
+    "placeholders": {
+      "filename": {
+        "type": "String"
+      }
+    }
+  },
+  "displaySettingsPageEnableDollarLatexTitle": "Встроенный рендеринг $...$",
+  "displaySettingsPageEnableDollarLatexSubtitle": "Отображать встроенную математику внутри $...$",
+  "displaySettingsPageEnableMathTitle": "Рендеринг математических формул",
+  "displaySettingsPageEnableMathSubtitle": "Отображать LaTeX математику (встроенную и блочную)",
+  "displaySettingsPageEnableUserMarkdownTitle": "Отображать сообщения пользователя с Markdown",
+  "displaySettingsPageEnableReasoningMarkdownTitle": "Отображать размышления с Markdown",
+  "displaySettingsPageEnableAssistantMarkdownTitle": "Отображать сообщения ассистента с Markdown",
+  "displaySettingsPageMobileCodeBlockWrapTitle": "Перенос слов в блоках кода на мобильном",
+  "displaySettingsPageAutoCollapseCodeBlockTitle": "Автосворачивание блоков кода",
+  "displaySettingsPageAutoCollapseCodeBlockLinesTitle": "Порог автосворачивания",
+  "displaySettingsPageAutoCollapseCodeBlockLinesUnit": "строк",
+  "messageExportSheetFormatTitle": "Формат экспорта",
+  "messageExportSheetMarkdown": "Markdown",
+  "messageExportSheetSingleMarkdownSubtitle": "Экспортировать это сообщение как файл Markdown",
+  "messageExportSheetBatchMarkdownSubtitle": "Экспортировать выбранные сообщения как файл Markdown",
+  "messageExportSheetPlainText": "Обычный текст",
+  "messageExportSheetSingleTxtSubtitle": "Экспортировать это сообщение как файл TXT",
+  "messageExportSheetBatchTxtSubtitle": "Экспортировать выбранные сообщения как файл TXT",
+  "messageExportSheetExportImage": "Экспорт как изображение",
+  "messageExportSheetSingleExportImageSubtitle": "Отобразить это сообщение в PNG изображение",
+  "messageExportSheetBatchExportImageSubtitle": "Отобразить выбранные сообщения в PNG изображение",
+  "messageExportSheetShowThinkingAndToolCards": "Показать карточки глубоких размышлений и инструментов",
+  "messageExportSheetShowThinkingContent": "Показать содержимое размышлений",
+  "messageExportThinkingContentLabel": "Содержимое размышлений",
+  "messageExportSheetDateTimeWithSecondsPattern": "yyyy-MM-dd HH:mm:ss",
+  "exportDisclaimerAiGenerated": "Контент сгенерирован ИИ. Пожалуйста, внимательно проверьте.",
+  "imagePreviewSheetSaveImage": "Сохранить изображение",
+  "imagePreviewSheetSaveSuccess": "Сохранено в галерею",
+  "imagePreviewSheetSaveFailed": "Сохранение не удалось: {error}",
+  "@imagePreviewSheetSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "sideDrawerMenuRename": "Переименовать",
+  "sideDrawerMenuPin": "Закрепить",
+  "sideDrawerMenuUnpin": "Открепить",
+  "sideDrawerMenuRegenerateTitle": "Перегенерировать заголовок",
+  "sideDrawerMenuMoveTo": "Переместить в",
+  "sideDrawerMenuDelete": "Удалить",
+  "sideDrawerDeleteSnackbar": "Удалено \"{title}\"",
+  "@sideDrawerDeleteSnackbar": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "sideDrawerRenameHint": "Введите новое имя",
+  "sideDrawerCancel": "Отмена",
+  "sideDrawerOK": "ОК",
+  "sideDrawerSave": "Сохранить",
+  "sideDrawerGreetingMorning": "Доброе утро 👋",
+  "sideDrawerGreetingNoon": "Добрый день 👋",
+  "sideDrawerGreetingAfternoon": "Добрый день 👋",
+  "sideDrawerGreetingEvening": "Добрый вечер 👋",
+  "sideDrawerDateToday": "Сегодня",
+  "sideDrawerDateYesterday": "Вчера",
+  "sideDrawerDateShortPattern": "d MMM",
+  "sideDrawerDateFullPattern": "d MMM yyyy",
+  "sideDrawerSearchHint": "Поиск по текущему ассистенту",
+  "sideDrawerSearchAssistantsHint": "Поиск ассистентов",
+  "sideDrawerTopicSearchModeLabel": "Режим тем",
+  "sideDrawerGlobalSearchModeLabel": "Глобальный режим",
+  "sideDrawerSearchModeSwipeToTopicHint": "Проведите по строке поиска для поиска тем",
+  "sideDrawerSearchModeSwipeToGlobalHint": "Проведите по строке поиска для глобального поиска",
+  "sideDrawerGlobalSearchHint": "Поиск по всем сессиям",
+  "sideDrawerGlobalSearchEmptyHint": "Поиск по заголовкам и сообщениям",
+  "sideDrawerGlobalSearchNoResults": "Нет подходящих сессий",
+  "sideDrawerGlobalSearchResultCount": "{count} результатов",
+  "@sideDrawerGlobalSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "sideDrawerUpdateTitle": "Новая версия: {version}",
+  "@sideDrawerUpdateTitle": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "sideDrawerUpdateTitleWithBuild": "Новая версия: {version} ({build})",
+  "@sideDrawerUpdateTitleWithBuild": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "build": {
+        "type": "int"
+      }
+    }
+  },
+  "sideDrawerLinkCopied": "Ссылка скопирована",
+  "sideDrawerPinnedLabel": "Закреплённые",
+  "sideDrawerHistory": "История",
+  "sideDrawerSettings": "Настройки",
+  "sideDrawerChooseAssistantTitle": "Выбрать ассистента",
+  "sideDrawerChooseImage": "Выбрать изображение",
+  "sideDrawerChooseEmoji": "Выбрать эмодзи",
+  "sideDrawerEnterLink": "Ввести ссылку",
+  "sideDrawerImportFromQQ": "Импорт из QQ",
+  "sideDrawerReset": "Сбросить",
+  "providerAvatarChooseBuiltInIcon": "Выбрать встроенную иконку",
+  "providerAvatarIconDialogTitle": "Выбрать встроенную иконку",
+  "providerAvatarIconSearchHint": "Поиск иконок",
+  "providerAvatarIconNoResults": "Иконки не найдены",
+  "providerAvatarInputLobehubIcon": "Ввести иконку LobeHub",
+  "providerAvatarChooseLobehubIcon": "Ввести иконку LobeHub",
+  "providerAvatarLobehubDialogTitle": "Ввести иконку LobeHub",
+  "providerAvatarLobehubDialogHint": "Введите название иконки LobeHub, например openai",
+  "sideDrawerEmojiDialogTitle": "Выбрать эмодзи",
+  "sideDrawerEmojiDialogHint": "Введите или вставьте любой эмодзи",
+  "sideDrawerImageUrlDialogTitle": "Ввести URL изображения",
+  "sideDrawerImageUrlDialogHint": "например, https://example.com/avatar.png",
+  "sideDrawerQQAvatarDialogTitle": "Импорт из QQ",
+  "sideDrawerQQAvatarInputHint": "Введите номер QQ (5-12 цифр)",
+  "sideDrawerQQAvatarFetchFailed": "Не удалось получить случайный аватар QQ. Попробуйте снова.",
+  "sideDrawerRandomQQ": "Случайный QQ",
+  "sideDrawerGalleryOpenError": "Не удалось открыть галерею. Попробуйте ввести URL изображения.",
+  "sideDrawerGeneralImageError": "Что-то пошло не так. Попробуйте ввести URL изображения.",
+  "sideDrawerSetNicknameTitle": "Установить никнейм",
+  "sideDrawerNicknameLabel": "Никнейм",
+  "sideDrawerNicknameHint": "Введите новый никнейм",
+  "sideDrawerRename": "Переименовать",
+  "chatInputBarHint": "Напишите сообщение для ИИ",
+  "chatInputBarSelectModelTooltip": "Выбрать модель",
+  "chatInputBarOnlineSearchTooltip": "Онлайн поиск",
+  "chatInputBarReasoningStrengthTooltip": "Сила размышлений",
+  "chatInputBarMcpServersTooltip": "MCP серверы",
+  "chatInputBarMoreTooltip": "Добавить",
+  "chatInputBarImageMode": "Режим изображений",
+  "chatInputBarDisableImageModeTooltip": "Отключить режим изображений",
+  "chatInputBarQueuedPending": "В очереди на отправку",
+  "chatInputBarQueuedCancel": "Отменить очередь",
+  "chatInputBarInsertNewline": "Новая строка",
+  "chatInputBarExpand": "Развернуть",
+  "chatInputBarCollapse": "Свернуть",
+  "mcpPageBackTooltip": "Назад",
+  "mcpPageAddMcpTooltip": "Добавить MCP",
+  "mcpPageNoServers": "Нет MCP серверов",
+  "mcpPageErrorDialogTitle": "Ошибка соединения",
+  "mcpPageErrorNoDetails": "Нет подробностей",
+  "mcpPageClose": "Закрыть",
+  "mcpPageReconnect": "Переподключиться",
+  "mcpPageStatusConnected": "Подключён",
+  "mcpPageStatusConnecting": "Подключение…",
+  "mcpPageStatusDisconnected": "Отключён",
+  "mcpPageStatusDisabled": "Отключён",
+  "mcpPageToolsCount": "Инструменты: {enabled}/{total}",
+  "@mcpPageToolsCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "mcpPageConnectionFailed": "Соединение не удалось",
+  "mcpPageDetails": "Подробности",
+  "mcpPageDelete": "Удалить",
+  "mcpPageConfirmDeleteTitle": "Подтвердить удаление",
+  "mcpPageConfirmDeleteContent": "Это можно отменить через Отменить. Удалить?",
+  "mcpPageServerDeleted": "Сервер удалён",
+  "mcpPageUndo": "Отменить",
+  "mcpPageCancel": "Отмена",
+  "mcpConversationSheetTitle": "MCP серверы",
+  "mcpConversationSheetSubtitle": "Выберите серверы, включённые для этого диалога",
+  "mcpConversationSheetSelectAll": "Выбрать всё",
+  "mcpConversationSheetClearAll": "Очистить",
+  "mcpConversationSheetNoRunning": "Нет запущенных MCP серверов",
+  "mcpConversationSheetConnected": "Подключён",
+  "mcpConversationSheetToolsCount": "Инструменты: {enabled}/{total}",
+  "@mcpConversationSheetToolsCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "mcpServerEditSheetEnabledLabel": "Включён",
+  "mcpServerEditSheetNameLabel": "Имя",
+  "mcpServerEditSheetTransportLabel": "Транспорт",
+  "mcpServerEditSheetSseRetryHint": "Если SSE не работает, попробуйте несколько раз",
+  "mcpServerEditSheetUrlLabel": "URL сервера",
+  "mcpServerEditSheetCustomHeadersTitle": "Пользовательские заголовки",
+  "mcpServerEditSheetHeaderNameLabel": "Название заголовка",
+  "mcpServerEditSheetHeaderNameHint": "например, Authorization",
+  "mcpServerEditSheetHeaderValueLabel": "Значение заголовка",
+  "mcpServerEditSheetHeaderValueHint": "например, Bearer xxxxxx",
+  "mcpServerEditSheetRemoveHeaderTooltip": "Удалить",
+  "mcpServerEditSheetAddHeader": "Добавить заголовок",
+  "mcpServerEditSheetTitleEdit": "Редактировать MCP",
+  "mcpServerEditSheetTitleAdd": "Добавить MCP",
+  "mcpServerEditSheetSyncToolsTooltip": "Синхронизировать инструменты",
+  "mcpServerEditSheetTabBasic": "Основные",
+  "mcpServerEditSheetTabTools": "Инструменты",
+  "mcpServerEditSheetNoToolsHint": "Нет инструментов, нажмите обновить для синхронизации",
+  "mcpServerEditSheetCancel": "Отмена",
+  "mcpServerEditSheetSave": "Сохранить",
+  "mcpServerEditSheetUrlRequired": "Введите URL сервера",
+  "defaultModelPageBackTooltip": "Назад",
+  "defaultModelPageTitle": "Модель по умолчанию",
+  "defaultModelPageChatModelTitle": "Модель чата",
+  "defaultModelPageChatModelSubtitle": "Глобальная модель чата по умолчанию",
+  "defaultModelPageTitleModelTitle": "Модель резюмирования заголовков",
+  "defaultModelPageTitleModelSubtitle": "Используется для резюмирования заголовков диалогов; предпочтительны быстрые и дешёвые модели",
+  "titleModelThinkingTitle": "Включить размышления",
+  "defaultModelPageSummaryModelTitle": "Модель резюмирования",
+  "defaultModelPageSummaryModelSubtitle": "Используется для генерации резюме диалогов; предпочтительны быстрые и дешёвые модели",
+  "defaultModelPageSuggestionModelTitle": "Модель предложений чата",
+  "defaultModelPageSuggestionModelSubtitle": "Используется для пузырьков с последующими предложениями после ответов ассистента. Отключена до выбора модели.",
+  "assistantEditRecentChatsSummaryFrequencyTitle": "Частота обновления резюме",
+  "assistantEditRecentChatsSummaryFrequencyDescription": "Обновлять резюме недавних чатов после выбранного количества новых сообщений.",
+  "assistantEditRecentChatsSummaryFrequencyOption": "Каждые {count}",
+  "@assistantEditRecentChatsSummaryFrequencyOption": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "assistantEditRecentChatsSummaryFrequencyCustomButton": "Настраиваемый",
+  "assistantEditRecentChatsSummaryFrequencyCustomTitle": "Настраиваемая частота резюме",
+  "assistantEditRecentChatsSummaryFrequencyCustomDescription": "Введите, сколько новых сообщений должно накопиться перед обновлением резюме недавних чатов.",
+  "assistantEditRecentChatsSummaryFrequencyCustomLabel": "Количество новых сообщений",
+  "assistantEditRecentChatsSummaryFrequencyCustomHint": "Введите число больше 0",
+  "assistantEditRecentChatsSummaryFrequencyCustomInvalid": "Введите целое число больше 0",
+  "defaultModelPageTranslateModelTitle": "Модель перевода",
+  "defaultModelPageTranslateModelSubtitle": "Используется для перевода содержимого сообщений; предпочтительны быстрые и точные модели",
+  "defaultModelPageOcrModelTitle": "OCR модель",
+  "defaultModelPageOcrModelSubtitle": "Используется для извлечения текста и описаний из изображений",
+  "defaultModelPageOcrModelRequiresImageInput": "Выберите модель с тегом ввода изображений для OCR",
+  "defaultModelPagePromptLabel": "Промпт",
+  "defaultModelPageTitlePromptHint": "Введите шаблон промпта для резюмирования заголовков",
+  "defaultModelPageSummaryPromptHint": "Введите шаблон промпта для генерации резюме",
+  "defaultModelPageSuggestionPromptHint": "Введите шаблон промпта для предложений чата",
+  "defaultModelPageTranslatePromptHint": "Введите шаблон промпта для перевода",
+  "defaultModelPageOcrPromptHint": "Введите шаблон промпта для понимания OCR изображений",
+  "defaultModelPageResetDefault": "Сбросить по умолчанию",
+  "defaultModelPageSave": "Сохранить",
+  "defaultModelPageTitleVars": "Переменные: содержимое: {contentVar}, локаль: {localeVar}",
+  "@defaultModelPageTitleVars": {
+    "placeholders": {
+      "contentVar": {
+        "type": "String"
+      },
+      "localeVar": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModelPageSummaryVars": "Переменные: предыдущее резюме: {previousSummaryVar}, новые сообщения: {userMessagesVar}",
+  "@defaultModelPageSummaryVars": {
+    "placeholders": {
+      "previousSummaryVar": {
+        "type": "String"
+      },
+      "userMessagesVar": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModelPageSuggestionVars": "Переменные: диалог: {contentVar}, язык: {localeVar}",
+  "@defaultModelPageSuggestionVars": {
+    "placeholders": {
+      "contentVar": {
+        "type": "String"
+      },
+      "localeVar": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModelPageCompressModelTitle": "Модель сжатия",
+  "defaultModelPageCompressModelSubtitle": "Используется для сжатия контекста диалога; предпочтительны быстрые модели",
+  "defaultModelPageCompressPromptHint": "Введите шаблон промпта для сжатия контекста",
+  "defaultModelPageCompressVars": "Переменные: диалог: {contentVar}, язык: {localeVar}",
+  "@defaultModelPageCompressVars": {
+    "placeholders": {
+      "contentVar": {
+        "type": "String"
+      },
+      "localeVar": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModelPageTranslateVars": "Переменные: исходный текст: {sourceVar}, целевой язык: {targetVar}",
+  "@defaultModelPageTranslateVars": {
+    "placeholders": {
+      "sourceVar": {
+        "type": "String"
+      },
+      "targetVar": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModelPageUseCurrentModel": "Использовать текущую модель чата",
+  "defaultModelPageNotEnabled": "Не включено",
+  "translatePagePasteButton": "Вставить",
+  "translatePageCopyResult": "Копировать результат",
+  "translatePageClearAll": "Очистить всё",
+  "translatePageInputHint": "Введите текст для перевода…",
+  "translatePageOutputHint": "Переведённый результат появится здесь…",
+  "modelDetailSheetAddModel": "Добавить модель",
+  "modelDetailSheetEditModel": "Редактировать модель",
+  "modelDetailSheetBasicTab": "Основные",
+  "modelDetailSheetAdvancedTab": "Расширенные",
+  "modelDetailSheetBuiltinToolsTab": "Встроенные инструменты",
+  "modelDetailSheetModelIdLabel": "ID модели",
+  "modelDetailSheetModelIdHint": "Обязательно, рекомендуются строчные/цифры/дефисы",
+  "modelDetailSheetModelIdDisabledHint": "{modelId}",
+  "@modelDetailSheetModelIdDisabledHint": {
+    "placeholders": {
+      "modelId": {
+        "type": "String"
+      }
+    }
+  },
+  "modelDetailSheetModelNameLabel": "Название модели",
+  "modelDetailSheetModelTypeLabel": "Тип модели",
+  "modelDetailSheetChatType": "Чат",
+  "modelDetailSheetEmbeddingType": "Эмбеддинг",
+  "modelDetailSheetInputModesLabel": "Режимы ввода",
+  "modelDetailSheetOutputModesLabel": "Режимы вывода",
+  "modelDetailSheetAbilitiesLabel": "Способности",
+  "modelDetailSheetTextMode": "Текст",
+  "modelDetailSheetImageMode": "Изображение",
+  "modelDetailSheetToolsAbility": "Инструменты",
+  "modelDetailSheetReasoningAbility": "Размышления",
+  "modelDetailSheetProviderOverrideDescription": "Переопределения провайдера: настройка провайдера для конкретной модели.",
+  "modelDetailSheetAddProviderOverride": "Добавить переопределение провайдера",
+  "modelDetailSheetCustomHeadersTitle": "Пользовательские заголовки",
+  "modelDetailSheetAddHeader": "Добавить заголовок",
+  "modelDetailSheetCustomBodyTitle": "Пользовательское тело",
+  "modelFetchInvertTooltip": "Инвертировать",
+  "modelDetailSheetSaveFailedMessage": "Сохранение не удалось. Попробуйте снова.",
+  "modelDetailSheetAddBody": "Добавить тело",
+  "modelDetailSheetBuiltinToolsDescription": "Встроенные инструменты поддерживают только официальные API.",
+  "modelDetailSheetBuiltinToolsUnsupportedHint": "Текущий провайдер не поддерживает эти встроенные инструменты.",
+  "modelDetailSheetSearchTool": "Поиск",
+  "modelDetailSheetSearchToolDescription": "Включить интеграцию Google Search",
+  "modelDetailSheetUrlContextTool": "URL контекст",
+  "modelDetailSheetUrlContextToolDescription": "Включить получение содержимого URL",
+  "modelDetailSheetCodeExecutionTool": "Выполнение кода",
+  "modelDetailSheetCodeExecutionToolDescription": "Включить инструмент выполнения кода",
+  "modelDetailSheetYoutubeTool": "YouTube",
+  "modelDetailSheetYoutubeToolDescription": "Включить получение URL YouTube (автоопределение ссылок в промптах)",
+  "modelDetailSheetOpenaiBuiltinToolsResponsesOnlyHint": "Требует OpenAI Responses API.",
+  "modelDetailSheetOpenaiCodeInterpreterTool": "Интерпретатор кода",
+  "modelDetailSheetOpenaiCodeInterpreterToolDescription": "Включить инструмент интерпретатора кода (контейнер авто, лимит памяти 4g)",
+  "modelDetailSheetOpenaiImageGenerationTool": "Генерация изображений",
+  "modelDetailSheetOpenaiImageGenerationToolDescription": "Включить инструмент генерации изображений",
+  "modelDetailSheetCancelButton": "Отмена",
+  "modelDetailSheetAddButton": "Добавить",
+  "modelDetailSheetConfirmButton": "Подтвердить",
+  "modelDetailSheetInvalidIdError": "Введите действительный ID модели (>=2 символов)",
+  "modelDetailSheetModelIdExistsError": "ID модели уже существует",
+  "modelDetailSheetHeaderKeyHint": "Ключ заголовка",
+  "modelDetailSheetHeaderValueHint": "Значение заголовка",
+  "modelDetailSheetBodyKeyHint": "Ключ тела",
+  "modelDetailSheetBodyJsonHint": "JSON тела",
+  "modelSelectSheetSearchHint": "Поиск моделей или провайдеров",
+  "modelSelectSheetFavoritesSection": "Избранное",
+  "modelSelectSheetFavoriteTooltip": "Избранное",
+  "modelSelectSheetChatType": "Чат",
+  "modelSelectSheetEmbeddingType": "Эмбеддинг",
+  "providerDetailPageShareTooltip": "Поделиться",
+  "providerDetailPageDeleteProviderTooltip": "Удалить провайдера",
+  "providerDetailPageDeleteProviderTitle": "Удалить провайдера",
+  "providerDetailPageDeleteProviderContent": "Вы уверены, что хотите удалить этого провайдера? Это действие нельзя отменить.",
+  "providerDetailPageCancelButton": "Отмена",
+  "providerDetailPageDeleteButton": "Удалить",
+  "providerDetailPageProviderDeletedSnackbar": "Провайдер удалён",
+  "providerDetailPageConfigTab": "Конфигурация",
+  "providerDetailPageModelsTab": "Модели",
+  "providerDetailPageNetworkTab": "Сеть",
+  "providerDetailPageEnabledTitle": "Включён",
+  "providerDetailPageManageSectionTitle": "Управление",
+  "providerDetailPageNameLabel": "Имя",
+  "providerDetailPageApiKeyHint": "Оставьте пустым для использования по умолчанию",
+  "providerDetailPageHideTooltip": "Скрыть",
+  "providerDetailPageShowTooltip": "Показать",
+  "providerDetailPageApiPathLabel": "API путь",
+  "providerDetailPageResponseApiTitle": "Response API (/responses)",
+  "providerDetailPageAihubmixAppCodeLabel": "APP-Code (скидка 10%)",
+  "providerDetailPageAihubmixAppCodeHelp": "Добавляет заголовок APP-Code к запросам для получения скидки 10%. Влияет только на AIhubmix.",
+  "providerDetailPageClaudePromptCachingTitle": "Кэширование промптов Claude",
+  "providerDetailPageClaudePromptCachingHelp": "Добавляет cache_control к запросам Claude через Anthropic или OpenRouter.",
+  "providerDetailPageClaudePromptCachingTtlTitle": "TTL кэша",
+  "providerDetailPageClaudePromptCachingTtlHelp": "5 минут по умолчанию. 1 час стоит дороже для записи, но может уменьшить пересборки в длинных диалогах.",
+  "providerDetailPageClaudePromptCachingTtl5m": "5 мин",
+  "providerDetailPageClaudePromptCachingTtl1h": "1 час",
+  "providerDetailPageBalanceTitle": "Баланс аккаунта",
+  "providerDetailPageBalanceInfo": "Получить баланс аккаунта",
+  "providerDetailPageBalanceApiPathLabel": "API путь баланса",
+  "providerDetailPageBalanceResultPathLabel": "JSON путь результата",
+  "providerDetailPageBalanceQueryButton": "Проверить баланс",
+  "providerDetailPageBalanceQuerying": "Проверка...",
+  "providerDetailPageBalanceResetDefaultsButton": "Сбросить",
+  "providerDetailPageBalanceResetDefaultsTooltip": "Сбросить настройки баланса",
+  "providerDetailPageBalanceResult": "Баланс: {value}",
+  "@providerDetailPageBalanceResult": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "providerDetailPageBalanceError": "Запрос баланса не удался: {message}",
+  "@providerDetailPageBalanceError": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "providerDetailPageVertexAiTitle": "Vertex AI",
+  "providerDetailPageLocationLabel": "Местоположение",
+  "providerDetailPageProjectIdLabel": "ID проекта",
+  "providerDetailPageServiceAccountJsonLabel": "JSON сервисного аккаунта (вставить или импортировать)",
+  "providerDetailPageImportJsonButton": "Импорт JSON",
+  "providerDetailPageImportJsonReadFailedMessage": "Не удалось прочитать файл",
+  "providerDetailPageTestButton": "Тест",
+  "providerDetailPageSaveButton": "Сохранить",
+  "providerDetailPageProviderRemovedMessage": "Провайдер удалён",
+  "providerDetailPageNoModelsTitle": "Нет моделей",
+  "providerDetailPageNoModelsSubtitle": "Нажмите кнопки ниже для добавления моделей",
+  "providerDetailPageDeleteModelButton": "Удалить",
+  "providerDetailPageConfirmDeleteTitle": "Подтвердить удаление",
+  "providerDetailPageConfirmDeleteContent": "Это можно отменить через Отменить. Удалить?",
+  "providerDetailPageModelDeletedSnackbar": "Модель удалена",
+  "providerDetailPageUndoButton": "Отменить",
+  "providerDetailPageAddNewModelButton": "Добавить модель",
+  "providerDetailPageFetchModelsButton": "Получить",
+  "providerDetailPageEnableProxyTitle": "Включить прокси",
+  "providerDetailPageHostLabel": "Хост",
+  "providerDetailPagePortLabel": "Порт",
+  "providerDetailPageUsernameOptionalLabel": "Имя пользователя (необязательно)",
+  "providerDetailPagePasswordOptionalLabel": "Пароль (необязательно)",
+  "providerDetailPageSavedSnackbar": "Сохранено",
+  "providerDetailPageEmbeddingsGroupTitle": "Эмбеддинги",
+  "providerDetailPageOtherModelsGroupTitle": "Прочие",
+  "providerDetailPageRemoveGroupTooltip": "Удалить группу",
+  "providerDetailPageAddGroupTooltip": "Добавить группу",
+  "providerDetailPageFilterHint": "Введите название модели для фильтрации",
+  "providerDetailPageDeleteText": "Удалить",
+  "providerDetailPageEditTooltip": "Редактировать",
+  "providerDetailPageTestConnectionTitle": "Тест соединения",
+  "providerDetailPageSelectModelButton": "Выбрать модель",
+  "providerDetailPageChangeButton": "Изменить",
+  "providerDetailPageUseStreamingLabel": "Использовать потоковую передачу",
+  "providerDetailPageTestingMessage": "Тестирование…",
+  "providerDetailPageTestSuccessMessage": "Успешно",
+  "providersPageTitle": "Провайдеры",
+  "providersPageImportTooltip": "Импорт",
+  "providersPageAddTooltip": "Добавить",
+  "providersPageSearchHint": "Поиск провайдеров или групп",
+  "providersPageProviderAddedSnackbar": "Провайдер добавлен",
+  "providerGroupsGroupLabel": "Группа",
+  "providerGroupsOther": "Прочие",
+  "providerGroupsOtherUngroupedOption": "Прочие (без группы)",
+  "providerGroupsPickerTitle": "Выбрать группу",
+  "providerGroupsManageTitle": "Управление группами",
+  "providerGroupsManageAction": "Управление группами",
+  "providerGroupsCreateNewGroupAction": "Новая группа…",
+  "providerGroupsCreateDialogTitle": "Новая группа",
+  "providerGroupsNameHint": "Название группы",
+  "providerGroupsCreateDialogCancel": "Отмена",
+  "providerGroupsCreateDialogOk": "Создать",
+  "providerGroupsCreateFailedToast": "Не удалось создать группу",
+  "providerGroupsDeleteConfirmTitle": "Удалить группу?",
+  "providerGroupsDeleteConfirmContent": "Провайдеры в этой группе будут перемещены в \"Прочие\".",
+  "providerGroupsDeleteConfirmCancel": "Отмена",
+  "providerGroupsDeleteConfirmOk": "Удалить",
+  "providerGroupsDeletedToast": "Группа удалена",
+  "providerGroupsEmptyState": "Групп пока нет.",
+  "providerGroupsExpandToMoveToast": "Сначала разверните группу.",
+  "providersPageSiliconFlowName": "SiliconFlow",
+  "providersPageAliyunName": "Aliyun",
+  "providersPageZhipuName": "Zhipu AI",
+  "providersPageByteDanceName": "ByteDance",
+  "providersPageEnabledStatus": "ВКЛ",
+  "providersPageDisabledStatus": "ВЫКЛ",
+  "providersPageModelsCountSuffix": " моделей",
+  "providersPageModelsCountSingleSuffix": " моделей",
+  "addProviderSheetTitle": "Добавить провайдера",
+  "addProviderSheetEnabledLabel": "Включён",
+  "addProviderSheetNameLabel": "Имя",
+  "addProviderSheetApiPathLabel": "API путь",
+  "addProviderSheetVertexAiLocationLabel": "Местоположение",
+  "addProviderSheetVertexAiProjectIdLabel": "ID проекта",
+  "addProviderSheetVertexAiServiceAccountJsonLabel": "JSON сервисного аккаунта (вставить или импортировать)",
+  "addProviderSheetImportJsonButton": "Импорт JSON",
+  "addProviderSheetCancelButton": "Отмена",
+  "addProviderSheetAddButton": "Добавить",
+  "importProviderSheetTitle": "Импорт провайдера",
+  "importProviderSheetScanQrTooltip": "Сканировать QR",
+  "importProviderSheetFromGalleryTooltip": "Из галереи",
+  "importProviderSheetImportSuccessMessage": "Импортировано {count} провайдеров",
+  "@importProviderSheetImportSuccessMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "importProviderSheetImportFailedMessage": "Импорт не удался: {error}",
+  "@importProviderSheetImportFailedMessage": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "importProviderSheetDescription": "Вставьте строки для обмена (поддерживается многострочность) или JSON Chatbox",
+  "importProviderSheetInputHint": "ai-provider:v1:... или JSON",
+  "importProviderSheetCancelButton": "Отмена",
+  "importProviderSheetImportButton": "Импорт",
+  "shareProviderSheetTitle": "Поделиться провайдером",
+  "shareProviderSheetDescription": "Скопируйте или поделитесь через QR-код.",
+  "shareProviderSheetCopiedMessage": "Скопировано",
+  "shareProviderSheetCopyButton": "Копировать",
+  "shareProviderSheetShareButton": "Поделиться",
+  "desktopProviderContextMenuShare": "Поделиться",
+  "desktopProviderShareCopyText": "Копировать код",
+  "desktopProviderShareCopyQr": "Копировать QR",
+  "providerDetailPageApiBaseUrlLabel": "Базовый URL API",
+  "providerDetailPageModelsTitle": "Модели",
+  "providerModelsGetButton": "Получить",
+  "providerDetailPageCapsVision": "Зрение",
+  "providerDetailPageCapsImage": "Изображение",
+  "providerDetailPageCapsTool": "Инструмент",
+  "providerDetailPageCapsReasoning": "Размышления",
+  "qrScanPageTitle": "Сканировать QR",
+  "qrScanPageInstruction": "Выровняйте QR-код в рамке",
+  "searchServicesPageBackTooltip": "Назад",
+  "searchServicesPageTitle": "Поисковые сервисы",
+  "searchServicesPageDone": "Готово",
+  "searchServicesPageEdit": "Редактировать",
+  "searchServicesPageAddProvider": "Добавить провайдера",
+  "searchServicesPageSearchProviders": "Поисковые провайдеры",
+  "searchServicesPageGeneralOptions": "Общие опции",
+  "searchServicesPageAutoTestTitle": "Автотест соединений при запуске",
+  "searchServicesPageMaxResults": "Максимум результатов",
+  "searchServicesPageTimeoutSeconds": "Таймаут (секунды)",
+  "searchServicesPageAtLeastOneServiceRequired": "Требуется хотя бы один поисковый сервис",
+  "searchServicesPageTestingStatus": "Тестирование…",
+  "searchServicesPageConnectedStatus": "Подключён",
+  "searchServicesPageFailedStatus": "Не удалось",
+  "searchServicesPageNotTestedStatus": "Не тестировался",
+  "searchServicesPageEditServiceTooltip": "Редактировать сервис",
+  "searchServicesPageTestConnectionTooltip": "Тест соединения",
+  "searchServicesPageDeleteServiceTooltip": "Удалить сервис",
+  "searchServicesPageConfiguredStatus": "Настроен",
+  "miniMapTitle": "Миникарта",
+  "miniMapTooltip": "Миникарта",
+  "miniMapScrollToBottomTooltip": "Прокрутить вниз",
+  "searchServicesPageApiKeyRequiredStatus": "Требуется API ключ",
+  "searchServicesPageUrlRequiredStatus": "Требуется URL",
+  "searchServicesAddDialogTitle": "Добавить поисковый сервис",
+  "searchServicesAddDialogServiceType": "Тип сервиса",
+  "searchServicesAddDialogBingLocal": "Локальный",
+  "searchServicesAddDialogCancel": "Отмена",
+  "searchServicesAddDialogAdd": "Добавить",
+  "searchServicesAddDialogApiKeyRequired": "API ключ обязателен",
+  "searchServicesFieldCustomUrlOptional": "Пользовательский URL (необязательно)",
+  "searchServicesDialogApiKey": "API ключ",
+  "searchServicesDialogModel": "Модель",
+  "searchServicesDialogSystemPrompt": "Системный промпт",
+  "searchServicesAddDialogInstanceUrl": "URL экземпляра",
+  "searchServicesAddDialogUrlRequired": "URL обязателен",
+  "searchServicesAddDialogEnginesOptional": "Движки (необязательно)",
+  "searchServicesAddDialogLanguageOptional": "Язык (необязательно)",
+  "searchServicesAddDialogUsernameOptional": "Имя пользователя (необязательно)",
+  "searchServicesAddDialogPasswordOptional": "Пароль (необязательно)",
+  "searchServicesAddDialogRegionOptional": "Регион (необязательно, по умолчанию: us-en)",
+  "searchServicesEditDialogEdit": "Редактировать",
+  "searchServicesEditDialogCancel": "Отмена",
+  "searchServicesEditDialogSave": "Сохранить",
+  "searchServicesEditDialogBingLocalNoConfig": "Для локального поиска Bing настройка не требуется.",
+  "searchServicesEditDialogApiKeyRequired": "API ключ обязателен",
+  "searchServicesEditDialogInstanceUrl": "URL экземпляра",
+  "searchServicesEditDialogUrlRequired": "URL обязателен",
+  "searchServicesEditDialogEnginesOptional": "Движки (необязательно)",
+  "searchServicesEditDialogLanguageOptional": "Язык (необязательно)",
+  "searchServicesEditDialogUsernameOptional": "Имя пользователя (необязательно)",
+  "searchServicesEditDialogPasswordOptional": "Пароль (необязательно)",
+  "searchServicesEditDialogRegionOptional": "Регион (необязательно, по умолчанию: us-en)",
+  "searchSettingsSheetTitle": "Настройки поиска",
+  "searchSettingsSheetBuiltinSearchTitle": "Встроенный поиск",
+  "searchSettingsSheetBuiltinSearchDescription": "Включить встроенный поиск модели",
+  "searchSettingsSheetClaudeDynamicSearchTitle": "Встроенный поиск (новый)",
+  "searchSettingsSheetClaudeDynamicSearchDescription": "Использовать `web_search_20260209` с динамической фильтрацией на поддерживаемых официальных моделях Claude.",
+  "searchSettingsSheetWebSearchTitle": "Веб-поиск",
+  "searchSettingsSheetWebSearchDescription": "Включить веб-поиск в чате",
+  "searchSettingsSheetOpenSearchServicesTooltip": "Открыть поисковые сервисы",
+  "searchSettingsSheetNoServicesMessage": "Нет сервисов. Добавьте из поисковых сервисов.",
+  "aboutPageEasterEggMessage": "Спасибо за исследование! \\n (Пока нет яйца)",
+  "aboutPageEasterEggButton": "Отлично!",
+  "aboutPageAppName": "Kelivo",
+  "aboutPageAppDescription": "ИИ-ассистент с открытым исходным кодом",
+  "aboutPageNoQQGroup": "QQ группы пока нет",
+  "aboutPageVersion": "Версия",
+  "aboutPageVersionDetail": "{version} / {buildNumber}",
+  "@aboutPageVersionDetail": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "buildNumber": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutPageSystem": "Система",
+  "aboutPageLoadingPlaceholder": "...",
+  "aboutPageUnknownPlaceholder": "-",
+  "aboutPagePlatformMacos": "macOS",
+  "aboutPagePlatformWindows": "Windows",
+  "aboutPagePlatformLinux": "Linux",
+  "aboutPagePlatformAndroid": "Android",
+  "aboutPagePlatformIos": "iOS",
+  "aboutPagePlatformOther": "Прочие ({os})",
+  "@aboutPagePlatformOther": {
+    "placeholders": {
+      "os": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutPageWebsite": "Веб-сайт",
+  "aboutPageGithub": "GitHub",
+  "aboutPageLicense": "Лицензия",
+  "aboutPageJoinQQGroup": "Присоединиться к нашей QQ группе",
+  "aboutPageQQGroupOne": "Kelivo группа 1",
+  "aboutPageQQGroupTwo": "Kelivo группа 2",
+  "aboutPageJoinDiscord": "Присоединиться к нам в Discord",
+  "displaySettingsPageShowUserAvatarTitle": "Показывать аватар пользователя",
+  "displaySettingsPageShowUserAvatarSubtitle": "Отображать аватар пользователя в сообщениях чата",
+  "displaySettingsPageShowUserNameTimestampTitle": "Показывать имя пользователя и время",
+  "displaySettingsPageShowUserNameTimestampSubtitle": "Показывать имя пользователя и время под ним в сообщениях чата",
+  "displaySettingsPageShowUserNameTitle": "Показывать имя пользователя",
+  "displaySettingsPageShowUserTimestampTitle": "Показывать время пользователя",
+  "displaySettingsPageShowUserMessageActionsTitle": "Показывать действия с сообщениями пользователя",
+  "displaySettingsPageShowUserMessageActionsSubtitle": "Отображать кнопки копирования, повтора и другие под вашими сообщениями",
+  "displaySettingsPageShowModelNameTimestampTitle": "Показывать имя модели и время",
+  "displaySettingsPageShowModelNameTimestampSubtitle": "Показывать имя модели и время под ним в сообщениях чата",
+  "displaySettingsPageShowModelNameTitle": "Показывать имя модели",
+  "displaySettingsPageShowModelTimestampTitle": "Показывать время модели",
+  "displaySettingsPageShowProviderInChatMessageTitle": "Показывать провайдера после имени модели",
+  "displaySettingsPageShowProviderInChatMessageSubtitle": "Отображать имя провайдера после ID модели в сообщениях чата (например, модель | провайдер)",
+  "displaySettingsPageChatModelIconTitle": "Иконка модели чата",
+  "displaySettingsPageChatModelIconSubtitle": "Показывать иконку модели в сообщениях чата",
+  "displaySettingsPageShowTokenStatsTitle": "Показывать статистику токенов и контекста",
+  "displaySettingsPageShowTokenStatsSubtitle": "Показывать использование токенов и количество сообщений",
+  "displaySettingsPageAutoCollapseThinkingTitle": "Автосворачивание размышлений",
+  "displaySettingsPageAutoCollapseThinkingSubtitle": "Сворачивать размышления после завершения",
+  "displaySettingsPageCollapseThinkingStepsTitle": "Сворачивать шаги размышлений",
+  "displaySettingsPageCollapseThinkingStepsSubtitle": "Показывать только последние шаги до разворачивания",
+  "displaySettingsPageShowToolResultSummaryTitle": "Показывать резюме результатов инструментов",
+  "displaySettingsPageInsertSuggestionOnlyTitle": "Вставлять предложения без отправки",
+  "displaySettingsPageShowToolResultSummarySubtitle": "Отображать текст резюме под шагами инструментов",
+  "displaySettingsPageRegenerateDeleteTrailingMessagesTitle": "Удалять сообщения ниже при перегенерации",
+  "displaySettingsPageShowRegenerateConfirmDialogTitle": "Подтверждать перед перегенерацией",
+  "chainOfThoughtExpandSteps": "Показать ещё {count} шагов",
+  "@chainOfThoughtExpandSteps": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "chainOfThoughtCollapse": "Свернуть",
+  "displaySettingsPageShowChatListDateTitle": "Показывать даты в списке чатов",
+  "displaySettingsPageShowChatListDateSubtitle": "Отображать метки групп дат в списке диалогов",
+  "displaySettingsPageEnableImageCropperTitle": "Включить обрезку изображений",
+  "@displaySettingsPageEnableImageCropperTitle": {},
+  "displaySettingsPageEnableImageCropperSubtitle": "Обрезать изображения после выбора из галереи или камеры",
+  "@displaySettingsPageEnableImageCropperSubtitle": {},
+  "displaySettingsPageKeepSidebarOpenOnAssistantTapTitle": "Держать боковую панель открытой при выборе ассистента",
+  "displaySettingsPageKeepSidebarOpenOnTopicTapTitle": "Держать боковую панель открытой при выборе темы",
+  "displaySettingsPageKeepAssistantListExpandedOnSidebarCloseTitle": "Не сворачивать список ассистентов при закрытии боковой панели",
+  "displaySettingsPageShowUpdatesTitle": "Показывать обновления",
+  "displaySettingsPageShowUpdatesSubtitle": "Показывать уведомления об обновлениях приложения",
+  "displaySettingsPageMessageNavButtonsTitle": "Кнопки навигации по сообщениям",
+  "displaySettingsPageMessageNavButtonsSubtitle": "Выберите, когда появляются кнопки быстрого перехода",
+  "displaySettingsPageMessageNavButtonsModeAlways": "Всегда показывать",
+  "displaySettingsPageMessageNavButtonsModeScroll": "Показывать при прокрутке",
+  "displaySettingsPageMessageNavButtonsModeHover": "Показывать при наведении мыши",
+  "displaySettingsPageMessageNavButtonsModeScrollAndHover": "Показывать при прокрутке или наведении",
+  "displaySettingsPageMessageNavButtonsModeNever": "Никогда не показывать",
+  "displaySettingsPageUseNewAssistantAvatarUxTitle": "Показывать аватар ассистента в заголовке чата",
+  "displaySettingsPageHapticsOnSidebarTitle": "Тактильная обратная связь на боковой панели",
+  "displaySettingsPageHapticsOnSidebarSubtitle": "Включить тактильную обратную связь при открытии/закрытии боковой панели",
+  "displaySettingsPageHapticsGlobalTitle": "Глобальная тактильная обратная связь",
+  "displaySettingsPageHapticsIosSwitchTitle": "Тактильная обратная связь на переключателях",
+  "displaySettingsPageHapticsOnListItemTapTitle": "Тактильная обратная связь на элементах списка",
+  "displaySettingsPageHapticsOnCardTapTitle": "Тактильная обратная связь на карточках",
+  "displaySettingsPageHapticsOnGenerateTitle": "Тактильная обратная связь при генерации",
+  "displaySettingsPageHapticsOnGenerateSubtitle": "Включить тактильную обратную связь во время генерации",
+  "displaySettingsPageNewChatAfterDeleteTitle": "Новый чат после удаления темы",
+  "displaySettingsPageNewChatOnAssistantSwitchTitle": "Новый чат при переключении ассистентов",
+  "displaySettingsPageNewChatOnLaunchTitle": "Новый чат при запуске",
+  "displaySettingsPageEnterToSendTitle": "Enter для отправки",
+  "displaySettingsPageSendShortcutTitle": "Сочетание для отправки",
+  "displaySettingsPageSendShortcutEnter": "Enter",
+  "displaySettingsPageSendShortcutCtrlEnter": "Ctrl/Cmd + Enter",
+  "displaySettingsPageAutoSwitchTopicsTitle": "Автопереключение на темы",
+  "desktopDisplaySettingsTopicPositionTitle": "Позиция тем",
+  "desktopDisplaySettingsTopicPositionLeft": "Слева",
+  "desktopDisplaySettingsTopicPositionRight": "Справа",
+  "displaySettingsPageNewChatOnLaunchSubtitle": "Автоматически создавать новый чат при запуске",
+  "displaySettingsPageChatFontSizeTitle": "Размер шрифта чата",
+  "displaySettingsPageAutoScrollEnableTitle": "Автопрокрутка вниз",
+  "displaySettingsPageAutoScrollIdleTitle": "Задержка автопрокрутки",
+  "displaySettingsPageAutoScrollIdleSubtitle": "Время ожидания после прокрутки пользователем перед переходом вниз",
+  "displaySettingsPageAutoScrollDisabledLabel": "Выкл",
+  "displaySettingsPageChatFontSampleText": "Это пример текста чата",
+  "displaySettingsPageChatBackgroundMaskTitle": "Непрозрачность наложения фона чата",
+  "displaySettingsPageChatInputBackgroundOpacityTitle": "Непрозрачность фона поля ввода",
+  "displaySettingsPageThemeSettingsTitle": "Настройки темы",
+  "displaySettingsPageThemeColorTitle": "Цвет темы",
+  "desktopSettingsFontsTitle": "Шрифты",
+  "displaySettingsPageTrayTitle": "Системный трей",
+  "displaySettingsPageTrayShowTrayTitle": "Показывать иконку в трее",
+  "displaySettingsPageTrayMinimizeOnCloseTitle": "Сворачивать в трей при закрытии",
+  "desktopFontAppLabel": "Шрифт приложения",
+  "desktopFontCodeLabel": "Шрифт кода",
+  "desktopFontFamilySystemDefault": "Системный по умолчанию",
+  "desktopFontFamilyMonospaceDefault": "Моноширинный",
+  "desktopFontFilterHint": "Фильтр шрифтов...",
+  "displaySettingsPageAppFontTitle": "Шрифт приложения",
+  "displaySettingsPageCodeFontTitle": "Шрифт кода",
+  "fontPickerChooseLocalFile": "Выбрать локальный файл",
+  "fontPickerGetFromGoogleFonts": "Просмотреть Google Fonts",
+  "fontPickerFilterHint": "Фильтр шрифтов...",
+  "desktopFontLoading": "Загрузка шрифтов…",
+  "displaySettingsPageFontLocalFileLabel": "Локальный файл",
+  "displaySettingsPageFontResetLabel": "Сбросить настройки шрифтов",
+  "displaySettingsPageOtherSettingsTitle": "Прочие настройки",
+  "themeSettingsPageDynamicColorSection": "Динамический цвет",
+  "themeSettingsPageUseDynamicColorTitle": "Системные динамические цвета",
+  "themeSettingsPageUseDynamicColorSubtitle": "Соответствовать системной палитре (Android 12+)",
+  "themeSettingsPageUsePureBackgroundTitle": "Чистый фон",
+  "themeSettingsPageUsePureBackgroundSubtitle": "Пузыри и акценты следуют теме.",
+  "themeSettingsPageColorPalettesSection": "Цветовые палитры",
+  "ttsServicesPageBackButton": "Назад",
+  "ttsServicesPageTitle": "Синтез речи",
+  "ttsServicesPageSettingsTooltip": "Настройки TTS",
+  "ttsServicesPageAddTooltip": "Добавить",
+  "ttsServicesPageAddNotImplemented": "Добавление TTS сервиса не реализовано",
+  "ttsServicesPageSystemTtsTitle": "Системный TTS",
+  "ttsServicesPageSystemTtsAvailableSubtitle": "Использовать встроенный системный TTS",
+  "ttsServicesPageSystemTtsUnavailableSubtitle": "Недоступен: {error}",
+  "@ttsServicesPageSystemTtsUnavailableSubtitle": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "ttsServicesPageSystemTtsUnavailableNotInitialized": "не инициализирован",
+  "ttsServicesPageTestSpeechText": "Привет, это тестовая речь.",
+  "ttsServicesPageConfigureTooltip": "Настроить",
+  "ttsServicesPageTestVoiceTooltip": "Тест голоса",
+  "ttsServicesPageStopTooltip": "Остановить",
+  "ttsServicesPageDeleteTooltip": "Удалить",
+  "ttsServicesPageSystemTtsSettingsTitle": "Настройки системного TTS",
+  "ttsServicesPageEngineLabel": "Движок",
+  "ttsServicesPageAutoLabel": "Авто",
+  "ttsServicesPageLanguageLabel": "Язык",
+  "ttsServicesPageSpeechRateLabel": "Скорость речи",
+  "ttsServicesPagePitchLabel": "Высота тона",
+  "ttsServicesPageSettingsSavedMessage": "Настройки сохранены.",
+  "ttsServicesPageDoneButton": "Готово",
+  "ttsServicesPageNetworkSectionTitle": "Сетевой TTS",
+  "ttsServicesPageNoNetworkServices": "Нет TTS сервисов.",
+  "ttsServicesDialogAddTitle": "Добавить TTS сервис",
+  "ttsServicesDialogEditTitle": "Редактировать TTS сервис",
+  "ttsServicesDialogProviderType": "Провайдер",
+  "ttsServicesDialogCancelButton": "Отмена",
+  "ttsServicesDialogAddButton": "Добавить",
+  "ttsServicesDialogSaveButton": "Сохранить",
+  "ttsServicesFieldNameLabel": "Имя",
+  "ttsServicesFieldApiKeyLabel": "API ключ",
+  "ttsServicesFieldBaseUrlLabel": "Базовый URL API",
+  "ttsServicesFieldModelLabel": "Модель",
+  "ttsServicesFieldVoiceLabel": "Голос",
+  "ttsServicesFieldVoiceIdLabel": "ID голоса",
+  "ttsServicesFieldEmotionLabel": "Эмоция",
+  "ttsServicesFieldSpeedLabel": "Скорость",
+  "ttsServicesFieldLanguageTypeLabel": "Тип языка",
+  "ttsServicesFieldLanguageLabel": "Язык",
+  "ttsServicesValidationApiKeyRequired": "API ключ обязателен",
+  "ttsServicesViewDetailsButton": "Просмотр подробностей",
+  "ttsServicesDialogErrorTitle": "Подробности ошибки",
+  "ttsServicesCloseButton": "Закрыть",
+  "ttsSettingsPageTitle": "Настройки TTS",
+  "ttsSettingsPlaybackSection": "Воспроизведение",
+  "ttsSettingsAutoPlayTitle": "Автовоспроизведение ответов ассистента",
+  "ttsSettingsAutoPlayDescription": "Автоматически запускать TTS после завершения ответа ассистента.",
+  "ttsSettingsTextSelectionSection": "Выбор текста",
+  "ttsSettingsTextSelectionFallbackDescription": "Если подходящий текст не найден, воспроизводится полный ответ.",
+  "ttsSettingsTextSelectionFullTextTitle": "Полный текст",
+  "ttsSettingsTextSelectionFullTextDescription": "Воспроизводить полный ответ ассистента.",
+  "ttsSettingsTextSelectionQuotedOnlyTitle": "Только текст в кавычках",
+  "ttsSettingsTextSelectionQuotedOnlyDescription": "Воспроизводить текст внутри \"\", '', \\\"\\\", '', 「」, или 『』.",
+  "ttsSettingsTextSelectionOutsideParenthesesTitle": "Вне скобок",
+  "ttsSettingsTextSelectionOutsideParenthesesDescription": "Пропускать текст внутри () и （）.",
+  "ttsSettingsTextSelectionItalicOnlyTitle": "Только курсивный текст",
+  "ttsSettingsTextSelectionItalicOnlyDescription": "Воспроизводить курсивный текст Markdown или HTML.",
+  "ttsSettingsTextSelectionNonItalicTitle": "Только некурсивный текст",
+  "ttsSettingsTextSelectionNonItalicDescription": "Пропускать курсивный текст Markdown или HTML.",
+  "ttsFloatingPlayerLabel": "TTS плеер",
+  "ttsFloatingPauseTooltip": "Пауза",
+  "ttsFloatingResumeTooltip": "Возобновить",
+  "ttsFloatingReplayTooltip": "Повтор",
+  "ttsFloatingRewind15Tooltip": "Назад 15 секунд",
+  "ttsFloatingForward15Tooltip": "Вперёд 15 секунд",
+  "ttsFloatingSpeedTooltip": "Скорость воспроизведения",
+  "ttsFloatingCloseTooltip": "Закрыть плеер",
+  "ttsFloatingExpandTooltip": "Развернуть элементы управления",
+  "ttsFloatingCollapseTooltip": "Свернуть элементы управления",
+  "imageViewerPageShareFailedOpenFile": "Не удалось поделиться, попытка открыть файл: {message}",
+  "@imageViewerPageShareFailedOpenFile": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerPageShareFailed": "Не удалось поделиться: {error}",
+  "@imageViewerPageShareFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerPageShareButton": "Поделиться изображением",
+  "imageViewerPageCloseButton": "Закрыть предпросмотр",
+  "imageViewerPageSaveButton": "Сохранить изображение",
+  "imageViewerPageCopyButton": "Копировать изображение",
+  "imageViewerPagePreviousButton": "Предыдущее изображение",
+  "imageViewerPageNextButton": "Следующее изображение",
+  "imageViewerPageZoomInButton": "Увеличить",
+  "imageViewerPageZoomOutButton": "Уменьшить",
+  "imageViewerPageResetZoomButton": "Сбросить масштаб",
+  "imageViewerPageFlipHorizontalButton": "Отразить горизонтально",
+  "imageViewerPageFlipVerticalButton": "Отразить вертикально",
+  "imageViewerPageRotateLeftButton": "Повернуть влево",
+  "imageViewerPageRotateRightButton": "Повернуть вправо",
+  "imageViewerPageCounter": "{index}/{total}",
+  "@imageViewerPageCounter": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "imageViewerPageImageLabel": "Изображение {index} из {total}",
+  "@imageViewerPageImageLabel": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "imageViewerPageImageLoadFailed": "Не удалось загрузить изображение",
+  "imageViewerPageSaveSuccess": "Сохранено в галерею",
+  "imageViewerPageSaveFailed": "Сохранение не удалось: {error}",
+  "@imageViewerPageSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsShare": "Kelivo - ИИ-ассистент с открытым исходным кодом",
+  "searchProviderBingLocalDescription": "Использует веб-скрапинг для получения результатов Bing. API ключ не требуется; может быть нестабильным.",
+  "searchProviderDuckDuckGoDescription": "Ориентированный на приватность поиск DuckDuckGo через DDGS. API ключ не требуется; поддерживает выбор региона.",
+  "searchProviderBraveDescription": "Независимая поисковая система от Brave. Ориентирована на приватность без отслеживания или профилирования.",
+  "searchProviderExaDescription": "Нейронный поиск с семантическим пониманием. Отлично подходит для исследований и поиска конкретного контента.",
+  "searchProviderLinkUpDescription": "API поиска с источниками ответов. Предоставляет как результаты, так и резюме, сгенерированные ИИ.",
+  "searchProviderMetasoDescription": "Китайский поиск от Metaso. Оптимизирован для китайского контента с возможностями ИИ.",
+  "searchProviderSearXNGDescription": "Метапоисковая система, уважающая приватность. Требуется самостоятельно размещённый экземпляр; без отслеживания.",
+  "searchProviderTavilyDescription": "API поиска ИИ, оптимизированный для LLM. Предоставляет высококачественные, релевантные результаты.",
+  "searchProviderZhipuDescription": "Китайский поиск ИИ от Zhipu AI. Оптимизирован для китайского контента и запросов.",
+  "searchProviderOllamaDescription": "API веб-поиска Ollama. Дополняет модели актуальной информацией.",
+  "searchProviderJinaDescription": "Основа поиска ИИ с эмбеддингами, ранжировщиками, веб-ридером, глубоким поиском и малыми языковыми моделями. Многоязычная и мультимодальная.",
+  "searchServiceNameBingLocal": "Bing (локальный)",
+  "searchServiceNameDuckDuckGo": "DuckDuckGo",
+  "searchServiceNameTavily": "Tavily",
+  "searchServiceNameExa": "Exa",
+  "searchServiceNameZhipu": "Zhipu AI",
+  "searchServiceNameSearXNG": "SearXNG",
+  "searchServiceNameLinkUp": "LinkUp",
+  "searchServiceNameBrave": "Brave Search",
+  "searchServiceNameMetaso": "Metaso",
+  "searchServiceNameOllama": "Ollama",
+  "searchServiceNameJina": "Jina",
+  "searchServiceNamePerplexity": "Perplexity",
+  "searchProviderPerplexityDescription": "API поиска Perplexity. Ранжированные веб-результаты с фильтрами региона и домена.",
+  "searchServiceNameBocha": "Bocha",
+  "searchProviderBochaDescription": "API веб-поиска Bocha. Точные веб-результаты с дополнительными резюме.",
+  "searchServiceNameSerper": "Serper",
+  "searchProviderSerperDescription": "API поиска Google Serper. Быстрые веб-результаты с дополнительными фильтрами страны, языка, времени и страницы.",
+  "searchServiceNameQuerit": "Querit",
+  "searchProviderQueritDescription": "API поиска Querit для LLM приложений. Возвращает веб-результаты в реальном времени с фильтрами сайта, времени, страны и языка.",
+  "searchServiceNameGrok": "Grok",
+  "searchProviderGrokDescription": "Поиск Grok через xAI Responses API. Использует инструменты веб-поиска и поиска X и возвращает цитируемые источники.",
+  "searchServicesDialogCountryOptional": "Страна/регион (необязательно)",
+  "searchServicesDialogLanguageOptional": "Язык (необязательно)",
+  "searchServicesDialogTimeFilterOptional": "Фильтр времени (необязательно)",
+  "searchServicesDialogPageOptional": "Страница (необязательно)",
+  "searchServicesDialogPageInvalid": "Страница должна быть положительным целым числом.",
+  "searchServicesDialogSitesIncludeOptional": "Включить сайты (необязательно)",
+  "searchServicesDialogSitesExcludeOptional": "Исключить сайты (необязательно)",
+  "searchServicesDialogTimeRangeOptional": "Временной диапазон (необязательно)",
+  "searchServicesDialogCountriesOptional": "Страны (необязательно)",
+  "searchServicesDialogLanguagesOptional": "Языки (необязательно)",
+  "searchServicesDialogSitesHint": "example.com, docs.example.com",
+  "searchServicesDialogTimeRangeHint": "d7",
+  "searchServicesDialogCountriesHint": "россия, япония",
+  "searchServicesDialogLanguagesHint": "русский, японский",
+  "generationInterrupted": "Генерация прервана",
+  "titleForLocale": "Новый чат",
+  "temporaryChatTitle": "Временный чат",
+  "temporaryChatEmptyMessage": "Временные чаты не появляются в истории и будут полностью удалены после выхода.",
+  "temporaryChatToggleTooltip": "Переключить временный чат",
+  "quickPhraseBackTooltip": "Назад",
+  "quickPhraseGlobalTitle": "Быстрые фразы",
+  "quickPhraseAssistantTitle": "Быстрые фразы ассистента",
+  "quickPhraseAddTooltip": "Добавить быструю фразу",
+  "quickPhraseEmptyMessage": "Быстрых фраз пока нет",
+  "quickPhraseAddTitle": "Добавить быструю фразу",
+  "quickPhraseEditTitle": "Редактировать быструю фразу",
+  "quickPhraseTitleLabel": "Заголовок",
+  "quickPhraseContentLabel": "Содержимое",
+  "quickPhraseCancelButton": "Отмена",
+  "quickPhraseSaveButton": "Сохранить",
+  "instructionInjectionTitle": "Внедрение инструкций",
+  "instructionInjectionBackTooltip": "Назад",
+  "instructionInjectionAddTooltip": "Добавить инструкцию",
+  "instructionInjectionImportTooltip": "Импорт из файлов",
+  "instructionInjectionEmptyMessage": "Карточек внедрения инструкций пока нет",
+  "instructionInjectionDefaultTitle": "Режим обучения",
+  "instructionInjectionAddTitle": "Добавить внедрение инструкции",
+  "instructionInjectionEditTitle": "Редактировать внедрение инструкции",
+  "instructionInjectionNameLabel": "Имя",
+  "instructionInjectionPromptLabel": "Промпт",
+  "instructionInjectionUngroupedGroup": "Без группы",
+  "instructionInjectionGroupLabel": "Группа",
+  "instructionInjectionGroupHint": "Необязательно",
+  "instructionInjectionImportSuccess": "Импортировано {count} инструкций",
+  "@instructionInjectionImportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "instructionInjectionSheetSubtitle": "Выберите промпт для применения перед чатом",
+  "mcpJsonEditButtonTooltip": "Редактировать JSON",
+  "mcpJsonEditTitle": "Редактировать JSON",
+  "mcpJsonEditParseFailed": "Парсинг JSON не удался",
+  "mcpJsonEditSavedApplied": "Сохранено и применено",
+  "mcpTimeoutSettingsTooltip": "Установить таймаут вызова инструмента",
+  "mcpTimeoutDialogTitle": "Таймаут вызова инструмента",
+  "mcpTimeoutSecondsLabel": "Таймаут вызова инструмента (секунды)",
+  "mcpTimeoutInvalid": "Введите положительное количество секунд",
+  "quickPhraseEditButton": "Редактировать",
+  "quickPhraseDeleteButton": "Удалить",
+  "quickPhraseMenuTitle": "Быстрые фразы",
+  "chatInputBarQuickPhraseTooltip": "Быстрые фразы",
+  "assistantEditQuickPhraseDescription": "Управляйте быстрыми фразами для этого ассистента. Нажмите кнопку ниже для добавления фраз.",
+  "assistantEditManageQuickPhraseButton": "Управление быстрыми фразами",
+  "assistantEditPageMemoryTab": "Память",
+  "assistantEditLocalToolTimeInfoTitle": "Информация о времени",
+  "assistantEditLocalToolTimeInfoSubtitle": "Читать дату устройства, день недели, время, часовой пояс, смещение UTC и временную метку.",
+  "assistantEditLocalToolClipboardTitle": "Буфер обмена",
+  "assistantEditLocalToolClipboardSubtitle": "Читать или записывать обычный текст из буфера обмена устройства при явной необходимости.",
+  "assistantEditLocalToolTextToSpeechTitle": "Синтез речи",
+  "assistantEditLocalToolTextToSpeechSubtitle": "Позволить ассистенту читать текст вслух с настроенным TTS воспроизведением.",
+  "assistantEditLocalToolAskUserTitle": "Спросить пользователя",
+  "assistantEditLocalToolAskUserSubtitle": "Позволить ассистенту задавать короткие вопросы и продолжать после вашего ответа.",
+  "assistantEditLocalToolCalculateTitle": "Калькулятор",
+  "assistantEditLocalToolCalculateSubtitle": "Вычислять математические выражения, поддерживает + - * / степень sqrt sin cos и т.д.",
+  "assistantEditMemorySwitchTitle": "Память",
+  "assistantEditMemorySwitchDescription": "Позволить ассистенту создавать и использовать воспоминания между чатами.",
+  "assistantEditRecentChatsSwitchTitle": "Ссылка на недавние чаты",
+  "assistantEditRecentChatsSwitchDescription": "Включать заголовки недавних диалогов для помощи с контекстом.",
+  "assistantEditManageMemoryTitle": "Управление воспоминаниями",
+  "assistantEditAddMemoryButton": "Добавить воспоминание",
+  "assistantEditMemoryEmpty": "Воспоминаний пока нет",
+  "assistantEditMemoryDialogTitle": "Воспоминание",
+  "assistantEditMemoryDialogHint": "Введите содержимое воспоминания",
+  "assistantEditAddQuickPhraseButton": "Добавить быструю фразу",
+  "multiKeyPageDeleteSnackbarDeletedOne": "Удалён 1 ключ",
+  "multiKeyPageUndo": "Отменить",
+  "multiKeyPageUndoRestored": "Восстановлено",
+  "multiKeyPageDeleteErrorsTooltip": "Удалить ошибки",
+  "multiKeyPageDeleteErrorsConfirmTitle": "Удалить все ключи с ошибками?",
+  "multiKeyPageDeleteErrorsConfirmContent": "Это удалит все ключи, помеченные как ошибочные.",
+  "multiKeyPageDeletedErrorsSnackbar": "Удалено {n} ключей с ошибками",
+  "@multiKeyPageDeletedErrorsSnackbar": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "providerDetailPageProviderTypeTitle": "Тип провайдера",
+  "displaySettingsPageChatItemDisplayTitle": "Отображение элементов чата",
+  "displaySettingsPageRenderingSettingsTitle": "Настройки рендеринга",
+  "displaySettingsPageBehaviorStartupTitle": "Поведение и запуск",
+  "displaySettingsPageHapticsSettingsTitle": "Тактильная обратная связь",
+  "assistantSettingsNoPromptPlaceholder": "Промпта пока нет",
+  "providersPageMultiSelectTooltip": "Множественный выбор",
+  "providersPageDeleteSelectedConfirmContent": "Удалить выбранных провайдеров? Это действие нельзя отменить.",
+  "providersPageDeleteSelectedSnackbar": "Выбранные провайдеры удалены",
+  "providersPageExportSelectedTitle": "Экспорт {count} провайдеров",
+  "@providersPageExportSelectedTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "providersPageExportCopyButton": "Копировать",
+  "providersPageExportShareButton": "Поделиться",
+  "providersPageExportCopiedSnackbar": "Код экспорта скопирован",
+  "providersPageDeleteAction": "Удалить",
+  "providersPageExportAction": "Экспорт",
+  "assistantEditPresetTitle": "Предустановленный диалог",
+  "assistantEditPresetAddUser": "Добавить предустановку пользователя",
+  "assistantEditPresetAddAssistant": "Добавить предустановку ассистента",
+  "assistantEditPresetInputHintUser": "Введите сообщение пользователя…",
+  "assistantEditPresetInputHintAssistant": "Введите сообщение ассистента…",
+  "assistantEditPresetEmpty": "Предустановленных сообщений пока нет",
+  "assistantEditPresetEditDialogTitle": "Редактировать предустановленное сообщение",
+  "assistantEditPresetRoleUser": "Пользователь",
+  "assistantEditPresetRoleAssistant": "Ассистент",
+  "desktopTtsPleaseAddProvider": "Сначала добавьте TTS провайдера",
+  "settingsPageNetworkProxy": "Сетевой прокси",
+  "networkProxyEnableLabel": "Включить прокси",
+  "networkProxySettingsHeader": "Настройки прокси",
+  "networkProxyType": "Тип прокси",
+  "networkProxyTypeHttp": "HTTP",
+  "networkProxyTypeHttps": "HTTPS",
+  "networkProxyTypeSocks5": "SOCKS5",
+  "networkProxyServerHost": "Сервер",
+  "networkProxyPort": "Порт",
+  "networkProxyUsername": "Имя пользователя",
+  "networkProxyPassword": "Пароль",
+  "networkProxyBypassLabel": "Обход прокси",
+  "networkProxyBypassHint": "Хосты/CIDR через запятую, например localhost,127.0.0.1,192.168.0.0/16,*.local",
+  "networkProxyOptionalHint": "Необязательно",
+  "networkProxyTestHeader": "Тест соединения",
+  "networkProxyTestUrlHint": "Тестовый URL",
+  "networkProxyTestButton": "Тест",
+  "networkProxyTesting": "Тестирование…",
+  "networkProxyTestSuccess": "Соединение успешно",
+  "networkProxyTestFailed": "Тест не удался: {error}",
+  "@networkProxyTestFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "networkProxyNoUrl": "Введите URL",
+  "networkProxyPriorityNote": "Когда включены и глобальный, и прокси провайдера, приоритет имеет прокси уровня провайдера.",
+  "desktopShowProviderInModelCapsule": "Показывать провайдера в капсуле модели",
+  "messageWebViewOpenInBrowser": "Открыть в браузере",
+  "messageWebViewConsoleLogs": "Логи консоли",
+  "messageWebViewNoConsoleMessages": "Нет сообщений консоли",
+  "messageWebViewRefreshTooltip": "Обновить",
+  "messageWebViewForwardTooltip": "Вперёд",
+  "chatInputBarOcrTooltip": "OCR изображения",
+  "providerDetailPageMultiSelectButton": "Множественный выбор",
+  "providerDetailPageBatchDetectButton": "Обнаружить",
+  "providerDetailPageBatchDetecting": "Обнаружение...",
+  "providerDetailPageBatchDetectStart": "Начать обнаружение",
+  "providerDetailPageDetectSuccess": "Обнаружение успешно",
+  "providerDetailPageDetectFailed": "Обнаружение не удалось",
+  "providerDetailPageDeleteSelectedModelsButton": "Удалить",
+  "providerDetailPageDeleteSelectedModelsTooltip": "Удалить выбранные модели",
+  "providerDetailPageDeleteSelectedModelsConfirm": "Удалить {count} выбранных моделей? Это действие нельзя отменить.",
+  "@providerDetailPageDeleteSelectedModelsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "providerDetailPageDeleteFailedDetectedModelsButton": "Удалить недоступные",
+  "providerDetailPageDeleteFailedDetectedModelsTooltip": "Удалить модели, которые не прошли обнаружение",
+  "providerDetailPageDeleteFailedDetectedModelsConfirm": "Удалить {count} моделей, которые не прошли обнаружение? Это действие нельзя отменить.",
+  "@providerDetailPageDeleteFailedDetectedModelsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "providerDetailPageSelectedModelsDeletedSnackbar": "Удалено {count} моделей",
+  "@providerDetailPageSelectedModelsDeletedSnackbar": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "providerDetailPageDeleteAllModelsTooltip": "Удалить все модели",
+  "providerDetailPageDeleteAllModelsWarning": "Это действие нельзя отменить.",
+  "requestLogSettingTitle": "Логирование запросов",
+  "requestLogSettingSubtitle": "При включении детали запросов/ответов записываются в logs/logs.txt (ротация ежедневно).",
+  "flutterLogSettingTitle": "Логирование Flutter",
+  "flutterLogSettingSubtitle": "При включении ошибки Flutter и вывод print записываются в logs/flutter_logs.txt (ротация ежедневно).",
+  "logViewerTitle": "Логи запросов",
+  "logViewerEmpty": "Логов пока нет",
+  "logViewerCurrentLog": "Текущий лог",
+  "logViewerExport": "Экспорт",
+  "logViewerOpenFolder": "Открыть папку логов",
+  "logViewerRequestsCount": "{count} запросов",
+  "@logViewerRequestsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "logViewerFieldId": "ID",
+  "logViewerFieldMethod": "Метод",
+  "logViewerFieldStatus": "Статус",
+  "logViewerFieldStarted": "Начато",
+  "logViewerFieldEnded": "Завершено",
+  "logViewerFieldDuration": "Длительность",
+  "logViewerSectionSummary": "Резюме",
+  "logViewerSectionParameters": "Параметры",
+  "logViewerSectionRequestHeaders": "Заголовки запроса",
+  "logViewerSectionRequestBody": "Тело запроса",
+  "logViewerSectionResponseHeaders": "Заголовки ответа",
+  "logViewerSectionResponseBody": "Тело ответа",
+  "logViewerSectionWarnings": "Предупреждения",
+  "logViewerErrorTitle": "Ошибка",
+  "logViewerMoreCount": "+{count} ещё",
+  "@logViewerMoreCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "logSettingsTitle": "Настройки логов",
+  "logSettingsSaveOutput": "Сохранять вывод ответов",
+  "logSettingsSaveOutputSubtitle": "Логировать содержимое тела ответа (может использовать значительное место)",
+  "logSettingsAutoDelete": "Автоудаление",
+  "logSettingsAutoDeleteSubtitle": "Удалять логи старше указанного количества дней",
+  "logSettingsAutoDeleteDisabled": "Отключено",
+  "logSettingsAutoDeleteDays": "{count} дней",
+  "@logSettingsAutoDeleteDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "logSettingsMaxSize": "Максимальный размер лога",
+  "logSettingsMaxSizeSubtitle": "Самые старые логи удаляются при превышении",
+  "logSettingsMaxSizeUnlimited": "Неограниченно",
+  "assistantEditManageSummariesTitle": "Управление резюме",
+  "assistantEditSummaryEmpty": "Резюме пока нет",
+  "assistantEditSummaryDialogTitle": "Редактировать резюме",
+  "assistantEditSummaryDialogHint": "Введите содержимое резюме",
+  "assistantEditDeleteSummaryTitle": "Очистить резюме",
+  "assistantEditDeleteSummaryContent": "Вы уверены, что хотите очистить это резюме?",
+  "homePageProcessingFiles": "Обработка файлов...",
+  "fileUploadDuplicateTitle": "Файл уже существует",
+  "fileUploadDuplicateContent": "Файл с именем {fileName} уже существует. Использовать существующий файл?",
+  "@fileUploadDuplicateContent": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "fileUploadDuplicateUseExisting": "Использовать существующий",
+  "fileUploadDuplicateUploadNew": "Загрузить новый",
+  "settingsPageWorldBook": "Книга мира",
+  "worldBookTitle": "Книга мира",
+  "worldBookAdd": "Добавить книгу мира",
+  "worldBookEmptyMessage": "Книг мира пока нет",
+  "worldBookUnnamed": "Книга мира без названия",
+  "worldBookDisabledTag": "Отключена",
+  "worldBookAlwaysOnTag": "Всегда включена",
+  "worldBookAddEntry": "Добавить запись",
+  "worldBookExport": "Поделиться / Экспорт",
+  "worldBookConfig": "Настроить",
+  "worldBookDeleteTitle": "Удалить книгу мира",
+  "worldBookDeleteMessage": "Удалить \"{name}\"? Это действие нельзя отменить.",
+  "@worldBookDeleteMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "worldBookCancel": "Отмена",
+  "worldBookDelete": "Удалить",
+  "worldBookExportFailed": "Экспорт не удался: {error}",
+  "@worldBookExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "worldBookNoEntriesHint": "Нет записей",
+  "worldBookUnnamedEntry": "Запись без названия",
+  "worldBookKeywordsLine": "Ключевые слова: {keywords}",
+  "@worldBookKeywordsLine": {
+    "placeholders": {
+      "keywords": {
+        "type": "String"
+      }
+    }
+  },
+  "worldBookEditEntry": "Редактировать запись",
+  "worldBookDeleteEntry": "Удалить запись",
+  "worldBookNameLabel": "Имя",
+  "worldBookDescriptionLabel": "Описание",
+  "worldBookEnabledLabel": "Включена",
+  "worldBookSave": "Сохранить",
+  "worldBookEntryNameLabel": "Название записи",
+  "worldBookEntryEnabledLabel": "Запись включена",
+  "worldBookEntryPriorityLabel": "Приоритет",
+  "worldBookEntryKeywordsLabel": "Ключевые слова",
+  "worldBookEntryKeywordsHint": "Введите ключевое слово и нажмите + для добавления.",
+  "worldBookEntryKeywordInputHint": "Введите ключевое слово",
+  "worldBookEntryKeywordAddTooltip": "Добавить ключевое слово",
+  "worldBookEntryUseRegexLabel": "Использовать regex",
+  "worldBookEntryCaseSensitiveLabel": "Учитывать регистр",
+  "worldBookEntryAlwaysOnLabel": "Всегда активна",
+  "worldBookEntryAlwaysOnHint": "Всегда внедрять без сопоставления ключевых слов",
+  "worldBookEntryScanDepthLabel": "Глубина сканирования",
+  "worldBookEntryContentLabel": "Содержимое",
+  "worldBookEntryInjectionPositionLabel": "Позиция внедрения",
+  "worldBookEntryInjectionRoleLabel": "Роль внедрения",
+  "worldBookEntryInjectDepthLabel": "Глубина внедрения",
+  "worldBookInjectionPositionBeforeSystemPrompt": "Перед системным промптом",
+  "worldBookInjectionPositionAfterSystemPrompt": "После системного промпта",
+  "worldBookInjectionPositionTopOfChat": "Вверху чата",
+  "worldBookInjectionPositionBottomOfChat": "Внизу чата",
+  "worldBookInjectionPositionAtDepth": "На глубине",
+  "worldBookInjectionRoleUser": "Пользователь",
+  "worldBookInjectionRoleAssistant": "Ассистент",
+  "mcpToolNeedsApproval": "Требует одобрения",
+  "toolApprovalPending": "Ожидание одобрения",
+  "toolApprovalApprove": "Одобрить",
+  "toolApprovalDeny": "Отклонить",
+  "toolApprovalDenyTitle": "Отклонить вызов инструмента",
+  "toolApprovalDenyHint": "Причина (необязательно)",
+  "toolApprovalDeniedMessage": "Вызов инструмента \"{toolName}\" был отклонён пользователем. Причина: {reason}",
+  "askUserCardSubmit": "Отправить ответ",
+  "askUserCardCustomHint": "Введите ваш ответ",
+  "askUserCardSomethingElse": "Что-то ещё",
+  "askUserCardSkip": "Пропустить",
+  "askUserCardSkipped": "Пропущено",
+  "askUserCardAnswered": "Отвечено",
+  "askUserCardInactive": "Этот вопрос больше не активен. Перегенерируйте или продолжите диалог.",
+  "askUserCardCancelled": "Вопрос отменён",
+  "askUserCardQuestionCount": "{count, plural, =1{Задать 1 вопрос} other{Задать {count} вопросов}}",
+  "@askUserCardQuestionCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tokenDetailPromptTokens": "{count} токенов",
+  "@tokenDetailPromptTokens": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tokenDetailPromptTokensWithCache": "{count} токенов ({cached} кэшированных)",
+  "@tokenDetailPromptTokensWithCache": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "cached": {
+        "type": "int"
+      }
+    }
+  },
+  "tokenDetailCompletionTokens": "{count} токенов",
+  "@tokenDetailCompletionTokens": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tokenDetailSpeed": "{value} токен/с",
+  "@tokenDetailSpeed": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "tokenDetailDuration": "{value}с",
+  "@tokenDetailDuration": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "tokenDetailTotalTokens": "{count} токенов",
+  "@tokenDetailTotalTokens": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageTitle": "Отладка",
+  "debugPageConversationToolsTitle": "Инструменты диалога",
+  "debugPageCreateOversizedConversationButton": "Создать огромный диалог (30 МБ)",
+  "debugPageCreateManyMessagesConversationButton": "Создать диалог с 1024 сообщениями",
+  "debugPageCreateDailyMixedMarkdownConversationButton": "Создать 3000 ежедневных смешанных Markdown сообщений",
+  "debugPageCreateLongReasoningConversationButton": "Создать диалог с длинными размышлениями (128 сообщений)",
+  "debugPageCreatingButton": "Создание...",
+  "debugPageCreatingOversizedConversation": "Создание огромного диалога 30 МБ...",
+  "debugPageCreatingManyMessagesConversation": "Создание диалога с 1024 сообщениями...",
+  "debugPageCreatingDailyMixedMarkdownConversation": "Создание диалога с 3000 ежедневными смешанными Markdown сообщениями...",
+  "debugPageCreatingLongReasoningConversation": "Создание отладочного диалога с длинными размышлениями...",
+  "debugPageNoCurrentAssistant": "Нет текущего ассистента. Сначала создайте или выберите ассистента.",
+  "debugPageConversationCreated": "Создан отладочный диалог с {count} сообщениями.",
+  "@debugPageConversationCreated": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageCreateConversationFailed": "Не удалось создать отладочный диалог: {error}",
+  "@debugPageCreateConversationFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "debugPageOversizedConversationTitle": "Тест огромного диалога ({sizeMB} МБ)",
+  "@debugPageOversizedConversationTitle": {
+    "placeholders": {
+      "sizeMB": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageManyMessagesConversationTitle": "Тест диалога с {count} сообщениями",
+  "@debugPageManyMessagesConversationTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageDailyMixedMarkdownConversationTitle": "Тест {count} ежедневных смешанных Markdown сообщений",
+  "@debugPageDailyMixedMarkdownConversationTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageLongReasoningConversationTitle": "Тест длинных размышлений с {count} сообщениями",
+  "@debugPageLongReasoningConversationTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "debugPageOversizedConversationSeedText": "Это длинный отладочный текст для воспроизведения медленного рендеринга в огромных диалогах. Он включает повторяющийся Markdown-подобный текст, пунктуацию, CJK контент и обычные слова, чтобы можно было профилировать рендеринг чата, хранение и прокрутку.",
+  "debugPageManyMessagesSeedText": "Сообщение {role} №{index}: быстрый случайный отладочный образец для тестирования рендеринга списка, стабильности прокрутки, группировки сообщений и производительности истории диалогов.",
+  "@debugPageManyMessagesSeedText": {
+    "placeholders": {
+      "role": {
+        "type": "String"
+      },
+      "index": {
+        "type": "int"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds complete Russian (ru) localization for Kelivo.

This PR rebases the original work from #757 onto current master and
squashes the previous 10 commits into a single, reviewable commit.

What is included
- New file: lib/l10n/app_ru.arb
  Full Russian translation of all 1725 keys from app_en.arb (1:1 with
  the English template, 0 empty values). Structure is synchronized with
  app_en.arb; ICU `plural` keyword uses a single `other` branch, matching
  the rest of the project.
- Modified: lib/core/providers/settings_provider.dart
  Adds `ru` handling in `_localeToTag` / `_parseLocaleTag`, mirroring the
  existing `zh` / `en` logic (`ru` -> `ru_RU` tag, round-trip back to
  `Locale(ru, RU)`).

Verification
- Translation key coverage: 1725 / 1725 EN keys present in app_ru.arb
  (script-verified; 0 empty values).
- Build verification: `flutter build apk --release` succeeds on this
  branch against Flutter 3.44.1 / Dart 3.12.1 (see workflow runs #9
  and #10 in Bront1483/kelivo before the rebased PR was opened).
- Equivalent in scope to existing `app_zh_Hans.arb` (1705 keys) — see
  comparison of upstream `lib/l10n/` directory.

Notes for reviewer
- The original PR body was in Russian; this rebased version uses an
  English description for accessibility to the wider community.
- No new dependencies introduced; no other files modified.
- Happy to split into separate commits (translation vs. provider patch)
  or to address any locale-handling feedback.