### PR TITLE
[codex] parse legacy <thinking> tags

### DIFF
--- a/docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md
+++ b/docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md
@@ -125,4 +125,3 @@ gh pr create --repo Chevey339/kelivo --base master --head Agoniedi:codex/support
 ```
 
 Expected: GitHub returns a draft pull request URL targeting `Chevey339/kelivo:master`.
-

--- a/docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md
+++ b/docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md
@@ -1,0 +1,128 @@
+# Thinking Tag Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parse complete `<thinking>...</thinking>` blocks as legacy inline reasoning without changing structured reasoning behavior.
+
+**Architecture:** Extend the existing legacy tag regular expression rather than adding provider-specific or streaming logic. Lock the behavior with focused parser tests for success and boundary cases.
+
+**Tech Stack:** Dart, Flutter test
+
+---
+
+### Task 1: Add regression coverage
+
+**Files:**
+- Test: `test/thinking_tag_regex_test.dart`
+
+- [ ] **Step 1: Add the failing and boundary tests**
+
+```dart
+test('extracts closed thinking block', () {
+  const input = '<thinking>reasoning here</thinking>answer';
+  final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+  expect(parsed.visibleContent, 'answer');
+  expect(parsed.thinkingTexts, const ['reasoning here']);
+});
+
+test('extracts mixed-case thinking block', () {
+  const input = '<THINKING>reasoning here</THINKING>answer';
+  final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+  expect(parsed.visibleContent, 'answer');
+  expect(parsed.thinkingTexts, const ['reasoning here']);
+});
+
+test('keeps unclosed thinking tag visible', () {
+  const input = '<thinking>partial reasoning';
+  final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+  expect(parsed.visibleContent, input);
+  expect(parsed.thinkingTexts, isEmpty);
+});
+
+test('keeps mismatched long thinking tags visible', () {
+  const input = '<thinking>reasoning</think>answer';
+  final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+  expect(parsed.visibleContent, input);
+  expect(parsed.thinkingTexts, isEmpty);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `flutter test test/thinking_tag_regex_test.dart`
+
+Expected: the complete lowercase and mixed-case `<thinking>` extraction tests fail because the parser leaves the input visible.
+
+### Task 2: Implement the minimal parser change
+
+**Files:**
+- Modify: `lib/features/chat/utils/thinking_tag_parser.dart`
+- Test: `test/thinking_tag_regex_test.dart`
+
+- [ ] **Step 1: Extend the existing tag expression**
+
+```dart
+static final RegExp _openTagRe = RegExp(
+  r'<(think|thinking|thought)>',
+  caseSensitive: false,
+);
+```
+
+- [ ] **Step 2: Format the changed Dart files**
+
+Run: `dart format lib/features/chat/utils/thinking_tag_parser.dart test/thinking_tag_regex_test.dart`
+
+Expected: both files are formatted successfully.
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+Run: `flutter test test/thinking_tag_regex_test.dart`
+
+Expected: all `ThinkingTagParser` tests pass.
+
+### Task 3: Validate and publish
+
+**Files:**
+- Review: `lib/features/chat/utils/thinking_tag_parser.dart`
+- Review: `test/thinking_tag_regex_test.dart`
+- Review: `docs/superpowers/specs/2026-07-12-thinking-tag-compatibility-design.md`
+- Review: `docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md`
+
+- [ ] **Step 1: Run static analysis**
+
+Run: `flutter analyze`
+
+Expected: exit code 0 with no analysis issues.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `flutter test`
+
+Expected: exit code 0 with all tests passing.
+
+- [ ] **Step 3: Review the final diff**
+
+Run: `git diff --check && git status -sb && git diff upstream/master...HEAD`
+
+Expected: only the parser, focused test, design, and plan are included; no whitespace errors are reported.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add lib/features/chat/utils/thinking_tag_parser.dart test/thinking_tag_regex_test.dart docs/superpowers/plans/2026-07-12-thinking-tag-compatibility.md
+git commit -m "fix: parse legacy thinking tags"
+```
+
+- [ ] **Step 5: Push and open a draft pull request**
+
+```bash
+git push -u origin codex/support-thinking-tag
+gh pr create --repo Chevey339/kelivo --base master --head Agoniedi:codex/support-thinking-tag --draft
+```
+
+Expected: GitHub returns a draft pull request URL targeting `Chevey339/kelivo:master`.
+

--- a/docs/superpowers/specs/2026-07-12-thinking-tag-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-12-thinking-tag-compatibility-design.md
@@ -38,4 +38,3 @@ OpenAI-compatible reasoning fields retain priority.
 - Failure path: keep mismatched `<thinking>...</think>` tags visible.
 - Regression: retain all existing `<think>`, `<thought>`, full-width, and plain
   text behavior.
-

--- a/docs/superpowers/specs/2026-07-12-thinking-tag-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-12-thinking-tag-compatibility-design.md
@@ -1,0 +1,41 @@
+# Thinking Tag Compatibility Design
+
+## Problem
+
+Some Kiro-compatible proxies return legacy inline reasoning as
+`<thinking>...</thinking>` inside the assistant text. Kelivo's fallback parser
+currently recognizes `<think>` and `<thought>`, so the Kiro tags remain visible
+in the final answer.
+
+## Mini Control Contract
+
+- **Primary Setpoint:** Treat a complete `<thinking>...</thinking>` block as
+  legacy inline reasoning.
+- **Acceptance:** The focused parser test extracts the reasoning text and keeps
+  the remaining answer visible.
+- **Guardrails:** Preserve the existing behavior for incomplete, mismatched,
+  full-width, and plain-text inputs.
+- **Boundary:** Change only the legacy tag parser and its focused test file.
+- **Risks:** A model intentionally emitting a complete `<thinking>` example may
+  be interpreted as reasoning, matching the existing behavior for `<think>` and
+  `<thought>` examples.
+
+## Design
+
+Extend the parser's existing opening-tag expression with `thinking`. Continue
+deriving the closing tag from the matched tag name so matching remains
+case-insensitive and mismatched tags remain visible.
+
+Do not add provider detection or a streaming state machine. The fallback parser
+only runs when the message has no structured reasoning, so native Anthropic and
+OpenAI-compatible reasoning fields retain priority.
+
+## Test Scenarios
+
+- Happy path: extract a complete lowercase `<thinking>` block.
+- Compatibility: extract a complete mixed-case `<THINKING>` block.
+- Boundary: keep an unclosed `<thinking>` block visible.
+- Failure path: keep mismatched `<thinking>...</think>` tags visible.
+- Regression: retain all existing `<think>`, `<thought>`, full-width, and plain
+  text behavior.
+

--- a/lib/features/chat/utils/thinking_tag_parser.dart
+++ b/lib/features/chat/utils/thinking_tag_parser.dart
@@ -12,7 +12,7 @@ class ThinkingTagParseResult {
 
 class ThinkingTagParser {
   static final RegExp _openTagRe = RegExp(
-    r'<(think|thought)>',
+    r'<(think|thinking|thought)>',
     caseSensitive: false,
   );
 

--- a/test/thinking_tag_regex_test.dart
+++ b/test/thinking_tag_regex_test.dart
@@ -19,6 +19,22 @@ void main() {
       expect(parsed.thinkingTexts, const ['reasoning here']);
     });
 
+    test('extracts closed thinking block', () {
+      const input = '<thinking>reasoning here</thinking>answer';
+      final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+      expect(parsed.visibleContent, 'answer');
+      expect(parsed.thinkingTexts, const ['reasoning here']);
+    });
+
+    test('extracts mixed-case thinking block', () {
+      const input = '<THINKING>reasoning here</THINKING>answer';
+      final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+      expect(parsed.visibleContent, 'answer');
+      expect(parsed.thinkingTexts, const ['reasoning here']);
+    });
+
     test('extracts multiple closed blocks', () {
       const input = '<think>a</think>mid<thought>b</thought>end';
       final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
@@ -35,8 +51,24 @@ void main() {
       expect(parsed.thinkingTexts, isEmpty);
     });
 
+    test('keeps unclosed thinking tag visible', () {
+      const input = '<thinking>partial reasoning';
+      final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+      expect(parsed.visibleContent, input);
+      expect(parsed.thinkingTexts, isEmpty);
+    });
+
     test('keeps mismatched thinking tags visible', () {
       const input = '<think>reasoning</thought>answer';
+      final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
+
+      expect(parsed.visibleContent, input);
+      expect(parsed.thinkingTexts, isEmpty);
+    });
+
+    test('keeps mismatched long thinking tags visible', () {
+      const input = '<thinking>reasoning</think>answer';
       final parsed = ThinkingTagParser.parseLegacyInlineBlocks(input);
 
       expect(parsed.visibleContent, input);


### PR DESCRIPTION
## Summary

- recognize complete `<thinking>...</thinking>` blocks in the existing legacy inline reasoning fallback
- preserve current behavior for incomplete and mismatched tags
- add focused coverage for lowercase, mixed-case, incomplete, and mismatched `<thinking>` blocks

## Root cause

Some Kiro-compatible proxies return reasoning inline with `<thinking>` tags. Kelivo's fallback parser only recognized `<think>` and `<thought>`, so these blocks remained visible in the assistant answer instead of being rendered as reasoning.

The fix extends the existing parser rather than adding provider-specific detection. Structured Anthropic/OpenAI reasoning still takes priority because this fallback only runs when no structured reasoning is present.

Closes #782.

## Validation

- `flutter test test/thinking_tag_regex_test.dart`: 11 passed
- `flutter analyze lib/features/chat/utils/thinking_tag_parser.dart test/thinking_tag_regex_test.dart`: no issues
- `flutter test`: 773 passed, 1 unrelated existing Windows path-separator failure in `settings_provider_local_font_test.dart`
- full `flutter analyze`: blocked by existing `dependencies/mcp_client/test/**` imports of unresolved `package:test`; changed-file analysis is clean
- `git diff --check upstream/master...HEAD`: clean

## Pre-launch Checklist

- [x] No user-visible strings or localization changes
- [x] Changed Dart files formatted
- [x] Focused regression tests pass
- [x] Changed-file static analysis passes
- [x] Self-review completed for maintainability, performance, security, style, and compatibility
