### PR TITLE
feat(openai): render server-executed tool events as native tool cards

### DIFF
--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -3090,6 +3090,71 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               finishReason = 'tool_calls';
             }
           }
+          // Server-executed tool events (root-level extension field).
+          // Gateways/bridges that run tools on the server side (agent proxies,
+          // Claude Code bridges, middleware layers) can emit
+          //   {"server_tool_event": {"type": "tool_use"|"tool_result", ...}}
+          // alongside normal deltas so tool activity renders as native tool
+          // cards and splits thinking segments, instead of being glued into
+          // reasoning_content as plain text.
+          // Unlike root-level tool_calls above (a request for the CLIENT to
+          // execute a tool), these events are purely presentational: they do
+          // NOT trigger client-side tool execution and do NOT alter
+          // finish_reason. Unknown/absent field costs nothing.
+          final serverToolEvent = json['server_tool_event'] as Map<String, dynamic>?;
+          if (serverToolEvent != null && config.useResponseApi != true) {
+            final evType = (serverToolEvent['type'] ?? '').toString();
+            if (evType == 'tool_use') {
+              final evId = (serverToolEvent['id'] ?? 'srv_call').toString();
+              final evName = (serverToolEvent['name'] ?? 'tool').toString();
+              final evInputRaw =
+                  serverToolEvent['input'] ?? serverToolEvent['input_preview'];
+              Map<String, dynamic> evArgs;
+              try {
+                if (evInputRaw is String && evInputRaw.isNotEmpty) {
+                  evArgs = (jsonDecode(evInputRaw) as Map).cast<String, dynamic>();
+                } else if (evInputRaw is Map) {
+                  evArgs = evInputRaw.cast<String, dynamic>();
+                } else {
+                  evArgs = const <String, dynamic>{};
+                }
+              } catch (_) {
+                evArgs = const <String, dynamic>{};
+              }
+              yield ChatStreamChunk(
+                content: '',
+                isDone: false,
+                totalTokens: totalTokens,
+                toolCalls: [
+                  ToolCallInfo(id: evId, name: evName, arguments: evArgs),
+                ],
+              );
+            } else if (evType == 'tool_result') {
+              final evId = (serverToolEvent['id'] ?? '').toString();
+              final evName = (serverToolEvent['name'] ?? '').toString();
+              final evContent = (serverToolEvent['content_preview'] ??
+                      serverToolEvent['content'] ??
+                      '')
+                  .toString();
+              final evIsError = serverToolEvent['is_error'] == true;
+              yield ChatStreamChunk(
+                content: '',
+                isDone: false,
+                totalTokens: totalTokens,
+                toolResults: [
+                  ToolResultInfo(
+                    id: evId,
+                    name: evName,
+                    arguments: const <String, dynamic>{},
+                    content: evContent,
+                    metadata: evIsError
+                        ? const <String, dynamic>{'is_error': true}
+                        : null,
+                  ),
+                ],
+              );
+            }
+          }
           usage = _mergeOpenAICompatibleUsage(usage, json['usage']);
           if (usage != null) totalTokens = usage.totalTokens;
         }


### PR DESCRIPTION
## Motivation

A growing class of OpenAI-compatible backends are **gateways/bridges that execute tools on the server side** — agent proxies, Claude Code bridges, LiteLLM-style middleware. The model calls tools, the server runs them, and the client only sees the final stream.

Today, the only way such a backend can show tool activity in Kelivo is to inject text into `reasoning_content`. The result: **the user's actual thinking and all tool call/result traffic get glued into one single thinking bubble** — no native tool cards, no thinking segmentation, and long tool outputs drown the reasoning.

Kelivo already renders beautiful tool cards for client-executed tools. This PR lets server-side-execution backends light up that same UI.

## What this adds

Parsing of one root-level extension field in the OpenAI-compatible SSE stream:

```json
{"server_tool_event": {"type": "tool_use",    "id": "t1", "name": "memory_search", "input": {"q": "..."}}}
{"server_tool_event": {"type": "tool_result", "id": "t1", "name": "memory_search", "content": "...", "is_error": false}}
```

- Each `tool_use` yields a `ChatStreamChunk(toolCalls: ...)` → closes the current thinking segment and opens a native tool card.
- Each `tool_result` yields `ChatStreamChunk(toolResults: ...)` → fills the card (expandable, error-aware).
- Net effect for the user: *thinking bubble → tool card → thinking bubble → final answer*, exactly like client-executed tools.

## Design notes / safety

- **Purely presentational.** Unlike the root-level `tool_calls` (XinLiu) path just above the insertion point — which asks the *client* to execute a tool — this path never triggers `onToolCall`, never touches `finishReason`, and never feeds anything back to the API. No agent-loop risk.
- **Zero cost when absent.** One null-check per SSE line for streams that don't use the field.
- Skipped when `config.useResponseApi == true`, consistent with neighboring compatibility paths.

## Tested

Running against a self-hosted Claude Code bridge (OpenAI-compatible, server-side MCP tool execution) that emits these events: thinking segments split correctly at each tool boundary, tool cards render with input/result, error results are marked via `metadata.is_error`. Streams without the field are unaffected.

Happy to adjust the field name or shape if you'd prefer a different extension convention — the backend side is under our control and easy to adapt.