### PR TITLE
记忆归档：目录常驻 + 按需取用（北极星模式），记忆时间戳降为天级

### DIFF
--- a/lib/core/models/assistant_memory_doc.dart
+++ b/lib/core/models/assistant_memory_doc.dart
@@ -1,0 +1,52 @@
+class AssistantMemoryDoc {
+  final int id; // 0 for new (not used in store), >0 persisted
+  final String assistantId;
+  final String title;
+  final String summary;
+  final String content;
+  final int updatedAt; // millisecondsSinceEpoch
+
+  const AssistantMemoryDoc({
+    required this.id,
+    required this.assistantId,
+    required this.title,
+    required this.summary,
+    required this.content,
+    required this.updatedAt,
+  });
+
+  AssistantMemoryDoc copyWith({
+    int? id,
+    String? assistantId,
+    String? title,
+    String? summary,
+    String? content,
+    int? updatedAt,
+  }) => AssistantMemoryDoc(
+    id: id ?? this.id,
+    assistantId: assistantId ?? this.assistantId,
+    title: title ?? this.title,
+    summary: summary ?? this.summary,
+    content: content ?? this.content,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'assistantId': assistantId,
+    'title': title,
+    'summary': summary,
+    'content': content,
+    'updatedAt': updatedAt,
+  };
+
+  static AssistantMemoryDoc fromJson(Map<String, dynamic> json) =>
+      AssistantMemoryDoc(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        assistantId: (json['assistantId'] ?? '').toString(),
+        title: (json['title'] ?? '').toString(),
+        summary: (json['summary'] ?? '').toString(),
+        content: (json['content'] ?? '').toString(),
+        updatedAt: (json['updatedAt'] as num?)?.toInt() ?? 0,
+      );
+}

--- a/lib/core/services/memory_doc_store.dart
+++ b/lib/core/services/memory_doc_store.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/assistant_memory_doc.dart';
+
+/// Storage for long-form memory docs. Unlike [MemoryStore] entries, doc
+/// contents are never injected wholesale; only a catalog (title + summary)
+/// goes into the system prompt and the model fetches full text on demand
+/// via the read_memory_doc tool.
+class MemoryDocStore {
+  static const String _docsKey = 'assistant_memory_docs_v1';
+
+  static List<AssistantMemoryDoc>? _cache;
+
+  static Future<List<AssistantMemoryDoc>> _loadAllInternal() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_docsKey);
+    if (raw == null || raw.isEmpty) return <AssistantMemoryDoc>[];
+    try {
+      final arr = jsonDecode(raw) as List<dynamic>;
+      return [
+        for (final e in arr)
+          if (e is Map<String, dynamic>)
+            AssistantMemoryDoc.fromJson(e)
+          else
+            AssistantMemoryDoc.fromJson((e as Map).cast<String, dynamic>()),
+      ];
+    } catch (_) {
+      return <AssistantMemoryDoc>[];
+    }
+  }
+
+  static Future<List<AssistantMemoryDoc>> getAll() async {
+    _cache ??= await _loadAllInternal();
+    return List<AssistantMemoryDoc>.of(_cache!);
+  }
+
+  static Future<void> _saveAll(List<AssistantMemoryDoc> list) async {
+    _cache = List<AssistantMemoryDoc>.of(list);
+    final prefs = await SharedPreferences.getInstance();
+    final json = jsonEncode(list.map((e) => e.toJson()).toList());
+    await prefs.setString(_docsKey, json);
+  }
+
+  static Future<List<AssistantMemoryDoc>> getForAssistant(
+    String assistantId,
+  ) async {
+    final all = await getAll();
+    return all.where((d) => d.assistantId == assistantId).toList();
+  }
+
+  static Future<AssistantMemoryDoc?> getById(int id) async {
+    final all = await getAll();
+    for (final d in all) {
+      if (d.id == id) return d;
+    }
+    return null;
+  }
+
+  static int _nextId(List<AssistantMemoryDoc> list) {
+    int maxId = 0;
+    for (final d in list) {
+      if (d.id > maxId) maxId = d.id;
+    }
+    return maxId + 1;
+  }
+
+  static Future<AssistantMemoryDoc> add({
+    required String assistantId,
+    required String title,
+    required String summary,
+    required String content,
+  }) async {
+    final all = await getAll();
+    final id = _nextId(all);
+    final doc = AssistantMemoryDoc(
+      id: id,
+      assistantId: assistantId,
+      title: title,
+      summary: summary,
+      content: content,
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+    );
+    all.add(doc);
+    await _saveAll(all);
+    return doc;
+  }
+
+  static Future<AssistantMemoryDoc?> update({
+    required int id,
+    String? title,
+    String? summary,
+    String? content,
+  }) async {
+    final all = await getAll();
+    final idx = all.indexWhere((d) => d.id == id);
+    if (idx == -1) return null;
+    final updated = all[idx].copyWith(
+      title: title,
+      summary: summary,
+      content: content,
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+    );
+    all[idx] = updated;
+    await _saveAll(all);
+    return updated;
+  }
+
+  static Future<bool> delete({required int id}) async {
+    final all = await getAll();
+    final before = all.length;
+    all.removeWhere((d) => d.id == id);
+    final changed = all.length != before;
+    if (changed) await _saveAll(all);
+    return changed;
+  }
+}

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -14,6 +14,7 @@ import '../../../core/providers/user_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/chat/document_text_extractor.dart';
 import '../../../core/services/chat/prompt_transformer.dart';
