### PR TITLE
Prevent remote backup names from escaping temp storage

### DIFF
--- a/lib/core/providers/s3_backup_provider.dart
+++ b/lib/core/providers/s3_backup_provider.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import '../models/backup.dart';
 import '../services/backup/data_sync.dart';
 import '../services/backup/s3_client.dart';
+import '../services/backup/temporary_restore_file.dart';
 import '../services/chat/chat_service.dart';
 
 class S3BackupProvider extends ChangeNotifier {
@@ -121,7 +122,7 @@ class S3BackupProvider extends ChangeNotifier {
     try {
       final key = _keyFromItem(item);
       final tmp = await _ensureTempDir();
-      file = File(p.join(tmp.path, item.displayName));
+      file = await createTemporaryRestoreFile(tmp);
       // Download directly to file to avoid holding entire object in memory.
       await _client.downloadToFile(_cfg, key: key, destination: file);
       await _dataSync.restoreFromLocalFile(

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -21,6 +21,7 @@ import '../chat/chat_service.dart';
 import '../../../utils/app_directories.dart';
 import 'backup_settings_validator.dart';
 import 'restore_bundle_preparation.dart';
+import 'temporary_restore_file.dart';
 
 typedef _ParsedChatBackup = ({
   List<Conversation> conversations,
@@ -816,7 +817,7 @@ class DataSync {
         throw Exception('Download failed: ${streamed.statusCode}');
       }
       final tmpDir = await _ensureTempDir();
-      file = File(p.join(tmpDir.path, item.displayName));
+      file = await createTemporaryRestoreFile(tmpDir);
       final sink = file.openWrite();
       await streamed.stream.pipe(sink);
       await _restoreFromBackupFile(file, cfg, mode: mode);

--- a/lib/core/services/backup/temporary_restore_file.dart
+++ b/lib/core/services/backup/temporary_restore_file.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+Future<File> createTemporaryRestoreFile(Directory directory) async {
+  final file = File(
+    p.join(directory.path, 'kelivo_restore_${const Uuid().v4()}.zip'),
+  );
+  await file.create(exclusive: true);
+  return file;
+}

--- a/test/core/providers/s3_backup_provider_security_test.dart
+++ b/test/core/providers/s3_backup_provider_security_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Kelivo/core/models/backup.dart';
+import 'package:Kelivo/core/providers/s3_backup_provider.dart';
+import 'package:Kelivo/core/services/chat/chat_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$root/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$root/tmp';
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = null;
+
+  group('S3BackupProvider restore paths', () {
+    late Directory root;
+    late PathProviderPlatform previousPathProvider;
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp(
+        'kelivo_s3_provider_security_',
+      );
+      previousPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(root.path);
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = previousPathProvider;
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+
+    test('ignores untrusted display names and cleans temp files', () async {
+      final settingsFile = File('${root.path}/settings.json');
+      await settingsFile.writeAsString('{}');
+      final remoteBackup = File('${root.path}/remote.zip');
+      final encoder = ZipFileEncoder();
+      encoder.create(remoteBackup.path);
+      encoder.addFileSync(settingsFile, 'settings.json');
+      encoder.closeSync();
+      final remoteBackupBytes = await remoteBackup.readAsBytes();
+
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        request.response.statusCode = HttpStatus.ok;
+        request.response.add(remoteBackupBytes);
+        await request.response.close();
+      });
+
+      final chatService = ChatService();
+      addTearDown(chatService.dispose);
+      final provider = S3BackupProvider(
+        chatService: chatService,
+        initialConfig: S3Config(
+          endpoint: 'http://${server.address.address}:${server.port}',
+          bucket: 'backup-bucket',
+          accessKeyId: 'test-access-key',
+          secretAccessKey: 'test-secret-key',
+          includeChats: false,
+          includeFiles: false,
+        ),
+      );
+      addTearDown(provider.dispose);
+
+      final relativeSentinel = File('${root.path}/s3_relative.zip');
+      final absoluteSentinel = File('${root.path}/s3_absolute.zip');
+      await relativeSentinel.writeAsString('keep relative');
+      await absoluteSentinel.writeAsString('keep absolute');
+      final remoteNames = <String>['../s3_relative.zip', absoluteSentinel.path];
+
+      for (var i = 0; i < remoteNames.length; i++) {
+        await provider.restoreFromItem(
+          BackupFileItem(
+            href: Uri.parse('s3://backup-bucket/kelivo_backups/remote_$i.zip'),
+            displayName: remoteNames[i],
+            size: remoteBackupBytes.length,
+            lastModified: null,
+          ),
+        );
+      }
+
+      expect(await relativeSentinel.readAsString(), 'keep relative');
+      expect(await absoluteSentinel.readAsString(), 'keep absolute');
+      expect(await Directory('${root.path}/tmp').list().toList(), isEmpty);
+    });
+  });
+}

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -2539,7 +2539,7 @@ void main() {
       expect(chatService.replaced, isFalse);
     });
 
-    test('cleans temporary restore files when WebDAV restore fails', () async {
+    test('WebDAV restore ignores untrusted display names', () async {
       final sourceDir = Directory('${root.path}/source_upload');
       await sourceDir.create(recursive: true);
       final sourceFile = File('${sourceDir.path}/file.txt');
@@ -2567,22 +2567,36 @@ void main() {
 
       final sync = DataSync(chatService: ChatService());
       final tmpDir = Directory('${root.path}/tmp');
-      final item = BackupFileItem(
-        href: Uri.parse('http://127.0.0.1:${server.port}/restore_source.zip'),
-        displayName: 'restore_source.zip',
-        size: await zipFile.length(),
-        lastModified: null,
-      );
+      final relativeSentinel = File('${root.path}/webdav_relative.zip');
+      final absoluteSentinel = File('${root.path}/webdav_absolute.zip');
+      await relativeSentinel.writeAsString('keep relative');
+      await absoluteSentinel.writeAsString('keep absolute');
+      final remoteNames = <String>[
+        '../webdav_relative.zip',
+        absoluteSentinel.path,
+      ];
 
-      await expectLater(
-        sync.restoreFromWebDav(
-          const WebDavConfig(includeChats: false, includeFiles: true),
-          item,
-        ),
-        throwsA(anything),
-      );
+      for (var i = 0; i < remoteNames.length; i++) {
+        final item = BackupFileItem(
+          href: Uri.parse(
+            'http://127.0.0.1:${server.port}/restore_source_$i.zip',
+          ),
+          displayName: remoteNames[i],
+          size: await zipFile.length(),
+          lastModified: null,
+        );
 
-      expect(await File('${tmpDir.path}/restore_source.zip').exists(), isFalse);
+        await expectLater(
+          sync.restoreFromWebDav(
+            const WebDavConfig(includeChats: false, includeFiles: true),
+            item,
+          ),
+          throwsA(anything),
+        );
+      }
+
+      expect(await relativeSentinel.readAsString(), 'keep relative');
+      expect(await absoluteSentinel.readAsString(), 'keep absolute');
       expect(await tmpDir.list().toList(), isEmpty);
     });
   });


### PR DESCRIPTION
> #792 has merged; this PR is rebased directly onto `master` and contains only the security fix.

## Summary

- create exclusive UUID-named local files for WebDAV and S3 restore downloads
- keep remote `displayName` values as presentation metadata only; downloads continue to use the trusted WebDAV href or S3 object key
- add regression coverage for both `../` and absolute-path display names on WebDAV and S3

## Root cause and impact

Remote backup display names were joined directly onto the local temporary directory. A crafted name could escape that directory, causing the download to overwrite an arbitrary reachable file and the failure cleanup path to delete it. The new helper creates the local destination independently of all remote metadata.

## Verification

- reproduced the old behavior with sentinel files outside the temp directory before applying the fix
- `dart format --output=none --set-exit-if-changed` on all 5 changed Dart files
- `dart analyze --fatal-infos lib test`
- targeted WebDAV/S3 backup test files
- `flutter gen-l10n` with no generated diff
- full `flutter test` suite