### PR TITLE
feat: support GPT-5.6 reasoning levels

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -436,6 +436,11 @@ class SettingsProvider extends ChangeNotifier {
     );
     switch (kind) {
       case ProviderKind.openai:
+        final modelForCheck = resolveOpenAIUpstreamModelId(
+          providerKey,
+          modelId,
+        );
+        return openAISupportsMaxReasoning(modelForCheck);
       case ProviderKind.google:
         return false;
       case ProviderKind.claude:

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -213,8 +213,9 @@ Map<String, dynamic> _buildAssistantToolCallMessage({
 
 String _openAIEffortForBudget(int? budget, String upstreamModelId) {
   final baseEffort = _effortForBudget(budget);
-  final requestedEffort =
-      baseEffort == 'high' && budget != null && budget >= 64000
+  final requestedEffort = budget != null && budget > 64000
+      ? 'max'
+      : baseEffort == 'high' && budget != null && budget >= 64000
       ? 'xhigh'
       : baseEffort;
   return openAINormalizeReasoningEffort(requestedEffort, upstreamModelId);

--- a/lib/core/utils/openai_model_compat.dart
+++ b/lib/core/utils/openai_model_compat.dart
@@ -9,6 +9,7 @@ class OpenAIReasoningSupport {
 
   bool get supportsNone => supportedEfforts.contains('none');
   bool get supportsXhigh => supportedEfforts.contains('xhigh');
+  bool get supportsMax => supportedEfforts.contains('max');
 }
 
 const OpenAIReasoningSupport _gpt5Support = OpenAIReasoningSupport(
@@ -56,6 +57,9 @@ const OpenAIReasoningSupport _gpt55Support = OpenAIReasoningSupport(
 const OpenAIReasoningSupport _gpt55ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['medium', 'high', 'xhigh'],
 );
+const OpenAIReasoningSupport _gpt56Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+);
 const OpenAIReasoningSupport _deepSeekSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
 );
@@ -79,6 +83,10 @@ bool openAISupportsXhighReasoning(String modelId) {
   return openAIReasoningSupport(modelId)?.supportsXhigh ?? false;
 }
 
+bool openAISupportsMaxReasoning(String modelId) {
+  return openAIReasoningSupport(modelId)?.supportsMax ?? false;
+}
+
 bool openAISupportsNoneReasoning(String modelId) {
   return openAIReasoningSupport(modelId)?.supportsNone ?? false;
 }
@@ -92,7 +100,8 @@ String openAINormalizeReasoningEffort(String effort, String modelId) {
   if (normalizedEffort == 'off') {
     return support?.supportsNone == true ? 'none' : 'off';
   }
-  if (normalizedEffort == 'xhigh' && support == null) {
+  if ((normalizedEffort == 'xhigh' || normalizedEffort == 'max') &&
+      support == null) {
     return 'high';
   }
   if (support == null) return normalizedEffort;
@@ -108,6 +117,7 @@ String openAINormalizeReasoningEffort(String effort, String modelId) {
         'medium',
         'high',
         'xhigh',
+        'max',
       ]);
     case 'low':
       return _pickSupportedEffort(support, const <String>[
@@ -115,24 +125,37 @@ String openAINormalizeReasoningEffort(String effort, String modelId) {
         'medium',
         'high',
         'xhigh',
+        'max',
       ]);
     case 'medium':
       return _pickSupportedEffort(support, const <String>[
         'medium',
         'high',
         'xhigh',
+        'max',
         'low',
       ]);
     case 'high':
       return _pickSupportedEffort(support, const <String>[
         'high',
         'xhigh',
+        'max',
         'medium',
         'low',
         'none',
       ]);
     case 'xhigh':
       return _pickSupportedEffort(support, const <String>[
+        'xhigh',
+        'max',
+        'high',
+        'medium',
+        'low',
+        'none',
+      ]);
+    case 'max':
+      return _pickSupportedEffort(support, const <String>[
+        'max',
         'xhigh',
         'high',
         'medium',
@@ -158,6 +181,9 @@ OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   if (normalized.contains('deepseek')) return _deepSeekSupport;
   if (!isOpenAIGpt5FamilyModel(normalized)) return null;
 
+  if (_matchesModel(normalized, r'^gpt-5\.6(?:$|[-.])')) {
+    return _gpt56Support;
+  }
   if (_matchesModel(normalized, r'^gpt-5\.5-pro(?:$|[-.])')) {
     return _gpt55ProSupport;
   }

--- a/test/chat_api_generate_text_encoding_test.dart
+++ b/test/chat_api_generate_text_encoding_test.dart
@@ -216,6 +216,22 @@ void main() {
       },
     );
 
+    test('maps GPT-5.6 maximum reasoning to max effort', () async {
+      final maximumBody = await _captureGenerateTextBody(
+        providerId: 'OpenAICompatTest',
+        modelId: 'gpt-5.6-sol',
+        thinkingBudget: 128000,
+      );
+      final xhighBody = await _captureGenerateTextBody(
+        providerId: 'OpenAICompatTest',
+        modelId: 'gpt-5.6-terra',
+        thinkingBudget: 64000,
+      );
+
+      expect(maximumBody['reasoning_effort'], 'max');
+      expect(xhighBody['reasoning_effort'], 'xhigh');
+    });
+
     test(
       'maps DashScope reasoning knobs for non-streaming text generation',
       () async {

--- a/test/core/utils/openai_model_compat_test.dart
+++ b/test/core/utils/openai_model_compat_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/utils/openai_model_compat.dart';
+
+void main() {
+  group('GPT-5.6 reasoning compatibility', () {
+    const modelIds = <String>[
+      'gpt-5.6',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ];
+
+    for (final modelId in modelIds) {
+      test('$modelId exposes every supported reasoning effort', () {
+        final support = openAIReasoningSupport(modelId);
+
+        expect(support?.supportedEfforts, const <String>[
+          'none',
+          'low',
+          'medium',
+          'high',
+          'xhigh',
+          'max',
+        ]);
+        expect(openAISupportsNoneReasoning(modelId), isTrue);
+        expect(openAISupportsXhighReasoning(modelId), isTrue);
+        expect(openAISupportsMaxReasoning(modelId), isTrue);
+        expect(openAINormalizeReasoningEffort('off', modelId), 'none');
+        expect(openAINormalizeReasoningEffort('xhigh', modelId), 'xhigh');
+        expect(openAINormalizeReasoningEffort('max', modelId), 'max');
+      });
+    }
+
+    test('older GPT-5 models keep their existing effort ceiling', () {
+      expect(openAISupportsMaxReasoning('gpt-5.5'), isFalse);
+      expect(openAINormalizeReasoningEffort('max', 'gpt-5.5'), 'xhigh');
+      expect(openAINormalizeReasoningEffort('max', 'gpt-5'), 'high');
+    });
+  });
+}

--- a/test/features/chat/widgets/reasoning_budget_sheet_test.dart
+++ b/test/features/chat/widgets/reasoning_budget_sheet_test.dart
@@ -12,24 +12,40 @@ Future<SettingsProvider> _settingsForClaudeModel(
   WidgetTester tester,
   String modelId,
 ) async {
+  return _settingsForModel(
+    tester,
+    providerId: 'Claude',
+    providerType: ProviderKind.claude,
+    baseUrl: 'https://api.anthropic.com/v1',
+    modelId: modelId,
+  );
+}
+
+Future<SettingsProvider> _settingsForModel(
+  WidgetTester tester, {
+  required String providerId,
+  required ProviderKind providerType,
+  required String baseUrl,
+  required String modelId,
+}) async {
   SharedPreferences.setMockInitialValues({});
   final settings = SettingsProvider();
   await tester.pump(const Duration(milliseconds: 300));
   await tester.pump();
 
   await settings.setProviderConfig(
-    'Claude',
+    providerId,
     ProviderConfig(
-      id: 'Claude',
+      id: providerId,
       enabled: true,
-      name: 'Claude',
+      name: providerId,
       apiKey: 'test-key',
-      baseUrl: 'https://api.anthropic.com/v1',
-      providerType: ProviderKind.claude,
+      baseUrl: baseUrl,
+      providerType: providerType,
       models: <String>[modelId],
     ),
   );
-  await settings.setCurrentModel('Claude', modelId);
+  await settings.setCurrentModel(providerId, modelId);
   return settings;
 }
 
@@ -101,6 +117,27 @@ void main() {
 
       expect(find.text('Extreme Reasoning'), findsNothing);
       expect(find.text('Maximum Reasoning'), findsNothing);
+    });
+
+    testWidgets('shows max reasoning for GPT-5.6 models', (tester) async {
+      final settings = await _settingsForModel(
+        tester,
+        providerId: 'OpenAI',
+        providerType: ProviderKind.openai,
+        baseUrl: 'https://api.openai.com/v1',
+        modelId: 'gpt-5.6-luna',
+      );
+      await _pumpSheetLauncher(tester, settings: settings);
+
+      await _openSheet(tester);
+
+      expect(find.text('Extreme Reasoning'), findsOneWidget);
+      expect(find.text('Maximum Reasoning'), findsOneWidget);
+
+      await tester.tap(find.text('Maximum Reasoning'));
+      await tester.pumpAndSettle();
+
+      expect(settings.thinkingBudget, 128000);
     });
   });
 }


### PR DESCRIPTION
## Summary

- recognize GPT-5.6, GPT-5.6 Sol, Terra, and Luna as supporting `none`, `low`, `medium`, `high`, `xhigh`, and `max`
- expose the existing Extreme and Maximum reasoning presets for GPT-5.6 models
- encode 64K as `xhigh` and budgets above 64K as `max`, while preserving older-model downgrade ceilings
- add compatibility, request-encoding, and reasoning-selector regression coverage

## Root cause

Kelivo's OpenAI compatibility matrix stopped at GPT-5.5 and modeled `xhigh` as the highest OpenAI effort. GPT-5.6 models therefore failed the capability checks used by the reasoning selectors, and the existing 128K Maximum preset would still have been serialized as `xhigh`.

OpenAI's current [model guidance](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6) documents all six reasoning efforts for GPT-5.6 Sol, Terra, and Luna.

## Validation

- `flutter test --no-pub test/core/utils/openai_model_compat_test.dart test/chat_api_generate_text_encoding_test.dart test/features/chat/widgets/reasoning_budget_sheet_test.dart` — 14 passed
- `dart analyze --fatal-infos lib test` — no issues
- `flutter build windows --release --no-pub` — succeeded
- full `flutter test --no-pub` — 1274 passed, 19 skipped, with 4 unrelated Windows/environment failures documented during development