+import '../../../core/services/memory_doc_store.dart';
 import '../../../core/services/instruction_injection_store.dart';
 import '../../../core/services/world_book_store.dart';
 import '../../../core/services/search/search_tool_service.dart';
@@ -538,7 +539,7 @@ class MessageBuilderService {
         final mp = contextProvider.read<MemoryProvider>();
         await mp.initialize();
         final mems = mp.getForAssistant(assistant!.id);
-        final currentHour = _formatCurrentHour(DateTime.now());
+        final currentDay = _formatCurrentDay(DateTime.now());
         final buf = StringBuffer();
         buf.writeln('## Memories');
         buf.writeln(
@@ -570,11 +571,25 @@ class MessageBuilderService {
 - 首次聊天时间
 - ...
 请主动调用工具记录，而不是需要用户要求。
-记忆如果包含日期信息，请包含在内，请使用绝对时间格式，并且当前时间是$currentHour。
+记忆如果包含日期信息，请包含在内，请使用绝对时间格式，并且今天是$currentDay。
 无需告知用户你已更改记忆记录，也不要在对话中直接显示记忆内容，除非用户主动要求。
 相似或相关的记忆应合并为一条记录，而不要重复记录，过时记录应删除。
 你可以在和用户闲聊的时候暗示用户你能记住东西。
 ''');
+        final docs = await MemoryDocStore.getForAssistant(assistant!.id);
+        buf.writeln('''
+## Memory Archive
+除了上面的短记忆，你还有按需取用的长期资料和过往对话，当前上下文只包含目录：
+- 需要查找过往对话时，先用 `search_past_chats` 搜索，再用 `read_chat` 读取原文。
+- 需要长期资料内容时，用 `read_memory_doc` 读取全文；用户要求存档长内容时用 `write_memory_doc`（给出标题和一句话摘要），过时资料用 `delete_memory_doc` 删除。
+你现在只看到了目录和摘要；引用任何具体内容前必须先调用工具读取全文，不要凭目录假装读过正文。
+<memory_docs>''');
+        for (final d in docs) {
+          buf.writeln(
+            '<doc><id>${d.id}</id><title>${d.title}</title><chars>${d.content.length}</chars><summary>${d.summary}</summary></doc>',
+          );
+        }
+        buf.writeln('</memory_docs>');
         _appendToSystemMessage(apiMessages, buf.toString());
       }
       if (assistant?.enableRecentChatsReference == true) {
@@ -612,8 +627,10 @@ class MessageBuilderService {
     } catch (_) {}
   }
 
-  String _formatCurrentHour(DateTime now) {
-    return '${now.year}年${now.month}月${now.day}日的${now.hour}点';
+  // Day granularity on purpose: this string lands in the system prompt, and
+  // an hourly timestamp would invalidate the provider prompt cache every hour.
+  String _formatCurrentDay(DateTime now) {
+    return '${now.year}年${now.month}月${now.day}日';
   }
 
   /// Inject search tool usage prompt into apiMessages.

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -10,8 +10,11 @@ import '../../../core/providers/memory_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/tts_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/mcp/mcp_tool_service.dart';
+import '../../../core/services/memory_doc_store.dart';
 import '../../../core/services/search/search_tool_service.dart';
+import '../../search/services/global_session_search_service.dart';
 import 'ask_user_interaction_service.dart';
 import 'local_tools_service.dart';
 import 'tool_approval_service.dart';
@@ -186,6 +189,7 @@ class ToolHandlerService {
     // Memory tools
     if (assistant?.enableMemory == true && supportsTools) {
       toolDefs.addAll(_buildMemoryToolDefinitions());
+      toolDefs.addAll(_buildMemoryArchiveToolDefinitions());
     }
 
     // Local tools
@@ -260,6 +264,124 @@ class ToolHandlerService {
               'id': {
                 'type': 'integer',
                 'description': 'The id of the memory record',
+              },
+            },
+            'required': ['id'],
+          },
+        },
+      },
+    ];
+  }
+
+  /// Build memory archive tool definitions (past-chat search/read + long docs).
+  ///
+  /// These implement the catalog-then-fetch pattern: the system prompt only
+  /// carries titles/summaries, and the model pulls full text on demand.
+  List<Map<String, dynamic>> _buildMemoryArchiveToolDefinitions() {
+    return [
+      {
+        'type': 'function',
+        'function': {
+          'name': 'search_past_chats',
+          'description':
+              'Search all past conversations on this device by keywords. '
+              'Returns a catalog of matches (title, date, snippet, conversationId). '
+              'Follow up with read_chat before quoting any detail.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'query': {
+                'type': 'string',
+                'description':
+                    'Space-separated keywords. All keywords must appear in a conversation for it to match.',
+              },
+            },
+            'required': ['query'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': 'read_chat',
+          'description':
+              'Read the original messages of one past conversation by conversationId '
+              '(from search_past_chats). Returns the last part of the conversation.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'conversation_id': {
+                'type': 'string',
+                'description': 'The conversationId returned by search_past_chats',
+              },
+              'max_messages': {
+                'type': 'integer',
+                'description':
+                    'Maximum number of messages to return, counted from the end. Default 30.',
+              },
+            },
+            'required': ['conversation_id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': 'read_memory_doc',
+          'description':
+              'Read the full text of one long-term memory doc listed in the '
+              '<memory_docs> catalog. Never pretend to know doc content from the catalog alone.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'id': {
+                'type': 'integer',
+                'description': 'The doc id from the <memory_docs> catalog',
+              },
+            },
+            'required': ['id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': 'write_memory_doc',
+          'description':
+              'Save a long text as a long-term memory doc. Use when the user asks to '
+              'archive long content (notes, settings, excerpts). Only the title and summary '
+              'will appear in future context; full text stays retrievable via read_memory_doc.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'title': {
+                'type': 'string',
+                'description': 'A short distinctive title',
+              },
+              'summary': {
+                'type': 'string',
+                'description': 'One-sentence summary shown in the catalog',
+              },
+              'content': {
+                'type': 'string',
+                'description': 'The full text to archive',
+              },
+            },
+            'required': ['title', 'summary', 'content'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': 'delete_memory_doc',
+          'description': 'Delete an outdated long-term memory doc by id.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'id': {
+                'type': 'integer',
+                'description': 'The doc id from the <memory_docs> catalog',
               },
             },
             'required': ['id'],
@@ -362,6 +484,16 @@ class ToolHandlerService {
         final memoryResult = await _handleMemoryToolCall(name, args, assistant);
         if (memoryResult != null) {
           return memoryResult;
+        }
+
+        // Memory archive tools (past-chat search/read + long docs)
+        final archiveResult = await _handleMemoryArchiveToolCall(
+          name,
+          args,
+          assistant,
+        );
+        if (archiveResult != null) {
+          return archiveResult;
         }
 
         // Local tools
@@ -545,6 +677,180 @@ class ToolHandlerService {
         tool: name,
         instruction:
             'The memory tool failed. Retry only after correcting the parameters, or inform the user about the issue.',
+      );
+    }
+
+    return null;
+  }
+
+  static const Set<String> _memoryArchiveToolNames = {
+    'search_past_chats',
+    'read_chat',
+    'read_memory_doc',
+    'write_memory_doc',
+    'delete_memory_doc',
+  };
+
+  /// Handle memory archive tool calls (past-chat search/read + long docs).
+  ///
+  /// Returns null if the tool is not an archive tool or memory is not enabled.
+  Future<String?> _handleMemoryArchiveToolCall(
+    String name,
+    Map<String, dynamic> args,
+    Assistant? assistant,
+  ) async {
+    if (assistant?.enableMemory != true) return null;
+    if (!_memoryArchiveToolNames.contains(name)) return null;
+
+    try {
+      if (name == 'search_past_chats') {
+        final query = (args['query'] ?? '').toString().trim();
+        if (query.isEmpty) {
+          return _toolError(
+            error: 'invalid_query',
+            message: 'query must not be empty.',
+            tool: name,
+          );
+        }
+        final chatService = contextProvider.read<ChatService>();
+        final results = GlobalSessionSearchService.search(
+          chatService: chatService,
+          query: query,
+          limit: 8,
+        );
+        return jsonEncode({
+          'results': [
+            for (final r in results)
+              {
+                'conversation_id': r.conversationId,
+                'title': r.conversationTitle,
+                'date': r.updatedAt.toIso8601String().substring(0, 10),
+                'snippet': r.snippet,
+              },
+          ],
+          'note': results.isEmpty
+              ? 'No past conversation matched all keywords. Try fewer or different keywords.'
+              : 'Catalog entries only. Call read_chat with a conversation_id before quoting details.',
+        });
+      } else if (name == 'read_chat') {
+        final id = (args['conversation_id'] ?? '').toString().trim();
+        if (id.isEmpty) {
+          return _toolError(
+            error: 'invalid_conversation_id',
+            message: 'conversation_id must not be empty.',
+            tool: name,
+          );
+        }
+        final chatService = contextProvider.read<ChatService>();
+        final convo = chatService.getConversation(id);
+        if (convo == null) {
+          return _toolError(
+            error: 'conversation_not_found',
+            message: 'No conversation was found for id $id.',
+            tool: name,
+            instruction:
+                'Use a conversation_id returned by search_past_chats.',
+          );
+        }
+        final maxMessages = ((args['max_messages'] as num?)?.toInt() ?? 30)
+            .clamp(1, 100);
+        final visible = [
+          for (final m in chatService.getMessages(id))
+            if ((m.role == 'user' || m.role == 'assistant') &&
+                m.content.trim().isNotEmpty)
+              m,
+        ];
+        // Take messages from the end, bounded by count and a character budget.
+        const charBudget = 12000;
+        var used = 0;
+        final lines = <String>[];
+        for (final m in visible.reversed) {
+          if (lines.length >= maxMessages) break;
+          final line = '[${m.role}] ${m.content.trim()}';
+          if (lines.isNotEmpty && used + line.length > charBudget) break;
+          used += line.length;
+          lines.add(line);
+        }
+        final buf = StringBuffer()
+          ..writeln('Conversation: ${convo.title}')
+          ..writeln(
+            visible.length > lines.length
+                ? '(showing last ${lines.length} of ${visible.length} messages)'
+                : '(${lines.length} messages)',
+          );
+        for (final line in lines.reversed) {
+          buf.writeln(line);
+        }
+        return buf.toString();
+      } else if (name == 'read_memory_doc') {
+        final id = (args['id'] as num?)?.toInt() ?? -1;
+        if (id <= 0) {
+          return _toolError(
+            error: 'invalid_doc_id',
+            message: 'Doc id must be a positive integer.',
+            tool: name,
+          );
+        }
+        final doc = await MemoryDocStore.getById(id);
+        if (doc == null || doc.assistantId != assistant!.id) {
+          return _toolError(
+            error: 'doc_not_found',
+            message: 'No memory doc was found for id $id.',
+            tool: name,
+            instruction: 'Use an id listed in the <memory_docs> catalog.',
+          );
+        }
+        return '# ${doc.title}\n\n${doc.content}';
+      } else if (name == 'write_memory_doc') {
+        final title = (args['title'] ?? '').toString().trim();
+        final summary = (args['summary'] ?? '').toString().trim();
+        final content = (args['content'] ?? '').toString();
+        if (title.isEmpty || summary.isEmpty || content.trim().isEmpty) {
+          return _toolError(
+            error: 'invalid_doc_fields',
+            message: 'title, summary and content must all be non-empty.',
+            tool: name,
+          );
+        }
+        final doc = await MemoryDocStore.add(
+          assistantId: assistant!.id,
+          title: title,
+          summary: summary,
+          content: content,
+        );
+        return jsonEncode({
+          'id': doc.id,
+          'title': doc.title,
+          'chars': doc.content.length,
+        });
+      } else if (name == 'delete_memory_doc') {
+        final id = (args['id'] as num?)?.toInt() ?? -1;
+        if (id <= 0) {
+          return _toolError(
+            error: 'invalid_doc_id',
+            message: 'Doc id must be a positive integer.',
+            tool: name,
+          );
+        }
+        final doc = await MemoryDocStore.getById(id);
+        if (doc == null || doc.assistantId != assistant!.id) {
+          return _toolError(
+            error: 'doc_not_found',
+            message: 'No memory doc was found for id $id.',
+            tool: name,
+            instruction: 'Use an id listed in the <memory_docs> catalog.',
+          );
+        }
+        await MemoryDocStore.delete(id: id);
+        return 'deleted';
+      }
+    } catch (e) {
+      return _toolError(
+        error: 'memory_archive_execution_error',
+        message: e.toString(),
+        tool: name,
+        instruction:
+            'The memory archive tool failed. Retry only after correcting the parameters, or inform the user about the issue.',
       );
     }
 


### PR DESCRIPTION
三个独立改动，共同目标是缓存友好的记忆架构：

1. 记忆注入的时间戳从小时级降为天级（_formatCurrentDay）——原先每小时 使 system prompt 变化一次，作废整条提供商 prompt cache 前缀。
2. 过往对话检索工具：search_past_chats（包装 GlobalSessionSearchService， 返回标题/日期/片段/会话 id 目录）+ read_chat（按 id 读原文，条数与 字符双重预算）。
3. 长期资料层：AssistantMemoryDoc 模型 + MemoryDocStore（镜像 MemoryStore 的 SharedPreferences JSON 存储）+ write/read/delete_memory_doc 工具。system prompt 只注入 <memory_docs> 目录（标题+摘要+字数）， 全文由模型按需调 read_memory_doc 取，永不进常驻前缀。

所有新工具与说明块都挂在现有 enableMemory 开关下，无新增设置项、
无 UI 改动、无本地化条目。工具跨助手访问已校验 assistantId。

验证声明：本次开发环境无 Flutter/Dart SDK，dart format / flutter analyze / flutter test 均未执行；代码逐项比对了既有同类实现（memory_store、
_buildMemoryToolDefinitions、_handleMemoryToolCall）的类型与空安全写法。 风险集中在编译期低级错误，建议先开 PR 触发 pr-check.yml 的 analyze，
通过后再跑 build.yml 出包。


Claude-Session: https://claude.ai/code/session_01LsvZSvk5jc4765qPBTFEiz