### PR TITLE
feat: cache-friendly memory placeholder in messages

### DIFF
--- a/lib/core/providers/memory_provider.dart
+++ b/lib/core/providers/memory_provider.dart
@@ -9,7 +9,8 @@ class MemoryProvider extends ChangeNotifier {
   List<AssistantMemory> get memories => List.unmodifiable(_memories);
 
   List<AssistantMemory> getForAssistant(String assistantId) =>
-      _memories.where((m) => m.assistantId == assistantId).toList();
+      _memories.where((m) => m.assistantId == assistantId).toList()
+        ..sort((a, b) => a.id.compareTo(b.id));
 
   Future<void> initialize() async {
     if (_initialized) return;

--- a/lib/core/utils/memory_placeholder.dart
+++ b/lib/core/utils/memory_placeholder.dart
@@ -1,0 +1,45 @@
+/// 时间占位符替换工具。
+///
+/// 给 AI 一个稳定协议:在 system prompt 没有任何时间变量的前提下,允许 AI
+/// 在写入记忆时插入真实时间,从而让 system message 整体保持字节级稳定,
+/// 命中 LLM 服务的 prompt cache。
+///
+/// 占位符(全部小写,两侧各一个花括号):
+/// - `{year}`    4 位年份,例如 `2026`
+/// - `{month}`   2 位月份(01-12),例如 `07`
+/// - `{day}`     2 位日期(01-31),例如 `13`
+/// - `{hour}`    2 位小时(00-23,24 小时制),例如 `06`
+/// - `{minute}`  2 位分钟(00-59),例如 `33`
+/// - `{second}`  2 位秒(00-59),例如 `58`
+/// - `{time}`    完整时间(无秒),格式 `{year}/{month}/{day} {hour}:{minute}`
+///               例如 `2026/07/13 06:33`
+///
+/// 替换规则:
+/// - 不区分大小写(但推荐小写,大写占位符也照样替换)
+/// - 全部替换,不做上下文区分(用户自己注意别在内容里写 `{time}` 字面量)
+/// - 替换只发生在工具调用路径,UI 手动编辑不会触发
+library;
+
+/// 把 content 中的时间占位符替换为 [now] 指定的实际时间。
+///
+/// [now] 默认为 [DateTime.now],单测时可以注入固定时间。
+String expandMemoryPlaceholders(String content, [DateTime? now]) {
+  final t = now ?? DateTime.now();
+  final year = t.year.toString();
+  final month = t.month.toString().padLeft(2, '0');
+  final day = t.day.toString().padLeft(2, '0');
+  final hour = t.hour.toString().padLeft(2, '0');
+  final minute = t.minute.toString().padLeft(2, '0');
+  final second = t.second.toString().padLeft(2, '0');
+  final time = '$year/$month/$day $hour:$minute';
+
+  // 按顺序替换,每个 .replaceAll 独立运行,不会重复命中前面替换结果里的字面量
+  return content
+      .replaceAll('{year}', year)
+      .replaceAll('{month}', month)
+      .replaceAll('{day}', day)
+      .replaceAll('{hour}', hour)
+      .replaceAll('{minute}', minute)
+      .replaceAll('{second}', second)
+      .replaceAll('{time}', time);
+}

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -538,13 +538,13 @@ class MessageBuilderService {
         final mp = contextProvider.read<MemoryProvider>();
         await mp.initialize();
         final mems = mp.getForAssistant(assistant!.id);
-        final currentHour = _formatCurrentHour(DateTime.now());
         final buf = StringBuffer();
         buf.writeln('## Memories');
         buf.writeln(
           'These are memories that you can reference in the future conversations.',
         );
         buf.writeln('<memories>');
+        // 始终输出 <memories> 标签(空列表也输出),保证"无记忆"这个状态字节级稳定
         for (final m in mems) {
           buf.writeln('<record>');
           buf.writeln('<id>${m.id}</id>');
@@ -570,50 +570,21 @@ class MessageBuilderService {
 - 首次聊天时间
 - ...
 请主动调用工具记录，而不是需要用户要求。
-记忆如果包含日期信息，请包含在内，请使用绝对时间格式，并且当前时间是$currentHour。
+如果你想在记忆中插入时间,使用占位符(系统在写入前会自动替换为实际时间):
+- {year} {month} {day} - 年/月/日(2 位数字,如 07)
+- {hour} {minute} {second} - 时/分/秒(24 小时制)
+- {time} - 完整时间(等价于 {year}/{month}/{day} {hour}:{minute},无秒)
+示例:"用户于 {year}/{month}/{day} 注册" 会被存为 "用户于 2026/07/13 注册"。
+如要写"昨天"等相对时间,请先获取当前日期后写具体数字。
 无需告知用户你已更改记忆记录，也不要在对话中直接显示记忆内容，除非用户主动要求。
 相似或相关的记忆应合并为一条记录，而不要重复记录，过时记录应删除。
 你可以在和用户闲聊的时候暗示用户你能记住东西。
 ''');
         _appendToSystemMessage(apiMessages, buf.toString());
       }
-      if (assistant?.enableRecentChatsReference == true) {
-        final chats = chatService.getAllConversations();
-        final relevantChats = chats
-            .where(
-              (c) =>
-                  c.assistantId == assistant!.id &&
-                  c.id != currentConversationId,
-            )
-            .where((c) => c.title.trim().isNotEmpty)
-            .take(10)
-            .toList();
-        if (relevantChats.isNotEmpty) {
-          final sb = StringBuffer();
-          sb.writeln('<recent_chats>');
-          sb.writeln('这是用户最近的一些对话标题和摘要，你可以参考这些内容了解用户偏好和关注点');
-          for (final c in relevantChats) {
-            sb.writeln('<conversation>');
-            // Format: timestamp: title || summary
-            final timestamp = c.updatedAt.toIso8601String().substring(0, 10);
-            final title = c.title.trim();
-            final summary = (c.summary ?? '').trim();
-            if (summary.isNotEmpty) {
-              sb.writeln('  $timestamp: $title || $summary');
-            } else {
-              sb.writeln('  $timestamp: $title');
-            }
-            sb.writeln('</conversation>');
-          }
-          sb.writeln('</recent_chats>');
-          _appendToSystemMessage(apiMessages, sb.toString());
-        }
-      }
+      // recent_chats 块已从 system message 移除,改为通过 read_recent_chats 工具按需读取
+      // (见 spec §5.2 / §5.3)
     } catch (_) {}
-  }
-
-  String _formatCurrentHour(DateTime now) {
-    return '${now.year}年${now.month}月${now.day}日的${now.hour}点';
   }
 
   /// Inject search tool usage prompt into apiMessages.

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -10,8 +10,10 @@ import '../../../core/providers/memory_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/tts_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/mcp/mcp_tool_service.dart';
 import '../../../core/services/search/search_tool_service.dart';
+import '../../../core/utils/memory_placeholder.dart';
 import 'ask_user_interaction_service.dart';
 import 'local_tools_service.dart';
 import 'tool_approval_service.dart';
@@ -188,6 +190,11 @@ class ToolHandlerService {
       toolDefs.addAll(_buildMemoryToolDefinitions());
     }
 
+    // Read recent chats tool (only registered when recent chats reference is enabled)
+    if (assistant?.enableRecentChatsReference == true && supportsTools) {
+      toolDefs.addAll(_buildRecentChatsToolDefinitions());
+    }
+
     // Local tools
     toolDefs.addAll(
       LocalToolsService.buildToolDefinitions(
@@ -206,6 +213,25 @@ class ToolHandlerService {
     toolDefs.addAll(mcpTools);
 
     return toolDefs;
+  }
+
+  /// Build recent chats tool definition (read_recent_chats).
+  List<Map<String, dynamic>> _buildRecentChatsToolDefinitions() {
+    return [
+      {
+        'type': 'function',
+        'function': {
+          'name': 'read_recent_chats',
+          'description':
+              '读取用户最近的一些对话标题和摘要(排除当前对话),用于了解用户的历史话题和偏好,无参数。',
+          'parameters': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+            'required': <String>[],
+          },
+        },
+      },
+    ];
   }
 
   /// Build memory tool definitions (create/edit/delete).
@@ -358,8 +384,12 @@ class ToolHandlerService {
           return await SearchToolService.executeSearch(q, settings);
         }
 
-        // Memory tools
-        final memoryResult = await _handleMemoryToolCall(name, args, assistant);
+        // Memory and recent chats tools
+        final memoryResult = await _handleMemoryAndRecentChatsToolCall(
+          name,
+          args,
+          assistant,
+        );
         if (memoryResult != null) {
           return memoryResult;
         }
@@ -460,14 +490,66 @@ class ToolHandlerService {
     };
   }
 
-  /// Handle memory tool calls (create/edit/delete).
+  /// Handle memory and recent chats tool calls.
   ///
-  /// Returns null if the tool is not a memory tool or memory is not enabled.
-  Future<String?> _handleMemoryToolCall(
+  /// Returns null if the tool is not handled here.
+  Future<String?> _handleMemoryAndRecentChatsToolCall(
     String name,
     Map<String, dynamic> args,
     Assistant? assistant,
   ) async {
+    // Recent chats: gated on enableRecentChatsReference
+    if (name == 'read_recent_chats') {
+      if (assistant?.enableRecentChatsReference != true) {
+        return _toolError(
+          error: 'recent_chats_not_enabled',
+          message: 'Recent chats reference is not enabled for this assistant.',
+          tool: name,
+        );
+      }
+      try {
+        final chatService = contextProvider.read<ChatService>();
+        final currentId = chatService.currentConversationId;
+        final relevantChats = chatService
+            .getAllConversations()
+            .where(
+              (c) =>
+                  c.assistantId == assistant!.id &&
+                  c.id != currentId,
+            )
+            .where((c) => c.title.trim().isNotEmpty)
+            .take(10)
+            .toList();
+        if (relevantChats.isEmpty) {
+          return 'No recent chats available.';
+        }
+        final sb = StringBuffer();
+        sb.writeln('<recent_chats>');
+        sb.writeln(
+          '这是用户最近的一些对话标题和摘要，你可以参考这些内容了解用户偏好和关注点',
+        );
+        for (final c in relevantChats) {
+          // Format: timestamp: title || summary
+          final timestamp = c.updatedAt.toIso8601String().substring(0, 10);
+          final title = c.title.trim();
+          final summary = (c.summary ?? '').trim();
+          if (summary.isNotEmpty) {
+            sb.writeln('  $timestamp: $title || $summary');
+          } else {
+            sb.writeln('  $timestamp: $title');
+          }
+        }
+        sb.writeln('</recent_chats>');
+        return sb.toString();
+      } catch (e) {
+        return _toolError(
+          error: 'recent_chats_execution_error',
+          message: e.toString(),
+          tool: name,
+        );
+      }
+    }
+
     if (assistant?.enableMemory != true) return null;
     if (name != 'create_memory' &&
         name != 'edit_memory' &&
@@ -479,19 +561,20 @@ class ToolHandlerService {
       final mp = contextProvider.read<MemoryProvider>();
 
       if (name == 'create_memory') {
-        final content = (args['content'] ?? '').toString();
-        if (content.isEmpty) {
+        final rawContent = (args['content'] ?? '').toString();
+        if (rawContent.isEmpty) {
           return _toolError(
             error: 'invalid_memory_content',
             message: 'Memory content must not be empty.',
             tool: name,
           );
         }
+        final content = expandMemoryPlaceholders(rawContent);
         final m = await mp.add(assistantId: assistant!.id, content: content);
         return m.content;
       } else if (name == 'edit_memory') {
         final id = (args['id'] as num?)?.toInt() ?? -1;
-        final content = (args['content'] ?? '').toString();
+        final rawContent = (args['content'] ?? '').toString();
         if (id <= 0) {
           return _toolError(
             error: 'invalid_memory_id',
@@ -499,13 +582,14 @@ class ToolHandlerService {
             tool: name,
           );
         }
-        if (content.isEmpty) {
+        if (rawContent.isEmpty) {
           return _toolError(
             error: 'invalid_memory_content',
             message: 'Memory content must not be empty.',
             tool: name,
           );
         }
+        final content = expandMemoryPlaceholders(rawContent);
         final m = await mp.update(id: id, content: content);
         if (m == null) {
           return _toolError(


### PR DESCRIPTION
该pr专门修复 #784 中的问题，针对主动记忆和被动摘要都做了缓存友好修复

### 记忆修复
不再在记忆中插入时间变量，改为要求ai创建记忆时插入时间使用{{time}}来插入时间

### 摘要修复
摘要不再自动注入提示词，而是改为ai手动调用工具获取，使可控性更强