### PR TITLE
fix: 对于 openai 图像响应，首选 b64_json

### DIFF
--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -471,20 +471,22 @@ Future<String> _openAIImagesResponseToMarkdown(
   final lines = <String>[];
   for (final item in data) {
     if (item is! Map) continue;
+    final b64 = (item['b64_json'] ?? '').toString().trim();
+    if (b64.isNotEmpty) {
+      final path = await AppDirectories.saveBase64Image(outputMime, b64);
+      if (path == null || path.isEmpty) {
+        throw const FileSystemException(
+          'Failed to save OpenAI Images API base64 image.',
+        );
+      }
+      lines.add('![image]($path)');
+      continue;
+    }
+
     final url = (item['url'] ?? '').toString().trim();
     if (url.isNotEmpty) {
       lines.add('![image]($url)');
-      continue;
     }
-    final b64 = (item['b64_json'] ?? '').toString().trim();
-    if (b64.isEmpty) continue;
-    final path = await AppDirectories.saveBase64Image(outputMime, b64);
-    if (path == null || path.isEmpty) {
-      throw const FileSystemException(
-        'Failed to save OpenAI Images API base64 image.',
-      );
-    }
-    lines.add('![image]($path)');
   }
   return lines.join('\n\n');
 }

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -513,6 +513,57 @@ void main() {
       expect(await File(imagePath).readAsBytes(), const [1, 2, 3, 4]);
     });
 
+    test('prefers base64 image over url when both are returned', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'kelivo_openai_b64_preferred_',
+      );
+      final previousPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+      addTearDown(() async {
+        PathProviderPlatform.instance = previousPathProvider;
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await request.drain<void>();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'data': [
+              {
+                'url': 'https://example.com/remote.png',
+                'b64_json': base64Encode(const [5, 6, 7, 8]),
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAiConfig(_baseUrl(server)),
+        modelId: 'gpt-image-2',
+        messages: const [
+          {'role': 'user', 'content': 'draw a tabby cat'},
+        ],
+      ).toList();
+
+      final imagePath = RegExp(
+        r'!\[image\]\(([^)]+)\)',
+      ).firstMatch(chunks.single.content)!.group(1)!;
+      expect(chunks.single.content, isNot(contains('https://example.com')));
+      expect(imagePath.endsWith('.png'), isTrue);
+      expect(await File(imagePath).readAsBytes(), const [5, 6, 7, 8]);
+    });
+
     test(
       'throws instead of rendering null when base64 image save fails',
       () async {


### PR DESCRIPTION
## 问题
在使用 OpenAI 兼容的图片中转站时，`/images/generations` 响应里同时返回 `url` 和 `b64_json`。
Kelivo 会先处理 `url`，忽略 `b64_json`，大多时候中转站的 `url` 并不是长期有效的，而且客户端加载 `url` 时间过长，容易以为是没有返回。

## 解决方案
当响应里存在 `b64_json` 时，优先使用它，并通过现有的本地图片保存逻辑保存图片，并在对话内容使用本地路径。只有在没有返回 `base64` 图片数据时，才回退使用 `url`。