### PR TITLE
feat: add multi-model chat

### DIFF
--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -65,6 +65,22 @@ typedef GenerationBeginResult = ({
   GenerationRun run,
 });
 
+typedef GenerationBatchTargetInput = ({
+  ChatMessage assistantMessage,
+  String runId,
+});
+
+typedef GenerationBatchTargetResult = ({
+  ChatMessage assistantMessage,
+  GenerationRun run,
+});
+
+typedef GenerationBatchBeginResult = ({
+  Conversation conversation,
+  ChatMessage userMessage,
+  List<GenerationBatchTargetResult> targets,
+});
+
 class BackupMergeReport {
   const BackupMergeReport({
     required this.importedConversations,
@@ -127,6 +143,10 @@ class ChatDatabaseRepository {
 
   Future<GenerationRun?> getGenerationRun(String id) =>
       GenerationRunCommands(_db).get(id);
+
+  Future<Map<String, GenerationRun>> getLatestGenerationRunsForTargets(
+    Iterable<String> targetRevisionIds,
+  ) => GenerationRunCommands(_db).latestByTargetRevisionIds(targetRevisionIds);
 
   Future<GenerationRun> transitionGenerationRun({
     required String id,
@@ -2642,11 +2662,66 @@ class ChatDatabaseRepository {
     required ChatMessage assistantMessage,
     required String runId,
   }) {
+    return beginSendGenerationBatch(
+      conversation: conversation,
+      userMessage: userMessage,
+      targets: <GenerationBatchTargetInput>[
+        (assistantMessage: assistantMessage, runId: runId),
+      ],
+    ).then((result) {
+      final target = result.targets.single;
+      return (
+        conversation: result.conversation,
+        userMessage: result.userMessage,
+        assistantMessage: target.assistantMessage,
+        run: target.run,
+      );
+    });
+  }
+
+  /// Atomically establishes a user turn and every model target in its batch.
+  /// Network requests must not start until this command succeeds.
+  Future<GenerationBatchBeginResult> beginSendGenerationBatch({
+    required Conversation conversation,
+    required ChatMessage userMessage,
+    required List<GenerationBatchTargetInput> targets,
+  }) {
+    if (targets.isEmpty || targets.length > 5) {
+      throw ArgumentError.value(targets.length, 'targets.length');
+    }
+    final messageIds = <String>{};
+    final runIds = <String>{};
     _validateGenerationBeginMessages(
       conversation: conversation,
       userMessage: userMessage,
-      assistantMessage: assistantMessage,
+      assistantMessage: targets.first.assistantMessage,
     );
+    for (final target in targets) {
+      _validateGenerationBeginMessages(
+        conversation: conversation,
+        assistantMessage: target.assistantMessage,
+      );
+      if (!messageIds.add(target.assistantMessage.id)) {
+        throw ArgumentError.value(
+          target.assistantMessage.id,
+          'targets.assistantMessage.id',
+        );
+      }
+      if (!runIds.add(target.runId)) {
+        throw ArgumentError.value(target.runId, 'targets.runId');
+      }
+    }
+    final groupId = targets.first.assistantMessage.id;
+    final normalized = <GenerationBatchTargetInput>[
+      for (final (index, target) in targets.indexed)
+        (
+          assistantMessage: target.assistantMessage.copyWith(
+            groupId: groupId,
+            version: index,
+          ),
+          runId: target.runId,
+        ),
+    ];
     return _observer.measure(
       ChatDatabaseOperation.commandAppendMessage,
       () => _db.transaction(() async {
@@ -2656,23 +2731,27 @@ class ChatDatabaseRepository {
           selectVersion: false,
           touchUpdatedAt: true,
         );
-        final persisted = await _appendLinearMessageToConversation(
-          conversation: afterUser,
-          message: assistantMessage,
-          selectVersion: false,
-          touchUpdatedAt: true,
-        );
-        final run = await GenerationRunCommands(_db).create(
-          id: runId,
-          conversationId: conversation.id,
-          targetRevisionId: assistantMessage.id,
-          createdAt: assistantMessage.timestamp,
-        );
+        var persisted = afterUser;
+        final results = <GenerationBatchTargetResult>[];
+        for (final (index, target) in normalized.indexed) {
+          persisted = await _appendLinearMessageToConversation(
+            conversation: persisted,
+            message: target.assistantMessage,
+            selectVersion: index == 0,
+            touchUpdatedAt: true,
+          );
+          final run = await GenerationRunCommands(_db).create(
+            id: target.runId,
+            conversationId: conversation.id,
+            targetRevisionId: target.assistantMessage.id,
+            createdAt: target.assistantMessage.timestamp,
+          );
+          results.add((assistantMessage: target.assistantMessage, run: run));
+        }
         return (
           conversation: persisted,
           userMessage: userMessage,
-          assistantMessage: assistantMessage,
-          run: run,
+          targets: List<GenerationBatchTargetResult>.unmodifiable(results),
         );
       }),
     );

--- a/lib/core/database/generation_run_commands.dart
+++ b/lib/core/database/generation_run_commands.dart
@@ -38,6 +38,26 @@ final class GenerationRunCommands {
     return row == null ? null : _map(row);
   }
 
+  Future<Map<String, GenerationRun>> latestByTargetRevisionIds(
+    Iterable<String> targetRevisionIds,
+  ) async {
+    final ids = targetRevisionIds.where((id) => id.isNotEmpty).toSet();
+    if (ids.isEmpty) return const <String, GenerationRun>{};
+    final rows =
+        await (_db.select(_db.generationRunRows)
+              ..where((run) => run.targetRevisionId.isIn(ids))
+              ..orderBy([
+                (run) => OrderingTerm.desc(run.updatedAt),
+                (run) => OrderingTerm.desc(run.createdAt),
+              ]))
+            .get();
+    final result = <String, GenerationRun>{};
+    for (final row in rows) {
+      result.putIfAbsent(row.targetRevisionId, () => _map(row));
+    }
+    return Map<String, GenerationRun>.unmodifiable(result);
+  }
+
   Future<GenerationRun> transition({
     required String id,
     required GenerationRunState expectedState,

--- a/lib/core/models/chat_model_target.dart
+++ b/lib/core/models/chat_model_target.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+/// One concrete provider/model destination used by chat generation.
+final class ChatModelTarget {
+  const ChatModelTarget({required this.providerKey, required this.modelId});
+
+  final String providerKey;
+  final String modelId;
+
+  String get key => '${base64Url.encode(utf8.encode(providerKey))}.$modelId';
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'providerKey': providerKey,
+    'modelId': modelId,
+  };
+
+  factory ChatModelTarget.fromJson(Map<String, dynamic> json) {
+    return ChatModelTarget(
+      providerKey: (json['providerKey'] ?? '').toString(),
+      modelId: (json['modelId'] ?? '').toString(),
+    );
+  }
+
+  bool get isValid =>
+      providerKey.trim().isNotEmpty && modelId.trim().isNotEmpty;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChatModelTarget &&
+          providerKey == other.providerKey &&
+          modelId == other.modelId;
+
+  @override
+  int get hashCode => Object.hash(providerKey, modelId);
+
+  @override
+  String toString() => '$providerKey/$modelId';
+}
+
+enum MultiModelSelectionScope {
+  assistant,
+  conversation,
+  nextMessage;
+
+  static MultiModelSelectionScope fromStorage(Object? value) {
+    final raw = value?.toString();
+    return values.firstWhere(
+      (scope) => scope.name == raw,
+      orElse: () => MultiModelSelectionScope.conversation,
+    );
+  }
+}

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -14,6 +14,8 @@ import '../../l10n/app_localizations.dart';
 import '../../utils/avatar_cache.dart';
 import '../../utils/app_directories.dart';
 
+typedef AssistantDeletedCallback = Future<void> Function(String assistantId);
+
 class AssistantProvider extends ChangeNotifier {
   static const String _assistantsKey = 'assistants_v1';
   static const String _currentAssistantKey = 'current_assistant_id_v1';
@@ -22,6 +24,7 @@ class AssistantProvider extends ChangeNotifier {
   final List<Assistant> _assistants = <Assistant>[];
   String? _currentAssistantId;
   final ChatService? chatService;
+  AssistantDeletedCallback? _assistantDeletedCallback;
 
   List<Assistant> get assistants => List.unmodifiable(_assistants);
   String? get currentAssistantId => _currentAssistantId;
@@ -36,6 +39,22 @@ class AssistantProvider extends ChangeNotifier {
 
   AssistantProvider({this.chatService}) {
     _load();
+  }
+
+  void setAssistantDeletedCallback(AssistantDeletedCallback? callback) {
+    _assistantDeletedCallback = callback;
+  }
+
+  Future<void> _notifyAssistantDeleted(String assistantId) async {
+    final callback = _assistantDeletedCallback;
+    if (callback == null) return;
+    try {
+      await callback(assistantId);
+    } catch (error) {
+      debugPrint(
+        '[AssistantProvider] assistant deletion callback failed: $error',
+      );
+    }
   }
 
   Future<void> _load() async {
@@ -520,6 +539,7 @@ class AssistantProvider extends ChangeNotifier {
     } else {
       await prefs.remove(_currentAssistantKey);
     }
+    await _notifyAssistantDeleted(id);
     notifyListeners();
     return true;
   }

--- a/lib/core/providers/chat_model_selection_provider.dart
+++ b/lib/core/providers/chat_model_selection_provider.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/chat_model_target.dart';
+
+/// Persists ordered chat model combinations independently for each scope.
+///
+/// This provider intentionally stores no database-owned state. Conversation ID
+/// remaps and deletions are exposed as explicit operations so restore and
+/// lifecycle callers can keep this lightweight preference index consistent.
+class ChatModelSelectionProvider extends ChangeNotifier {
+  ChatModelSelectionProvider({SharedPreferences? preferences})
+    : _preferences = preferences {
+    _ready = preferences == null
+        ? _load()
+        : Future<void>.sync(() => _loadFromPreferences(preferences));
+  }
+
+  static const String storageKey = 'chat_model_selections_v1';
+  static const int minimumTargets = 2;
+  static const int maximumTargets = 5;
+  static const String _fallbackAssistantKey = '__default__';
+
+  final SharedPreferences? _preferences;
+  late final Future<void> _ready;
+  MultiModelSelectionScope _scope = MultiModelSelectionScope.conversation;
+  final Map<String, List<ChatModelTarget>> _assistantSelections = {};
+  final Map<String, List<ChatModelTarget>> _conversationSelections = {};
+  final Map<String, List<ChatModelTarget>> _nextMessageSelections = {};
+  bool _loaded = false;
+
+  Future<void> get ready => _ready;
+  bool get isLoaded => _loaded;
+  MultiModelSelectionScope get scope => _scope;
+
+  Future<void> _load() async {
+    final preferences = await SharedPreferences.getInstance();
+    _loadFromPreferences(preferences);
+  }
+
+  void _loadFromPreferences(SharedPreferences preferences) {
+    final raw = preferences.getString(storageKey);
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map) {
+          final json = decoded.cast<String, dynamic>();
+          _scope = MultiModelSelectionScope.fromStorage(json['scope']);
+          _decodeSelectionMap(json['assistants'], _assistantSelections);
+          _decodeSelectionMap(json['conversations'], _conversationSelections);
+          _decodeSelectionMap(json['nextMessages'], _nextMessageSelections);
+        }
+      } catch (_) {
+        _assistantSelections.clear();
+        _conversationSelections.clear();
+        _nextMessageSelections.clear();
+        _scope = MultiModelSelectionScope.conversation;
+      }
+    }
+    _loaded = true;
+    notifyListeners();
+  }
+
+  void _decodeSelectionMap(
+    Object? raw,
+    Map<String, List<ChatModelTarget>> destination,
+  ) {
+    if (raw is! Map) return;
+    for (final entry in raw.entries) {
+      if (entry.value is! List) continue;
+      final targets = <ChatModelTarget>[];
+      for (final value in entry.value as List) {
+        if (value is! Map) continue;
+        final target = ChatModelTarget.fromJson(value.cast<String, dynamic>());
+        if (target.isValid && !targets.contains(target)) targets.add(target);
+        if (targets.length == maximumTargets) break;
+      }
+      if (targets.length >= minimumTargets) {
+        destination[entry.key.toString()] = List.unmodifiable(targets);
+      }
+    }
+  }
+
+  Future<void> setScope(MultiModelSelectionScope value) async {
+    await ready;
+    if (_scope == value) return;
+    _scope = value;
+    await _persist();
+    notifyListeners();
+  }
+
+  List<ChatModelTarget> targetsForScope({
+    MultiModelSelectionScope? scope,
+    String? assistantId,
+    String? conversationId,
+  }) {
+    final activeScope = scope ?? _scope;
+    final targets = switch (activeScope) {
+      MultiModelSelectionScope.assistant =>
+        _assistantSelections[assistantId ?? _fallbackAssistantKey],
+      MultiModelSelectionScope.conversation =>
+        conversationId == null ? null : _conversationSelections[conversationId],
+      MultiModelSelectionScope.nextMessage =>
+        conversationId == null ? null : _nextMessageSelections[conversationId],
+    };
+    return List<ChatModelTarget>.unmodifiable(targets ?? const []);
+  }
+
+  List<ChatModelTarget> effectiveTargets({
+    required ChatModelTarget fallback,
+    String? assistantId,
+    String? conversationId,
+  }) {
+    final configured = targetsForScope(
+      assistantId: assistantId,
+      conversationId: conversationId,
+    );
+    return configured.length >= minimumTargets
+        ? configured
+        : List<ChatModelTarget>.unmodifiable([fallback]);
+  }
+
+  Future<void> setTargets({
+    required List<ChatModelTarget> targets,
+    MultiModelSelectionScope? scope,
+    String? assistantId,
+    String? conversationId,
+  }) async {
+    await ready;
+    final normalized = _normalizeRequired(targets);
+    final activeScope = scope ?? _scope;
+    switch (activeScope) {
+      case MultiModelSelectionScope.assistant:
+        _assistantSelections[assistantId ?? _fallbackAssistantKey] = normalized;
+      case MultiModelSelectionScope.conversation:
+        if (conversationId == null || conversationId.isEmpty) {
+          throw ArgumentError.value(conversationId, 'conversationId');
+        }
+        _conversationSelections[conversationId] = normalized;
+      case MultiModelSelectionScope.nextMessage:
+        if (conversationId == null || conversationId.isEmpty) {
+          throw ArgumentError.value(conversationId, 'conversationId');
+        }
+        _nextMessageSelections[conversationId] = normalized;
+    }
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> clearActiveOverride({
+    String? assistantId,
+    String? conversationId,
+  }) async {
+    await clearTargets(
+      scope: _scope,
+      assistantId: assistantId,
+      conversationId: conversationId,
+    );
+  }
+
+  Future<void> clearTargets({
+    required MultiModelSelectionScope scope,
+    String? assistantId,
+    String? conversationId,
+  }) async {
+    await ready;
+    final removed = switch (scope) {
+      MultiModelSelectionScope.assistant => _assistantSelections.remove(
+        assistantId ?? _fallbackAssistantKey,
+      ),
+      MultiModelSelectionScope.conversation =>
+        conversationId == null
+            ? null
+            : _conversationSelections.remove(conversationId),
+      MultiModelSelectionScope.nextMessage =>
+        conversationId == null
+            ? null
+            : _nextMessageSelections.remove(conversationId),
+    };
+    if (removed == null) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Consume a next-message override only after the generation batch exists.
+  Future<List<ChatModelTarget>> consumeNextMessage(
+    String conversationId,
+  ) async {
+    await ready;
+    final removed = _nextMessageSelections.remove(conversationId);
+    if (removed == null) return const [];
+    await _persist();
+    notifyListeners();
+    return List.unmodifiable(removed);
+  }
+
+  Future<void> removeConversation(String conversationId) async {
+    await ready;
+    final removedConversation =
+        _conversationSelections.remove(conversationId) != null;
+    final removedNextMessage =
+        _nextMessageSelections.remove(conversationId) != null;
+    final changed = removedConversation || removedNextMessage;
+    if (!changed) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> remapConversationIds(Map<String, String> remapping) async {
+    await ready;
+    var changed = false;
+    for (final entry in remapping.entries) {
+      changed =
+          _remapKey(_conversationSelections, entry.key, entry.value) || changed;
+      changed =
+          _remapKey(_nextMessageSelections, entry.key, entry.value) || changed;
+    }
+    if (!changed) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> removeAssistant(String assistantId) async {
+    await ready;
+    if (_assistantSelections.remove(assistantId) == null) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> pruneTargets(
+    bool Function(ChatModelTarget target) isAvailable,
+  ) async {
+    await ready;
+    var changed = false;
+    for (final map in <Map<String, List<ChatModelTarget>>>[
+      _assistantSelections,
+      _conversationSelections,
+      _nextMessageSelections,
+    ]) {
+      for (final key in List<String>.of(map.keys)) {
+        final filtered = map[key]!.where(isAvailable).toList(growable: false);
+        if (filtered.length == map[key]!.length) continue;
+        changed = true;
+        if (filtered.length < minimumTargets) {
+          map.remove(key);
+        } else {
+          map[key] = List.unmodifiable(filtered.take(maximumTargets));
+        }
+      }
+    }
+    if (!changed) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  List<ChatModelTarget> _normalizeRequired(List<ChatModelTarget> targets) {
+    final normalized = <ChatModelTarget>[];
+    for (final target in targets) {
+      if (!target.isValid || normalized.contains(target)) continue;
+      normalized.add(target);
+      if (normalized.length > maximumTargets) {
+        throw ArgumentError.value(
+          targets,
+          'targets',
+          'Select between $minimumTargets and $maximumTargets unique models.',
+        );
+      }
+    }
+    if (normalized.length < minimumTargets) {
+      throw ArgumentError.value(
+        targets,
+        'targets',
+        'Select between $minimumTargets and $maximumTargets unique models.',
+      );
+    }
+    return List.unmodifiable(normalized);
+  }
+
+  bool _remapKey(
+    Map<String, List<ChatModelTarget>> map,
+    String source,
+    String target,
+  ) {
+    if (source == target) return false;
+    final value = map.remove(source);
+    if (value == null) return false;
+    map.putIfAbsent(target, () => value);
+    return true;
+  }
+
+  Future<void> _persist() async {
+    final preferences = _preferences ?? await SharedPreferences.getInstance();
+    final payload = <String, dynamic>{
+      'version': 1,
+      'scope': _scope.name,
+      'assistants': _encodeSelectionMap(_assistantSelections),
+      'conversations': _encodeSelectionMap(_conversationSelections),
+      'nextMessages': _encodeSelectionMap(_nextMessageSelections),
+    };
+    await preferences.setString(storageKey, jsonEncode(payload));
+  }
+
+  Map<String, dynamic> _encodeSelectionMap(
+    Map<String, List<ChatModelTarget>> source,
+  ) => <String, dynamic>{
+    for (final entry in source.entries)
+      entry.key: [for (final target in entry.value) target.toJson()],
+  };
+}

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -25,6 +25,10 @@ import '../utils/openai_model_compat.dart';
 import '../../utils/provider_grouping_logic.dart';
 import '../../utils/brand_assets.dart';
 
+typedef ModelsDeletedCallback =
+    Future<void> Function(String providerKey, Set<String> modelIds);
+typedef ProviderUnavailableCallback = Future<void> Function(String providerKey);
+
 // Desktop: topic list position
 enum DesktopTopicPosition { left, right }
 
@@ -564,8 +568,44 @@ class SettingsProvider extends ChangeNotifier {
   int _appLaunchCount = 0;
   int get appLaunchCount => _appLaunchCount;
 
+  ModelsDeletedCallback? _modelsDeletedCallback;
+  ProviderUnavailableCallback? _providerUnavailableCallback;
+
   SettingsProvider() {
     _load();
+  }
+
+  void setModelSelectionLifecycleCallbacks({
+    ModelsDeletedCallback? onModelsDeleted,
+    ProviderUnavailableCallback? onProviderUnavailable,
+  }) {
+    _modelsDeletedCallback = onModelsDeleted;
+    _providerUnavailableCallback = onProviderUnavailable;
+  }
+
+  Future<void> _notifyModelsDeleted(
+    String providerKey,
+    Set<String> modelIds,
+  ) async {
+    final callback = _modelsDeletedCallback;
+    if (callback == null) return;
+    try {
+      await callback(providerKey, Set.unmodifiable(modelIds));
+    } catch (error) {
+      debugPrint('[SettingsProvider] model deletion callback failed: $error');
+    }
+  }
+
+  Future<void> _notifyProviderUnavailable(String providerKey) async {
+    final callback = _providerUnavailableCallback;
+    if (callback == null) return;
+    try {
+      await callback(providerKey);
+    } catch (error) {
+      debugPrint(
+        '[SettingsProvider] provider unavailable callback failed: $error',
+      );
+    }
   }
 
   Future<_MigrationResult> _migrateEmbeddingModelOverrides(
@@ -2500,8 +2540,13 @@ class SettingsProvider extends ChangeNotifier {
       old.copyWith(models: nextModels, modelOverrides: nextOverrides),
     );
     for (final modelId in deletedModelIds) {
-      await clearSelectionsForModel(providerKey, modelId);
+      await clearSelectionsForModel(
+        providerKey,
+        modelId,
+        notifyModelDeletion: false,
+      );
     }
+    await _notifyModelsDeleted(providerKey, deletedModelIds);
     return deletedCount;
   }
 
@@ -2678,14 +2723,16 @@ class SettingsProvider extends ChangeNotifier {
       changed = true;
     }
     if (changed) notifyListeners();
+    await _notifyProviderUnavailable(providerKey);
   }
 
   /// Clears global model selections that reference a specific model.
   /// Used when a model is deleted from a provider.
   Future<void> clearSelectionsForModel(
     String providerKey,
-    String modelId,
-  ) async {
+    String modelId, {
+    bool notifyModelDeletion = true,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
     bool changed = false;
     if (_currentModelProvider == providerKey && _currentModelId == modelId) {
@@ -2742,6 +2789,9 @@ class SettingsProvider extends ChangeNotifier {
       changed = true;
     }
     if (changed) notifyListeners();
+    if (notifyModelDeletion) {
+      await _notifyModelsDeleted(providerKey, <String>{modelId});
+    }
   }
 
   Future<void> removeProviderConfig(String key) async {
@@ -2805,6 +2855,7 @@ class SettingsProvider extends ChangeNotifier {
     await prefs.setString(_providerConfigsKey, jsonEncode(map));
     await prefs.setStringList(_providersOrderKey, _providersOrder);
     await prefs.setString(_providerGroupMapKey, jsonEncode(_providerGroupMap));
+    await _notifyProviderUnavailable(key);
     notifyListeners();
   }
 

--- a/lib/core/services/backup/backup_settings_validator.dart
+++ b/lib/core/services/backup/backup_settings_validator.dart
@@ -28,6 +28,7 @@ final class BackupSettingsValidator {
     'provider_group_collapsed_v1',
     'assistant_tag_map_v1',
     'assistant_tag_collapsed_v1',
+    'chat_model_selections_v1',
   };
   static const _jsonMapOfMapKeys = {'provider_configs_v1'};
   static const _jsonMapOfStringKeys = {
@@ -86,7 +87,50 @@ final class BackupSettingsValidator {
       _validateJsonShape(key, value, expectList: true);
     } else if (_jsonMapKeys.contains(key)) {
       _validateJsonShape(key, value, expectList: false);
+      if (key == 'chat_model_selections_v1') {
+        _validateChatModelSelections(key, value);
+      }
     }
+  }
+
+  /// Merges the preference-backed multi-model selection index during a backup
+  /// merge. Only incoming conversation IDs are remapped: the database merge
+  /// report describes imported IDs, not local conversation renames.
+  static String mergeChatModelSelectionsForRestore({
+    required String incomingValue,
+    String? existingValue,
+    Map<String, String> remappedConversationIds = const <String, String>{},
+  }) {
+    final incoming = _decodeChatModelSelections(incomingValue);
+    final existing = existingValue == null || existingValue.isEmpty
+        ? const <String, dynamic>{}
+        : _decodeChatModelSelections(existingValue);
+
+    Map<String, dynamic> mergeIndex(String key, {required bool remap}) {
+      final imported = _selectionIndex(incoming[key]);
+      final remapped = <String, dynamic>{};
+      for (final entry in imported.entries) {
+        final targetKey = remap
+            ? (remappedConversationIds[entry.key] ?? entry.key)
+            : entry.key;
+        remapped.putIfAbsent(targetKey, () => entry.value);
+      }
+      // Local scope history wins when an imported identifier still collides.
+      return <String, dynamic>{...remapped, ..._selectionIndex(existing[key])};
+    }
+
+    final merged = <String, dynamic>{
+      ...incoming,
+      ...existing,
+      'version': existing['version'] ?? incoming['version'] ?? 1,
+      'scope': existing['scope'] ?? incoming['scope'] ?? 'conversation',
+      'assistants': mergeIndex('assistants', remap: false),
+      'conversations': mergeIndex('conversations', remap: true),
+      'nextMessages': mergeIndex('nextMessages', remap: true),
+    };
+    final encoded = jsonEncode(merged);
+    _validateChatModelSelections('chat_model_selections_v1', encoded);
+    return encoded;
   }
 
   static void _validateJsonShape(
@@ -114,6 +158,70 @@ final class BackupSettingsValidator {
         throw FormatException(key);
       }
     } on FormatException {
+      throw FormatException(key);
+    }
+  }
+
+  static Map<String, dynamic> _decodeChatModelSelections(String value) {
+    _validateChatModelSelections('chat_model_selections_v1', value);
+    return Map<String, dynamic>.from(jsonDecode(value) as Map);
+  }
+
+  static Map<String, dynamic> _selectionIndex(Object? value) {
+    if (value == null) return const <String, dynamic>{};
+    return Map<String, dynamic>.from(value as Map);
+  }
+
+  static void _validateChatModelSelections(String key, dynamic value) {
+    if (value is! String) throw FormatException(key);
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! Map) throw FormatException(key);
+      final version = decoded['version'];
+      if (version != null && version != 1) throw FormatException(key);
+      final scope = decoded['scope'];
+      if (scope != null &&
+          scope != 'assistant' &&
+          scope != 'conversation' &&
+          scope != 'nextMessage') {
+        throw FormatException(key);
+      }
+      for (final indexKey in const <String>[
+        'assistants',
+        'conversations',
+        'nextMessages',
+      ]) {
+        final index = decoded[indexKey];
+        if (index == null) continue;
+        if (index is! Map) throw FormatException(key);
+        for (final entry in index.entries) {
+          if (entry.key is! String || (entry.key as String).isEmpty) {
+            throw FormatException(key);
+          }
+          final targets = entry.value;
+          if (targets is! List || targets.length < 2 || targets.length > 5) {
+            throw FormatException(key);
+          }
+          final seen = <String>{};
+          for (final target in targets) {
+            if (target is! Map ||
+                target['providerKey'] is! String ||
+                target['modelId'] is! String) {
+              throw FormatException(key);
+            }
+            final providerKey = (target['providerKey'] as String).trim();
+            final modelId = (target['modelId'] as String).trim();
+            if (providerKey.isEmpty ||
+                modelId.isEmpty ||
+                !seen.add('$providerKey\u0000$modelId')) {
+              throw FormatException(key);
+            }
+          }
+        }
+      }
+    } on FormatException {
+      throw FormatException(key);
+    } on Object {
       throw FormatException(key);
     }
   }

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -1474,6 +1474,7 @@ class DataSync {
               'assistant_tags_v1', // Ordered tag list [{id,name}]
               'assistant_tag_map_v1', // assistantId -> tagId
               'assistant_tag_collapsed_v1', // tagId -> bool
+              'chat_model_selections_v1', // ordered chat model combinations
             };
 
             for (final entry in settings.entries) {
@@ -1482,7 +1483,17 @@ class DataSync {
 
               if (mergeableKeys.contains(key)) {
                 // Special handling for mergeable configurations
-                if (key == 'assistants_v1' && existing.containsKey(key)) {
+                if (key == 'chat_model_selections_v1') {
+                  pendingSettings[key] =
+                      BackupSettingsValidator.mergeChatModelSelectionsForRestore(
+                        incomingValue: newValue as String,
+                        existingValue: existing[key] as String?,
+                        remappedConversationIds:
+                            _lastMergeReport?.remappedConversationIds ??
+                            const <String, String>{},
+                      );
+                } else if (key == 'assistants_v1' &&
+                    existing.containsKey(key)) {
                   // Merge assistants by ID with field-level rules.
                   // Preserve local avatar if already set to avoid clearing/overwriting.
                   final existingAssistants =

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -11,6 +11,7 @@ import '../../database/chat_database_gateway.dart';
 import '../../database/chat_database_repository.dart';
 import '../../database/generation_run.dart';
 import '../../models/chat_message.dart';
+import '../../models/chat_model_target.dart';
 import '../../models/conversation.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
@@ -50,6 +51,32 @@ final class LoadedTimelinePage {
 }
 
 typedef AssetContentHash = Future<String> Function(File file);
+typedef ConversationDeletedCallback =
+    Future<void> Function(String conversationId);
+
+final class ChatGenerationBatchTarget {
+  const ChatGenerationBatchTarget({
+    required this.target,
+    required this.assistantMessage,
+    required this.run,
+  });
+
+  final ChatModelTarget target;
+  final ChatMessage assistantMessage;
+  final GenerationRun? run;
+}
+
+final class ChatGenerationBatchResult {
+  ChatGenerationBatchResult({
+    required this.userMessage,
+    required List<ChatGenerationBatchTarget> targets,
+  }) : targets = List.unmodifiable(targets);
+
+  final ChatMessage userMessage;
+  final List<ChatGenerationBatchTarget> targets;
+
+  ChatGenerationBatchTarget get primaryTarget => targets.first;
+}
 
 class ChatService extends ChangeNotifier {
   ChatService({
@@ -73,9 +100,24 @@ class ChatService extends ChangeNotifier {
   late File _databaseFile;
   final ChatDatabaseGateway _databaseGateway;
   final AssetContentHash _assetContentHash;
+  ConversationDeletedCallback? _conversationDeletedCallback;
   ChatDatabaseLease? _databaseLease;
   Future<void>? _assetReferenceMaintenanceFuture;
   Future<void>? _postStartupAssetMaintenanceFuture;
+
+  void setConversationDeletedCallback(ConversationDeletedCallback? callback) {
+    _conversationDeletedCallback = callback;
+  }
+
+  Future<void> _notifyConversationDeleted(String conversationId) async {
+    final callback = _conversationDeletedCallback;
+    if (callback == null) return;
+    try {
+      await callback(conversationId);
+    } catch (error) {
+      debugPrint('[ChatService] conversation deletion callback failed: $error');
+    }
+  }
 
   String? _currentConversationId;
   final Map<String, List<ChatMessage>> _messagesCache = {};
@@ -1069,6 +1111,7 @@ class ChatService extends ChangeNotifier {
     if (_currentConversationId == id) {
       _currentConversationId = null;
     }
+    unawaited(_notifyConversationDeleted(id));
   }
 
   Future<void> deleteConversation(String id) async {
@@ -1078,6 +1121,8 @@ class ChatService extends ChangeNotifier {
         await _deleteDraftConversation(id) ||
         await _deletePersistedConversation(id);
     if (!deleted) return;
+
+    await _notifyConversationDeleted(id);
 
     // Delete orphaned files (not referenced by any remaining conversation)
     await _cleanupOrphanUploads();
@@ -1131,15 +1176,22 @@ class ChatService extends ChangeNotifier {
         .map((conversation) => conversation.id)
         .toList(growable: false);
 
-    var deleted = false;
+    final deletedConversationIds = <String>[];
     for (final conversationId in draftConversationIds) {
-      deleted = await _deleteDraftConversation(conversationId) || deleted;
+      if (await _deleteDraftConversation(conversationId)) {
+        deletedConversationIds.add(conversationId);
+      }
     }
     for (final conversationId in persistedConversationIds) {
-      deleted = await _deletePersistedConversation(conversationId) || deleted;
+      if (await _deletePersistedConversation(conversationId)) {
+        deletedConversationIds.add(conversationId);
+      }
     }
 
-    if (!deleted) return;
+    if (deletedConversationIds.isEmpty) return;
+    for (final conversationId in deletedConversationIds) {
+      await _notifyConversationDeleted(conversationId);
+    }
     await _cleanupOrphanUploads();
     notifyListeners();
   }
@@ -1454,6 +1506,10 @@ class ChatService extends ChangeNotifier {
     required Map<String, String> geminiSignaturesByMessageId,
   }) async {
     if (!_initialized) await init();
+    final previousConversationIds = <String>{
+      ..._conversationsCache.keys,
+      ..._draftConversations.keys,
+    };
 
     final nextOrderByConversation = <String, int>{};
     final orderedMessages = <({ChatMessage message, int messageOrder})>[];
@@ -1473,7 +1529,9 @@ class ChatService extends ChangeNotifier {
       geminiSignaturesByMessageId: geminiSignaturesByMessageId,
     );
 
-    await _resetAfterOverwriteRestore();
+    await _resetAfterOverwriteRestore(
+      previousConversationIds: previousConversationIds,
+    );
   }
 
   Future<ChatDatabaseSnapshotInfo> createBackupDatabaseSnapshot(
@@ -1492,8 +1550,14 @@ class ChatService extends ChangeNotifier {
 
   Future<void> restoreDatabaseSnapshot(File snapshotFile) async {
     if (!_initialized) await init();
+    final previousConversationIds = <String>{
+      ..._conversationsCache.keys,
+      ..._draftConversations.keys,
+    };
     await _repo.replaceBackupSnapshot(snapshotFile);
-    await _resetAfterOverwriteRestore();
+    await _resetAfterOverwriteRestore(
+      previousConversationIds: previousConversationIds,
+    );
   }
 
   Future<BackupMergeReport> mergeDatabaseSnapshot(File snapshotFile) async {
@@ -1531,7 +1595,9 @@ class ChatService extends ChangeNotifier {
     return report;
   }
 
-  Future<void> _resetAfterOverwriteRestore() async {
+  Future<void> _resetAfterOverwriteRestore({
+    Set<String> previousConversationIds = const <String>{},
+  }) async {
     _messagesCache.clear();
     _draftConversations.clear();
     _temporaryConversationIds.clear();
@@ -1544,6 +1610,12 @@ class ChatService extends ChangeNotifier {
     _currentConversationId = null;
     await _backfillAssetReferencesForCurrentRoot();
     await _loadConversationsCache();
+    final deletedConversationIds = previousConversationIds.difference(
+      _conversationsCache.keys.toSet(),
+    );
+    for (final conversationId in deletedConversationIds) {
+      await _notifyConversationDeleted(conversationId);
+    }
     notifyListeners();
   }
 
@@ -1865,37 +1937,125 @@ class ChatService extends ChangeNotifier {
     required String providerId,
   }) async {
     if (!_initialized) await init();
+    // The legacy return type requires a persisted GenerationRun. Temporary
+    // conversations use [beginSendGenerationBatch], whose run entries are null.
     if (isTemporaryConversation(conversationId)) {
       throw StateError('temporary_generation_is_not_persisted');
     }
+    final batch = await beginSendGenerationBatch(
+      conversationId: conversationId,
+      userContent: userContent,
+      targets: <ChatModelTarget>[
+        ChatModelTarget(providerKey: providerId, modelId: modelId),
+      ],
+    );
+    final primary = batch.primaryTarget;
+    return (
+      conversation:
+          _conversationsCache[conversationId] ??
+          _draftConversations[conversationId]!,
+      userMessage: batch.userMessage,
+      assistantMessage: primary.assistantMessage,
+      run: primary.run!,
+    );
+  }
+
+  Future<ChatGenerationBatchResult> beginSendGenerationBatch({
+    required String conversationId,
+    required String userContent,
+    required List<ChatModelTarget> targets,
+  }) async {
+    if (!_initialized) await init();
+    final normalizedTargets = <ChatModelTarget>[];
+    for (final target in targets) {
+      if (!target.isValid || normalizedTargets.contains(target)) continue;
+      normalizedTargets.add(target);
+      if (normalizedTargets.length > 5) {
+        throw ArgumentError.value(targets, 'targets');
+      }
+    }
+    if (normalizedTargets.isEmpty) {
+      throw ArgumentError.value(targets, 'targets');
+    }
+
     final conversation =
         _conversationsCache[conversationId] ??
         _draftConversations[conversationId] ??
         Conversation(id: conversationId, title: _defaultConversationTitle);
-    if (_conversationsCache.containsKey(conversationId)) {
-      await _loadMessageOrder(conversationId);
-    }
     final userMessage = ChatMessage(
       role: 'user',
       content: userContent,
       conversationId: conversationId,
     );
-    final assistantMessage = ChatMessage(
-      role: 'assistant',
-      content: '',
-      conversationId: conversationId,
-      modelId: modelId,
-      providerId: providerId,
-      isStreaming: true,
-    );
-    final result = await _repo.beginSendGeneration(
+    final firstAssistantId = const Uuid().v4();
+    final assistantMessages = <ChatMessage>[
+      for (final (index, target) in normalizedTargets.indexed)
+        ChatMessage(
+          id: index == 0 ? firstAssistantId : const Uuid().v4(),
+          role: 'assistant',
+          content: '',
+          conversationId: conversationId,
+          modelId: target.modelId,
+          providerId: target.providerKey,
+          isStreaming: true,
+          groupId: firstAssistantId,
+          version: index,
+        ),
+    ];
+
+    if (isTemporaryConversation(conversationId)) {
+      _draftConversations[conversationId] = conversation;
+      conversation.messageIds.addAll(<String>[
+        userMessage.id,
+        ...assistantMessages.map((message) => message.id),
+      ]);
+      conversation.versionSelections[firstAssistantId] = 0;
+      conversation.updatedAt = DateTime.now();
+      final messages = _messagesCache.putIfAbsent(
+        conversationId,
+        () => <ChatMessage>[],
+      );
+      messages.addAll(<ChatMessage>[userMessage, ...assistantMessages]);
+      notifyListeners();
+      return ChatGenerationBatchResult(
+        userMessage: userMessage,
+        targets: <ChatGenerationBatchTarget>[
+          for (final (index, target) in normalizedTargets.indexed)
+            ChatGenerationBatchTarget(
+              target: target,
+              assistantMessage: assistantMessages[index],
+              run: null,
+            ),
+        ],
+      );
+    }
+
+    if (_conversationsCache.containsKey(conversationId)) {
+      await _loadMessageOrder(conversationId);
+    }
+    final runIds = <String>[
+      for (final _ in assistantMessages) const Uuid().v4(),
+    ];
+    final result = await _repo.beginSendGenerationBatch(
       conversation: conversation,
       userMessage: userMessage,
-      assistantMessage: assistantMessage,
-      runId: const Uuid().v4(),
+      targets: <GenerationBatchTargetInput>[
+        for (final (index, message) in assistantMessages.indexed)
+          (assistantMessage: message, runId: runIds[index]),
+      ],
     );
-    await _publishGenerationBegin(result);
-    return result;
+    await _publishGenerationBatchBegin(result);
+    return ChatGenerationBatchResult(
+      userMessage: result.userMessage,
+      targets: <ChatGenerationBatchTarget>[
+        for (final (index, target) in result.targets.indexed)
+          ChatGenerationBatchTarget(
+            target: normalizedTargets[index],
+            assistantMessage: target.assistantMessage,
+            run: target.run,
+          ),
+      ],
+    );
   }
 
   Future<GenerationBeginResult> beginRegeneration({
@@ -1949,6 +2109,33 @@ class ChatService extends ChangeNotifier {
     if (result.userMessage case final userMessage?
         when _messageCanOwnAssets(userMessage)) {
       await _synchronizeMessageAssetsBestEffort(userMessage);
+    }
+    final order = _messageOrderIds.putIfAbsent(
+      conversationId,
+      () => <String>[],
+    );
+    for (final message in messages) {
+      if (!order.contains(message.id)) order.add(message.id);
+    }
+    _messageCounts[conversationId] = order.length;
+    if (_messagesCache.containsKey(conversationId)) {
+      _messagesCache[conversationId]!.addAll(messages);
+    }
+    notifyListeners();
+  }
+
+  Future<void> _publishGenerationBatchBegin(
+    GenerationBatchBeginResult result,
+  ) async {
+    final conversationId = result.conversation.id;
+    _draftConversations.remove(conversationId);
+    _conversationsCache[conversationId] = result.conversation;
+    final messages = <ChatMessage>[
+      result.userMessage,
+      ...result.targets.map((target) => target.assistantMessage),
+    ];
+    if (_messageCanOwnAssets(result.userMessage)) {
+      await _synchronizeMessageAssetsBestEffort(result.userMessage);
     }
     final order = _messageOrderIds.putIfAbsent(
       conversationId,
@@ -2142,6 +2329,13 @@ class ChatService extends ChangeNotifier {
     );
     _replaceCachedMessage(message);
     _toolEventsCache[message.id] = List<Map<String, dynamic>>.of(toolEvents);
+  }
+
+  Future<Map<String, GenerationRun>> loadLatestGenerationRunsForTargets(
+    Iterable<String> targetRevisionIds,
+  ) async {
+    if (!_initialized) await init();
+    return _repo.getLatestGenerationRunsForTargets(targetRevisionIds);
   }
 
   Future<GenerationRun> transitionGenerationRun({
@@ -2613,6 +2807,10 @@ class ChatService extends ChangeNotifier {
 
   Future<void> clearAllData({bool deleteUploads = true}) async {
     if (!_initialized) await init();
+    final deletedConversationIds = <String>{
+      ..._conversationsCache.keys,
+      ..._draftConversations.keys,
+    };
 
     await _repo.clearAllData();
     _messagesCache.clear();
@@ -2631,6 +2829,9 @@ class ChatService extends ChangeNotifier {
       if (await uploadDir.exists()) {
         await uploadDir.delete(recursive: true);
       }
+    }
+    for (final conversationId in deletedConversationIds) {
+      await _notifyConversationDeleted(conversationId);
     }
     notifyListeners();
   }

--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -11,6 +11,8 @@ import '../l10n/app_localizations.dart';
 import '../theme/app_font_weights.dart';
 import '../theme/palettes.dart';
 import '../core/providers/settings_provider.dart';
+import '../core/providers/chat_model_selection_provider.dart';
+import '../core/models/chat_model_target.dart';
 import '../core/providers/model_provider.dart';
 import '../core/services/logging/flutter_logger.dart';
 import '../core/services/model_override_resolver.dart';

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -100,6 +100,7 @@ class _DisplaySettingsBody extends StatelessWidget {
               _SettingsCard(
                 title: l10n.displaySettingsPageBehaviorStartupTitle,
                 children: const [
+                  _MultiModelScopeSection(),
                   _ToggleRowAutoSwitchTopicsDesktop(),
                   _RowDivider(),
                   _ToggleRowAutoCollapseThinking(),
@@ -2174,6 +2175,75 @@ class _ToggleRowAutoCollapseThinking extends StatelessWidget {
       value: sp.autoCollapseThinking,
       onChanged: (v) =>
           context.read<SettingsProvider>().setAutoCollapseThinking(v),
+    );
+  }
+}
+
+class _MultiModelScopeSection extends StatelessWidget {
+  const _MultiModelScopeSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final selection = context.watch<ChatModelSelectionProvider?>();
+    if (selection == null) return const SizedBox.shrink();
+
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    String label(MultiModelSelectionScope value) => switch (value) {
+      MultiModelSelectionScope.assistant => l10n.multiModelScopeAssistant,
+      MultiModelSelectionScope.conversation => l10n.multiModelScopeConversation,
+      MultiModelSelectionScope.nextMessage => l10n.multiModelScopeNextMessage,
+    };
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.multiModelScopeTitle,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: AppFontWeights.semibold,
+                        color: cs.onSurface.withValues(alpha: 0.9),
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      l10n.multiModelScopeSubtitle,
+                      style: TextStyle(
+                        fontSize: 11.5,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              SegmentedButton<MultiModelSelectionScope>(
+                segments: [
+                  for (final value in MultiModelSelectionScope.values)
+                    ButtonSegment<MultiModelSelectionScope>(
+                      value: value,
+                      label: Text(label(value)),
+                    ),
+                ],
+                selected: <MultiModelSelectionScope>{selection.scope},
+                showSelectedIcon: false,
+                onSelectionChanged: (values) =>
+                    selection.setScope(values.single),
+              ),
+            ],
+          ),
+        ),
+        const _RowDivider(),
+      ],
     );
   }
 }

--- a/lib/features/home/controllers/active_streaming_message_store.dart
+++ b/lib/features/home/controllers/active_streaming_message_store.dart
@@ -2,27 +2,64 @@ import '../../../core/models/chat_message.dart';
 
 /// Keeps generation identity independent from the currently loaded timeline.
 class ActiveStreamingMessageStore {
-  final Map<String, ChatMessage> _messagesByConversation =
-      <String, ChatMessage>{};
+  final Map<String, ChatMessage> _messagesById = <String, ChatMessage>{};
+  final Map<String, List<String>> _messageIdsByConversation =
+      <String, List<String>>{};
 
   ChatMessage? operator [](String conversationId) {
-    return _messagesByConversation[conversationId];
+    final ids = _messageIdsByConversation[conversationId];
+    if (ids == null || ids.isEmpty) return null;
+    return _messagesById[ids.last];
   }
 
   void put(ChatMessage message) {
-    _messagesByConversation[message.conversationId] = message;
+    _messagesById[message.id] = message;
+    final ids = _messageIdsByConversation.putIfAbsent(
+      message.conversationId,
+      () => <String>[],
+    );
+    if (!ids.contains(message.id)) ids.add(message.id);
   }
 
   bool isActive(ChatMessage message) {
-    return _messagesByConversation[message.conversationId]?.id == message.id;
+    return _messagesById.containsKey(message.id);
   }
+
+  bool hasActiveConversation(String conversationId) =>
+      _messageIdsByConversation[conversationId]?.isNotEmpty ?? false;
+
+  List<ChatMessage> activeMessages(String conversationId) =>
+      List<ChatMessage>.unmodifiable(
+        (_messageIdsByConversation[conversationId] ?? const <String>[])
+            .map((id) => _messagesById[id])
+            .whereType<ChatMessage>(),
+      );
 
   ChatMessage? cancellationTarget(
     String conversationId,
     List<ChatMessage> loadedMessages,
+    Map<String, int> versionSelections,
   ) {
-    final active = _messagesByConversation[conversationId];
-    if (active != null) return active;
+    final active = activeMessages(conversationId);
+    if (active.isNotEmpty) {
+      final groups = <String>{
+        for (final message in active) message.groupId ?? message.id,
+      };
+      for (final groupId in groups) {
+        final selectedVersion = versionSelections[groupId];
+        if (selectedVersion == null) continue;
+        for (final message in active) {
+          if ((message.groupId ?? message.id) == groupId &&
+              message.version == selectedVersion) {
+            return message;
+          }
+        }
+        // The selected sibling is terminal. Do not silently stop a different
+        // model; the user can switch to an answer that is still generating.
+        return null;
+      }
+      return active.last;
+    }
     for (var index = loadedMessages.length - 1; index >= 0; index--) {
       final message = loadedMessages[index];
       if (message.conversationId == conversationId &&
@@ -35,8 +72,11 @@ class ActiveStreamingMessageStore {
   }
 
   void removeIfMatches(ChatMessage message) {
-    if (_messagesByConversation[message.conversationId]?.id == message.id) {
-      _messagesByConversation.remove(message.conversationId);
+    if (_messagesById.remove(message.id) == null) return;
+    final ids = _messageIdsByConversation[message.conversationId];
+    ids?.remove(message.id);
+    if (ids?.isEmpty ?? false) {
+      _messageIdsByConversation.remove(message.conversationId);
     }
   }
 }

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -6,9 +6,11 @@ import '../../../core/database/generation_run.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/chat_model_target.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/models/token_usage.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/chat_model_selection_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
@@ -92,15 +94,28 @@ class ChatActionResult {
   final bool success;
   final String? errorMessage;
   final ChatMessage? assistantMessage;
+  final List<ChatMessage> assistantMessages;
 
   ChatActionResult({
     required this.success,
     this.errorMessage,
     this.assistantMessage,
-  });
+    List<ChatMessage>? assistantMessages,
+  }) : assistantMessages = List.unmodifiable(
+         assistantMessages ??
+             (assistantMessage == null
+                 ? const <ChatMessage>[]
+                 : <ChatMessage>[assistantMessage]),
+       );
 
-  factory ChatActionResult.success(ChatMessage assistantMessage) =>
-      ChatActionResult(success: true, assistantMessage: assistantMessage);
+  factory ChatActionResult.success(
+    ChatMessage assistantMessage, {
+    List<ChatMessage>? allAssistantMessages,
+  }) => ChatActionResult(
+    success: true,
+    assistantMessage: assistantMessage,
+    assistantMessages: allAssistantMessages,
+  );
 
   factory ChatActionResult.error(String message) =>
       ChatActionResult(success: false, errorMessage: message);
@@ -126,6 +141,24 @@ class ChatActions {
     required bool deleteTrailingEnabled,
     required bool isTemporaryConversation,
   }) => deleteTrailingEnabled && isTemporaryConversation;
+
+  @visibleForTesting
+  static ({String? providerKey, String? modelId})
+  resolveRegenerationModelTarget({
+    required ChatMessage message,
+    required String? fallbackProviderKey,
+    required String? fallbackModelId,
+  }) {
+    final messageProviderKey = message.providerId;
+    final messageModelId = message.modelId;
+    if (messageProviderKey != null &&
+        messageProviderKey.trim().isNotEmpty &&
+        messageModelId != null &&
+        messageModelId.trim().isNotEmpty) {
+      return (providerKey: messageProviderKey, modelId: messageModelId);
+    }
+    return (providerKey: fallbackProviderKey, modelId: fallbackModelId);
+  }
 
   ChatActions({
     required this.chatService,
@@ -208,9 +241,19 @@ class ChatActions {
   Future<void> _startIosBackgroundGeneration(
     stream_ctrl.GenerationContext ctx,
   ) async {
+    if (!_iosBackgroundStartedConversations.add(
+      ctx.assistantMessage.conversationId,
+    )) {
+      return;
+    }
     final settings = ctx.settings;
     final l10n = _l10n;
-    if (l10n == null) return;
+    if (l10n == null) {
+      _iosBackgroundStartedConversations.remove(
+        ctx.assistantMessage.conversationId,
+      );
+      return;
+    }
     try {
       await IosBackgroundGenerationService.instance.start(
         enabled: settings.iosBackgroundGenerationEnabled,
@@ -287,12 +330,14 @@ class ChatActions {
       <String, _GenerationCheckpointCursor>{};
   final ActiveStreamingMessageStore _activeAssistantMessages =
       ActiveStreamingMessageStore();
+  final Map<String, bool> _batchHadSuccessfulReply = <String, bool>{};
+  final Map<String, bool> _batchHadFailure = <String, bool>{};
+  final Map<String, bool> _batchShouldGenerateTitle = <String, bool>{};
+  final Set<String> _iosBackgroundStartedConversations = <String>{};
 
   List<ChatMessage> get _messages => chatController.messages;
   Map<String, int> get _versionSelections => chatController.versionSelections;
   Conversation? get _currentConversation => chatController.currentConversation;
-  Set<String> get _loadingConversationIds =>
-      chatController.loadingConversationIds;
   Map<String, StreamSubscription<dynamic>> get _conversationStreams =>
       chatController.conversationStreams;
 
@@ -367,6 +412,7 @@ class ChatActions {
   }
 
   void _registerGenerationRun(String messageId, String? runId) {
+    chatController.setGenerationState(messageId, GenerationRunState.preparing);
     if (runId == null) return;
     _generationCheckpointCursors[messageId] = _GenerationCheckpointCursor(
       runId: runId,
@@ -409,6 +455,7 @@ class ChatActions {
         await writer.finalize(writeFinal);
       }
       committed = true;
+      chatController.setGenerationState(message.id, terminalState);
     } finally {
       if (committed) _clearGenerationRuntimeState(message);
     }
@@ -418,6 +465,59 @@ class ChatActions {
     _generationCheckpointCursors.remove(message.id);
     _streamingToolEvents.remove(message.id);
     _activeAssistantMessages.removeIfMatches(message);
+  }
+
+  bool _batchHasActiveMessages(String conversationId) =>
+      _activeAssistantMessages.hasActiveConversation(conversationId);
+
+  bool _finishConversationIfBatchComplete(String conversationId) {
+    if (_batchHasActiveMessages(conversationId)) return false;
+    _setConversationLoading(conversationId, false);
+    return true;
+  }
+
+  void _markBatchStarted(
+    String conversationId, {
+    required bool shouldGenerateTitle,
+  }) {
+    _batchHadSuccessfulReply[conversationId] = false;
+    _batchHadFailure[conversationId] = false;
+    _batchShouldGenerateTitle[conversationId] = shouldGenerateTitle;
+  }
+
+  ChatMessage _selectedBatchReply(ChatMessage fallback) {
+    final groupId = fallback.groupId ?? fallback.id;
+    final selectedVersion = _versionSelections[groupId] ?? fallback.version;
+    final candidates = chatController.groupedMessages[groupId];
+    if (candidates != null) {
+      for (final candidate in candidates) {
+        if (candidate.version == selectedVersion) return candidate;
+      }
+    }
+    return fallback;
+  }
+
+  Future<bool> _completeBatchIfReady(
+    String conversationId, {
+    required ChatMessage fallback,
+  }) async {
+    if (!_finishConversationIfBatchComplete(conversationId)) return false;
+    final hadSuccess = _batchHadSuccessfulReply.remove(conversationId) ?? false;
+    final hadFailure = _batchHadFailure.remove(conversationId) ?? false;
+    final shouldGenerateTitle =
+        _batchShouldGenerateTitle.remove(conversationId) ?? false;
+    final selected = _selectedBatchReply(fallback);
+    if (hadSuccess) {
+      onAssistantMessageFinished?.call(selected);
+      if (shouldGenerateTitle) onMaybeGenerateTitle?.call(conversationId);
+      onMaybeGenerateSummary?.call(conversationId);
+      onMaybeGenerateSuggestions?.call(conversationId);
+    }
+    if (_iosBackgroundStartedConversations.remove(conversationId)) {
+      await _finishIosBackgroundGeneration(success: hadSuccess && !hadFailure);
+    }
+    onStreamFinished?.call();
+    return true;
   }
 
   Future<void> _finishPreparingMessage(
@@ -439,10 +539,11 @@ class ChatActions {
       );
     } finally {
       _clearGenerationRuntimeState(message);
+      _batchHadFailure[conversationId] = true;
       if (chatController.publishTerminalMessage(message)) {
         onMessagesChanged?.call();
       }
-      _setConversationLoading(conversationId, false);
+      await _completeBatchIfReady(conversationId, fallback: message);
     }
   }
 
@@ -777,8 +878,28 @@ class ChatActions {
     if (modelConfig.providerKey == null || modelConfig.modelId == null) {
       return ChatActionResult.noModel();
     }
-    final providerKey = modelConfig.providerKey!;
-    final modelId = modelConfig.modelId!;
+    final fallbackTarget = ChatModelTarget(
+      providerKey: modelConfig.providerKey!,
+      modelId: modelConfig.modelId!,
+    );
+    ChatModelSelectionProvider? selectionProvider;
+    try {
+      selectionProvider = contextProvider.read<ChatModelSelectionProvider>();
+      await selectionProvider.ready;
+      await selectionProvider.pruneTargets((target) {
+        final config = settings.getProviderConfig(target.providerKey);
+        return config.enabled && config.models.contains(target.modelId);
+      });
+    } catch (_) {}
+    final targets =
+        selectionProvider?.effectiveTargets(
+          fallback: fallbackTarget,
+          assistantId: assistantId,
+          conversationId: conversation.id,
+        ) ??
+        <ChatModelTarget>[fallbackTarget];
+    final selectionScope = selectionProvider?.scope;
+    final isMultiModel = targets.length > 1;
 
     if (chatController.hasMoreAfter) {
       final loaded = await chatController.loadEndWindow();
@@ -792,124 +913,177 @@ class ChatActions {
           conversation,
           maxMessages: _contextReadLimit(assistant, conversation),
         );
-    if (_hasUnsupportedAudioAttachments(
-      messages: existingContextMessages,
-      conversation: conversation,
-      settings: settings,
-      providerKey: providerKey,
-      modelId: modelId,
-      pendingInput: input,
-      maxRawTruncateIndex: null,
-    )) {
-      return ChatActionResult.error('audio_attachment_unsupported');
+    final lastContextAssistant = existingContextMessages.lastWhere(
+      (message) => message.role == 'assistant',
+      orElse: () => ChatMessage(
+        role: 'assistant',
+        content: '__available__',
+        conversationId: conversation.id,
+      ),
+    );
+    if (!lastContextAssistant.isStreaming &&
+        lastContextAssistant.content.trim().isEmpty &&
+        (chatController
+                    .groupedMessages[lastContextAssistant.groupId ??
+                        lastContextAssistant.id]
+                    ?.length ??
+                1) >
+            1) {
+      return ChatActionResult.error('selected_model_answer_unavailable');
+    }
+    final incompatibleAttachmentTargets = <ChatModelTarget>[];
+    for (final target in targets) {
+      if (_hasUnsupportedAudioAttachments(
+        messages: existingContextMessages,
+        conversation: conversation,
+        settings: settings,
+        providerKey: target.providerKey,
+        modelId: target.modelId,
+        pendingInput: input,
+        maxRawTruncateIndex: null,
+      )) {
+        incompatibleAttachmentTargets.add(target);
+      }
+    }
+    if (incompatibleAttachmentTargets.isNotEmpty) {
+      if (!isMultiModel) {
+        return ChatActionResult.error('audio_attachment_unsupported');
+      }
+      final labels = incompatibleAttachmentTargets
+          .map((target) => '${target.providerKey}/${target.modelId}')
+          .join(', ');
+      return ChatActionResult.error(
+        'multi_model_attachment_unsupported:$labels',
+      );
     }
 
-    late final ChatMessage userMessage;
-    late final ChatMessage assistantMessage;
-    String? generationRunId;
+    late final ChatGenerationBatchResult begin;
     try {
-      final begin = await messageGenerationService.beginSendGeneration(
+      begin = await messageGenerationService.beginSendGenerationBatch(
         conversationId: conversation.id,
         input: input,
         assistant: assistant,
-        modelId: modelId,
-        providerKey: providerKey,
+        targets: targets,
       );
-      userMessage = begin.userMessage;
-      assistantMessage = begin.assistantMessage;
-      generationRunId = begin.runId;
-      _registerGenerationRun(assistantMessage.id, generationRunId);
     } catch (e) {
       return ChatActionResult.error(e.toString());
     }
-    _activeAssistantMessages.put(assistantMessage);
+    final userMessage = begin.userMessage;
+    for (final branch in begin.targets) {
+      _registerGenerationRun(branch.assistantMessage.id, branch.run?.id);
+      _activeAssistantMessages.put(branch.assistantMessage);
+      streamController.markStreamingStarted(branch.assistantMessage.id);
+    }
+    _markBatchStarted(conversation.id, shouldGenerateTitle: true);
     _setConversationLoading(conversation.id, true);
 
-    // Pre-create streaming notifier BEFORE adding message to list
-    // so that MessageListView can detect it's streaming on first render
-    streamController.markStreamingStarted(assistantMessage.id);
-
-    if (await chatController.appendPersistedTailMessages([
+    if (await chatController.appendPersistedTailMessages(<ChatMessage>[
       userMessage,
-      assistantMessage,
+      ...begin.targets.map((branch) => branch.assistantMessage),
     ])) {
       viewModel.restoreMessageUiState();
+    }
+    for (final branch in begin.targets) {
+      chatController.setGenerationState(
+        branch.assistantMessage.id,
+        branch.run?.state ?? GenerationRunState.preparing,
+      );
     }
     onMessagesChanged?.call();
     onSendPairAppended?.call();
 
-    // Reset tool parts and initialize reasoning
-    streamController.toolParts.remove(assistantMessage.id);
-    final supportsReasoning = _isReasoningModel(providerKey, modelId);
-    final enableReasoning =
-        supportsReasoning &&
-        _isReasoningEnabled(
-          assistant?.thinkingBudget ?? settings.thinkingBudget,
-        );
-    // Prepare API messages
-    messageGenerationService.onFileProcessingStarted = onFileProcessingStarted;
-    messageGenerationService.onFileProcessingFinished =
-        onFileProcessingFinished;
-    try {
-      await messageGenerationService.initializeReasoningState(
-        messageId: assistantMessage.id,
-        enableReasoning: enableReasoning,
-      );
-      final apiContextMessages = <ChatMessage>[
-        ...existingContextMessages,
-        userMessage,
-        assistantMessage,
-      ];
-      final prepared = await messageGenerationService
-          .prepareApiMessagesWithInjections(
-            messages: apiContextMessages,
-            versionSelections: _versionSelections,
-            currentConversation: conversation.copyWith(truncateIndex: -1),
-            settings: settings,
-            assistant: assistant,
-            assistantId: assistantId,
-            providerKey: providerKey,
-            modelId: modelId,
-            approvalService: approvalService,
-            askUserService: askUserService,
-          );
-
-      // Build user image paths
-      final userImagePaths = messageGenerationService.buildUserImagePaths(
-        input: input,
-        lastUserImagePaths: prepared.lastUserImagePaths,
-        settings: settings,
-        providerKey: providerKey,
-        modelId: modelId,
-      );
-
-      // Execute generation
-      final ctx = messageGenerationService.buildGenerationContext(
-        assistantMessage: assistantMessage,
-        prepared: prepared,
-        userImagePaths: userImagePaths,
-        allowImagesApiRouting: input.allowImagesApiRouting,
-        providerKey: providerKey,
-        modelId: modelId,
-        assistant: assistant,
-        settings: settings,
-        supportsReasoning: supportsReasoning,
-        enableReasoning: enableReasoning,
-        generateTitleOnFinish: true,
-        generationRunId: generationRunId,
-      );
-
-      if (!_activeAssistantMessages.isActive(assistantMessage)) {
-        return ChatActionResult.success(assistantMessage);
-      }
-      await _executeGeneration(ctx);
-      return ChatActionResult.success(assistantMessage);
-    } catch (e) {
-      // Ensure file processing indicator is cleared on error
-      onFileProcessingFinished?.call();
-      await _finishPreparingMessage(conversation.id, assistantMessage);
-      return ChatActionResult.error(e.toString());
+    if (selectionScope == MultiModelSelectionScope.nextMessage &&
+        isMultiModel) {
+      await selectionProvider?.consumeNextMessage(conversation.id);
     }
+
+    if (isMultiModel) {
+      onFileProcessingStarted?.call();
+      messageGenerationService.onFileProcessingStarted = null;
+      messageGenerationService.onFileProcessingFinished = null;
+    } else {
+      messageGenerationService.onFileProcessingStarted =
+          onFileProcessingStarted;
+      messageGenerationService.onFileProcessingFinished =
+          onFileProcessingFinished;
+    }
+
+    await Future.wait<void>([
+      for (final branch in begin.targets)
+        () async {
+          final assistantMessage = branch.assistantMessage;
+          final target = branch.target;
+          streamController.toolParts.remove(assistantMessage.id);
+          final supportsReasoning = _isReasoningModel(
+            target.providerKey,
+            target.modelId,
+          );
+          final enableReasoning =
+              supportsReasoning &&
+              _isReasoningEnabled(
+                assistant?.thinkingBudget ?? settings.thinkingBudget,
+              );
+          try {
+            await messageGenerationService.initializeReasoningState(
+              messageId: assistantMessage.id,
+              enableReasoning: enableReasoning,
+            );
+            final prepared = await messageGenerationService
+                .prepareApiMessagesWithInjections(
+                  messages: <ChatMessage>[
+                    ...existingContextMessages,
+                    userMessage,
+                    assistantMessage,
+                  ],
+                  versionSelections: _versionSelections,
+                  currentConversation: conversation.copyWith(truncateIndex: -1),
+                  settings: settings,
+                  assistant: assistant,
+                  assistantId: assistantId,
+                  providerKey: target.providerKey,
+                  modelId: target.modelId,
+                  approvalService: isMultiModel ? null : approvalService,
+                  askUserService: isMultiModel ? null : askUserService,
+                  restrictToSearchTools: isMultiModel,
+                );
+            final userImagePaths = messageGenerationService.buildUserImagePaths(
+              input: input,
+              lastUserImagePaths: List<String>.of(prepared.lastUserImagePaths),
+              settings: settings,
+              providerKey: target.providerKey,
+              modelId: target.modelId,
+            );
+            final ctx = messageGenerationService.buildGenerationContext(
+              assistantMessage: assistantMessage,
+              prepared: prepared,
+              userImagePaths: userImagePaths,
+              allowImagesApiRouting:
+                  !isMultiModel && input.allowImagesApiRouting,
+              providerKey: target.providerKey,
+              modelId: target.modelId,
+              assistant: assistant,
+              settings: settings,
+              supportsReasoning: supportsReasoning,
+              enableReasoning: enableReasoning,
+              generateTitleOnFinish: true,
+              generationRunId: branch.run?.id,
+            );
+            if (_activeAssistantMessages.isActive(assistantMessage)) {
+              await _executeGeneration(ctx);
+            }
+          } catch (error) {
+            await _finishPreparingMessage(conversation.id, assistantMessage);
+            onStreamError?.call(error.toString());
+          }
+        }(),
+    ]);
+    if (isMultiModel) onFileProcessingFinished?.call();
+    return ChatActionResult.success(
+      begin.primaryTarget.assistantMessage,
+      allAssistantMessages: [
+        for (final branch in begin.targets) branch.assistantMessage,
+      ],
+    );
   }
 
   int _contextReadLimit(Assistant? assistant, Conversation conversation) {
@@ -1003,11 +1177,27 @@ class ChatActions {
       assistant,
     );
 
-    if (modelConfig.providerKey == null || modelConfig.modelId == null) {
+    final regenerationTarget = ChatActions.resolveRegenerationModelTarget(
+      message: message,
+      fallbackProviderKey: modelConfig.providerKey,
+      fallbackModelId: modelConfig.modelId,
+    );
+    if (regenerationTarget.providerKey == null ||
+        regenerationTarget.modelId == null) {
       return ChatActionResult.noModel();
     }
-    final providerKey = modelConfig.providerKey!;
-    final modelId = modelConfig.modelId!;
+    final providerKey = regenerationTarget.providerKey!;
+    final modelId = regenerationTarget.modelId!;
+    final sourceGroupId = message.groupId ?? message.id;
+    final sourceSiblings =
+        chatController.groupedMessages[sourceGroupId] ?? const <ChatMessage>[];
+    final isMultiModelGroup =
+        <String>{
+          for (final sibling in sourceSiblings)
+            if (sibling.providerId != null && sibling.modelId != null)
+              '${sibling.providerId}\u0000${sibling.modelId}',
+        }.length >=
+        2;
 
     final projectedMessages = ChatActions.projectMessagesForRegenerationContext(
       messages: completeMessages,
@@ -1067,6 +1257,7 @@ class ChatActions {
     final assistantMessage = begin.assistantMessage;
     _registerGenerationRun(assistantMessage.id, begin.runId);
     _activeAssistantMessages.put(assistantMessage);
+    _markBatchStarted(conversation.id, shouldGenerateTitle: false);
 
     // Pre-create streaming notifier BEFORE adding message to list
     // so that MessageListView can detect it's streaming on first render
@@ -1123,8 +1314,9 @@ class ChatActions {
             assistantId: assistantId,
             providerKey: providerKey,
             modelId: modelId,
-            approvalService: regenApprovalService,
-            askUserService: regenAskUserService,
+            approvalService: isMultiModelGroup ? null : regenApprovalService,
+            askUserService: isMultiModelGroup ? null : regenAskUserService,
+            restrictToSearchTools: isMultiModelGroup,
           );
 
       // Build user image paths
@@ -1203,16 +1395,23 @@ class ChatActions {
       settings,
       assistant,
     );
-    if (modelConfig.providerKey == null || modelConfig.modelId == null) {
+    final continuationTarget = ChatActions.resolveRegenerationModelTarget(
+      message: message,
+      fallbackProviderKey: modelConfig.providerKey,
+      fallbackModelId: modelConfig.modelId,
+    );
+    if (continuationTarget.providerKey == null ||
+        continuationTarget.modelId == null) {
       return ChatActionResult.noModel();
     }
-    final providerKey = modelConfig.providerKey!;
-    final modelId = modelConfig.modelId!;
+    final providerKey = continuationTarget.providerKey!;
+    final modelId = continuationTarget.modelId!;
 
     final streamingMessage = _messages[visibleIndex].copyWith(
       isStreaming: true,
     );
     _activeAssistantMessages.put(streamingMessage);
+    _markBatchStarted(conversation.id, shouldGenerateTitle: false);
     chatController.publishGenerationStarted(streamingMessage);
     await chatService.updateMessage(streamingMessage.id, isStreaming: true);
     onMessagesChanged?.call();
@@ -1296,20 +1495,16 @@ class ChatActions {
       // AskUserInteractionService may not be registered yet
     }
 
-    // Reset file processing state on cancel
-    onFileProcessingFinished?.call();
-
-    // Cancel active stream for current conversation only
-    final sub = _conversationStreams.remove(cid);
-    await sub?.cancel();
-    ChatApiService.cancelRequest(cid);
-
     // The active identity is independent from the currently loaded window.
     final streaming = _activeAssistantMessages.cancellationTarget(
       cid,
       _messages,
+      _versionSelections,
     );
     if (streaming != null) {
+      final sub = _conversationStreams.remove(streaming.id);
+      await sub?.cancel();
+      ChatApiService.cancelRequest(streaming.id);
       // Mark streaming as ended to allow UI rebuilds again
       streamController.markStreamingEnded(streaming.id);
       streamController.cleanupTimers(streaming.id);
@@ -1328,11 +1523,12 @@ class ChatActions {
         );
       } finally {
         _clearGenerationRuntimeState(finalizedMessage);
+        _batchHadFailure[cid] = true;
         if (chatController.publishTerminalMessage(finalizedMessage)) {
           onMessagesChanged?.call();
         }
         streamController.removeStreamingNotifier(streaming.id);
-        _setConversationLoading(cid, false);
+        await _completeBatchIfReady(cid, fallback: finalizedMessage);
       }
 
       // If streaming output included inline base64 images, sanitize them even on manual cancel
@@ -1341,10 +1537,13 @@ class ChatActions {
         latestStreaming.content,
         immediate: true,
       );
-      await _cancelIosBackgroundGeneration();
     } else {
-      chatController.publishGenerationState(cid, isGenerating: false);
-      _setConversationLoading(cid, false);
+      // The currently selected answer is already terminal. Keep sibling
+      // generations running until the user switches to one of them.
+      if (!_batchHasActiveMessages(cid)) {
+        chatController.publishGenerationState(cid, isGenerating: false);
+        _setConversationLoading(cid, false);
+      }
     }
   }
 
@@ -1391,7 +1590,10 @@ class ChatActions {
     try {
       await _startIosBackgroundGeneration(ctx);
       if (!_activeAssistantMessages.isActive(ctx.assistantMessage)) {
-        await _cancelIosBackgroundGeneration();
+        if (!_batchHasActiveMessages(conversationId) &&
+            _iosBackgroundStartedConversations.remove(conversationId)) {
+          await _cancelIosBackgroundGeneration();
+        }
         return;
       }
       final runId = ctx.generationRunId;
@@ -1407,6 +1609,7 @@ class ChatActions {
           nextState: GenerationRunState.requesting,
         );
         state.generationStateRevision = run.stateRevision;
+        chatController.setGenerationState(state.messageId, run.state);
         cursor
           ..state = run.state
           ..stateRevision = run.stateRevision
@@ -1427,19 +1630,18 @@ class ChatActions {
         extraHeaders: ctx.extraHeaders,
         extraBody: ctx.extraBody,
         stream: ctx.streamOutput,
-        requestId: conversationId,
+        requestId: state.messageId,
         allowImagesApiRouting: ctx.allowImagesApiRouting,
         ocrActive: ctx.ocrActive,
       );
 
-      await _conversationStreams[conversationId]?.cancel();
       final sub = listenSequentiallyToStream<ChatStreamChunk>(
         stream: stream,
         onData: (chunk) => _handleStreamChunk(chunk, state),
         onError: (error, stackTrace) => _handleStreamError(error, state),
         onDone: () => _handleStreamDone(state),
       );
-      _conversationStreams[conversationId] = sub;
+      _conversationStreams[state.messageId] = sub;
     } catch (e) {
       await _handleStreamError(e, state);
     }
@@ -1505,6 +1707,7 @@ class ChatActions {
     state
       ..generationStateRevision = run.stateRevision
       ..generationStreamingStarted = true;
+    chatController.setGenerationState(state.messageId, run.state);
     final cursor = _generationCheckpointCursors[state.messageId];
     if (cursor != null) {
       cursor
@@ -1722,7 +1925,6 @@ class ChatActions {
     String chunkContent,
   ) async {
     final messageId = state.messageId;
-    final conversationId = state.conversationId;
     final autoCollapseThinking =
         (!state.ctx.streamOutput && state.bufferedReasoning.isNotEmpty)
         ? contextProvider.read<SettingsProvider>().autoCollapseThinking
@@ -1783,12 +1985,7 @@ class ChatActions {
     await finishFuture;
     _finishStreamingFutures.remove(messageId);
 
-    // Notify for background notification if needed
-    if (!state.finishHandled) {
-      onStreamFinished?.call();
-    }
-
-    await _conversationStreams.remove(conversationId)?.cancel();
+    await _conversationStreams.remove(messageId)?.cancel();
   }
 
   /// Finish streaming and persist final state.
@@ -1810,7 +2007,7 @@ class ChatActions {
     if (state.finishHandled) {
       if (shouldGenerateTitle) {
         state.titleQueued = true;
-        onMaybeGenerateTitle?.call(conversationId);
+        _batchShouldGenerateTitle[conversationId] = true;
       }
       return;
     }
@@ -1866,26 +2063,17 @@ class ChatActions {
         finalizedMessage,
         terminalState: GenerationRunState.completed,
       );
-
-      onAssistantMessageFinished?.call(finalizedMessage);
-
+      _batchHadSuccessfulReply[conversationId] = true;
       if (shouldGenerateTitle) {
-        onMaybeGenerateTitle?.call(conversationId);
+        _batchShouldGenerateTitle[conversationId] = true;
       }
-
-      // Trigger summary generation check (actual logic in HomeViewModel)
-      onMaybeGenerateSummary?.call(conversationId);
-
-      // Trigger follow-up suggestions after the final assistant reply is stored.
-      onMaybeGenerateSuggestions?.call(conversationId);
-      await _finishIosBackgroundGeneration(success: true);
     } finally {
       // UI lifecycle cleanup is independent from terminal persistence success.
       if (chatController.publishTerminalMessage(finalizedMessage)) {
         onMessagesChanged?.call();
       }
       streamController.removeStreamingNotifier(messageId);
-      _setConversationLoading(conversationId, false);
+      await _completeBatchIfReady(conversationId, fallback: finalizedMessage);
     }
   }
 
@@ -1897,9 +2085,7 @@ class ChatActions {
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     final errorText = e.toString();
-
-    // Reset file processing state on error
-    onFileProcessingFinished?.call();
+    state.finishHandled = true;
 
     // Mark streaming as ended to allow UI rebuilds again
     streamController.markStreamingEnded(messageId);
@@ -1922,24 +2108,19 @@ class ChatActions {
       );
     } finally {
       _clearGenerationRuntimeState(errorMessage);
+      _batchHadFailure[conversationId] = true;
       if (chatController.publishTerminalMessage(errorMessage)) {
         onMessagesChanged?.call();
       }
       streamController.removeStreamingNotifier(messageId);
-      _setConversationLoading(conversationId, false);
-      await _conversationStreams.remove(conversationId)?.cancel();
+      await _conversationStreams.remove(messageId)?.cancel();
       onStreamError?.call(errorText);
-      onStreamFinished?.call();
-      await _finishIosBackgroundGeneration(success: false, detail: errorText);
+      await _completeBatchIfReady(conversationId, fallback: errorMessage);
     }
   }
 
   /// Handle stream done callback.
   Future<void> _handleStreamDone(stream_ctrl.StreamingState state) async {
-    // Reset file processing state on done (just in case)
-    onFileProcessingFinished?.call();
-
-    final conversationId = state.conversationId;
     final messageId = state.messageId;
 
     // Ensure streaming is marked as ended
@@ -1954,7 +2135,7 @@ class ChatActions {
     final inFlight = _finishStreamingFutures[messageId];
     if (inFlight != null) {
       await inFlight;
-    } else if (_loadingConversationIds.contains(conversationId)) {
+    } else if (_activeAssistantMessages.isActive(state.ctx.assistantMessage)) {
       await _finishStreaming(
         state,
         generateTitle: state.ctx.generateTitleOnFinish,
@@ -1962,8 +2143,7 @@ class ChatActions {
     }
     // Idempotent: ensure notifier is removed even if _finishStreaming was skipped
     streamController.removeStreamingNotifier(messageId);
-    onStreamFinished?.call();
-    await _conversationStreams.remove(conversationId)?.cancel();
+    await _conversationStreams.remove(messageId)?.cancel();
   }
 
   // ============================================================================
@@ -1973,52 +2153,51 @@ class ChatActions {
   /// Persist latest in-flight assistant message content and reasoning.
   Future<void> flushConversationProgress(Conversation? conversation) async {
     final cid = conversation?.id;
-    if (cid == null || _messages.isEmpty) return;
+    if (cid == null) return;
 
-    // Find the latest streaming assistant message in the current conversation
-    ChatMessage? streaming;
-    for (var i = _messages.length - 1; i >= 0; i--) {
-      final m = _messages[i];
-      if (m.role == 'assistant' && m.isStreaming && m.conversationId == cid) {
-        streaming = m;
-        break;
-      }
-    }
-    if (streaming == null) return;
-
-    // Use the UI-side content snapshot (may be ahead of last persisted chunk)
-    final latestContent = streaming.content;
-    // Also capture reasoning progress if tracked in-memory
-    final r = streamController.reasoning[streaming.id];
-    final segs = streamController.reasoningSegments[streaming.id];
-
-    final splits = streamController.getContentSplitData(streaming.id);
-    final reasoningSegmentsJson = segs != null || splits != null
-        ? streamController.serializeReasoningSegmentsWithSplits(
-            segs ?? const [],
-            contentSplitOffsets: splits?.offsets,
-            reasoningCountAtSplit: splits?.reasoningCounts,
-            toolCountAtSplit: splits?.toolCounts,
-          )
-        : streaming.reasoningSegmentsJson;
-    final snapshot = streaming.copyWith(
-      content: latestContent,
-      reasoningText: r?.text,
-      reasoningStartAt: r?.startAt,
-      reasoningFinishedAt: r?.finishedAt,
-      reasoningSegmentsJson: reasoningSegmentsJson,
-    );
-    final writer = _checkpointWriters[streaming.id];
-    if (writer == null) {
-      await chatService.updateStreamingCheckpointSilent(
-        snapshot,
-        _copyToolEvents(streaming.id),
-      );
-    } else {
-      writer.add(_createStreamingCheckpoint(snapshot));
-      await writer.barrier();
-    }
-    // Ensure any inline data URLs get converted even if the user navigates away mid-stream
-    onScheduleImageSanitize?.call(streaming.id, latestContent, immediate: true);
+    final active = _activeAssistantMessages.activeMessages(cid);
+    await Future.wait<void>([
+      for (final identity in active)
+        () async {
+          final loadedIndex = _messages.indexWhere(
+            (message) => message.id == identity.id,
+          );
+          final streaming = loadedIndex < 0 ? identity : _messages[loadedIndex];
+          final latestContent = streaming.content;
+          final r = streamController.reasoning[streaming.id];
+          final segs = streamController.reasoningSegments[streaming.id];
+          final splits = streamController.getContentSplitData(streaming.id);
+          final reasoningSegmentsJson = segs != null || splits != null
+              ? streamController.serializeReasoningSegmentsWithSplits(
+                  segs ?? const [],
+                  contentSplitOffsets: splits?.offsets,
+                  reasoningCountAtSplit: splits?.reasoningCounts,
+                  toolCountAtSplit: splits?.toolCounts,
+                )
+              : streaming.reasoningSegmentsJson;
+          final snapshot = streaming.copyWith(
+            content: latestContent,
+            reasoningText: r?.text,
+            reasoningStartAt: r?.startAt,
+            reasoningFinishedAt: r?.finishedAt,
+            reasoningSegmentsJson: reasoningSegmentsJson,
+          );
+          final writer = _checkpointWriters[streaming.id];
+          if (writer == null) {
+            await chatService.updateStreamingCheckpointSilent(
+              snapshot,
+              _copyToolEvents(streaming.id),
+            );
+          } else {
+            writer.add(_createStreamingCheckpoint(snapshot));
+            await writer.barrier();
+          }
+          onScheduleImageSanitize?.call(
+            streaming.id,
+            latestContent,
+            immediate: true,
+          );
+        }(),
+    ]);
   }
 }

--- a/lib/features/home/controllers/chat_controller.dart
+++ b/lib/features/home/controllers/chat_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import '../../../core/database/generation_run.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/services/chat/chat_service.dart';
@@ -50,6 +51,12 @@ class ChatController extends ChangeNotifier {
   /// Selected version per message group (groupId -> selected version index).
   Map<String, int> _versionSelections = <String, int>{};
   Map<String, int> get versionSelections => _versionSelections;
+  final Map<String, GenerationRunState> _generationStatesByMessageId =
+      <String, GenerationRunState>{};
+  Map<String, GenerationRunState> get generationStatesByMessageId =>
+      Map<String, GenerationRunState>.unmodifiable(
+        _generationStatesByMessageId,
+      );
 
   /// Cached collapsed messages (invalidated on notifyListeners).
   List<ChatMessage>? _collapsedCache;
@@ -62,11 +69,12 @@ class ChatController extends ChangeNotifier {
   final Set<String> _loadingConversationIds = <String>{};
   Set<String> get loadingConversationIds => _loadingConversationIds;
 
-  /// Active stream subscriptions per conversation.
-  final Map<String, StreamSubscription<dynamic>> _conversationStreams =
+  /// Active stream subscriptions keyed by assistant message ID. Multiple
+  /// models in one conversation can therefore stream independently.
+  final Map<String, StreamSubscription<dynamic>> _generationStreams =
       <String, StreamSubscription<dynamic>>{};
   Map<String, StreamSubscription<dynamic>> get conversationStreams =>
-      _conversationStreams;
+      _generationStreams;
 
   // ============================================================================
   // Getters
@@ -77,6 +85,25 @@ class ChatController extends ChangeNotifier {
     final cid = _currentConversation?.id;
     if (cid == null) return false;
     return _loadingConversationIds.contains(cid);
+  }
+
+  /// Whether the answer currently selected in the active multi-model group is
+  /// still generating. Sibling activity alone does not make the stop action
+  /// targetable.
+  bool get isSelectedAnswerStreaming {
+    for (final message in _messages.reversed) {
+      if (message.role != 'assistant') continue;
+      final groupId = message.groupId ?? message.id;
+      final siblings = groupedMessages[groupId] ?? <ChatMessage>[message];
+      if (!siblings.any((sibling) => sibling.isStreaming)) continue;
+      final selectedVersion =
+          _versionSelections[groupId] ?? siblings.first.version;
+      for (final sibling in siblings) {
+        if (sibling.version == selectedVersion) return sibling.isStreaming;
+      }
+      return false;
+    }
+    return false;
   }
 
   /// Get the ChatService instance.
@@ -104,6 +131,7 @@ class ChatController extends ChangeNotifier {
     _loadedStartIndex = 0;
     _totalMessageCount = 0;
     _versionSelections = <String, int>{};
+    _generationStatesByMessageId.clear();
     notifyListeners();
   }
 
@@ -114,9 +142,10 @@ class ChatController extends ChangeNotifier {
       _loadedStartIndex = 0;
       _totalMessageCount = 0;
       _versionSelections = <String, int>{};
+      _generationStatesByMessageId.clear();
     } else {
-      await _loadInitialMessageWindow(conversation.id);
       _loadVersionSelections();
+      await _loadInitialMessageWindow(conversation.id);
     }
     notifyListeners();
   }
@@ -161,6 +190,7 @@ class ChatController extends ChangeNotifier {
     _loadedStartIndex = 0;
     _totalMessageCount = 0;
     _versionSelections = <String, int>{};
+    _generationStatesByMessageId.clear();
     notifyListeners();
     return conversation;
   }
@@ -173,8 +203,8 @@ class ChatController extends ChangeNotifier {
     final convo = _chatService.getConversation(id);
     if (convo != null) {
       _currentConversation = convo;
-      await _loadInitialMessageWindow(id);
       _loadVersionSelections();
+      await _loadInitialMessageWindow(id);
       notifyListeners();
     }
   }
@@ -191,6 +221,7 @@ class ChatController extends ChangeNotifier {
     _loadedStartIndex = 0;
     _totalMessageCount = 0;
     _versionSelections = <String, int>{};
+    _generationStatesByMessageId.clear();
   }
 
   Future<void> _loadInitialMessageWindow(String conversationId) async {
@@ -204,6 +235,7 @@ class ChatController extends ChangeNotifier {
   }
 
   void _replaceWindow(LoadedTimelinePage? page) {
+    _generationStatesByMessageId.clear();
     if (page == null) {
       _messages = <ChatMessage>[];
       _loadedStartIndex = 0;
@@ -304,6 +336,7 @@ class ChatController extends ChangeNotifier {
       limit: ChatService.defaultLoadedWindowMax,
     );
     _replaceWindow(page);
+    _loadVersionSelections();
     await _preloadVisibleGroupData();
     notifyListeners();
     return _messages.isNotEmpty;
@@ -453,6 +486,22 @@ class ChatController extends ChangeNotifier {
       _chatService.loadMessagesForGroups(conversation.id, groupIds),
       _chatService.loadFirstMessageIndicesForGroups(conversation.id, groupIds),
     ]);
+    final targetIds = <String>{
+      for (final message in _chatService.getMessagesForGroups(
+        conversation.id,
+        groupIds,
+      ))
+        message.id,
+    };
+    final runs = await _chatService.loadLatestGenerationRunsForTargets(
+      targetIds,
+    );
+    for (final id in targetIds) {
+      _generationStatesByMessageId.remove(id);
+    }
+    for (final entry in runs.entries) {
+      _generationStatesByMessageId[entry.key] = entry.value.state;
+    }
     invalidateCache();
   }
 
@@ -555,6 +604,7 @@ class ChatController extends ChangeNotifier {
       limit: ChatService.defaultLoadedWindowMax,
     );
     _replaceWindow(page);
+    _loadVersionSelections();
     await _preloadVisibleGroupData();
     notifyListeners();
     return true;
@@ -604,12 +654,25 @@ class ChatController extends ChangeNotifier {
   /// Publishes a terminal generation snapshot and always closes the timeline's
   /// generation lifecycle, even when the message is outside the loaded window.
   bool publishTerminalMessage(ChatMessage message) {
+    final belongsToCurrentConversation =
+        _currentConversation?.id == message.conversationId;
     final terminalMessage = message.isStreaming
         ? message.copyWith(isStreaming: false)
         : message;
     final replaced = replaceMessageSnapshot(terminalMessage);
     publishGenerationState(message.conversationId, isGenerating: false);
-    return replaced;
+    return replaced || belongsToCurrentConversation;
+  }
+
+  void setGenerationState(
+    String messageId,
+    GenerationRunState state, {
+    bool notify = false,
+  }) {
+    if (_generationStatesByMessageId[messageId] == state) return;
+    _generationStatesByMessageId[messageId] = state;
+    invalidateCache();
+    if (notify) notifyListeners();
   }
 
   /// Update a message by ID with optional new values.
@@ -696,31 +759,31 @@ class ChatController extends ChangeNotifier {
   // Stream Subscription Management
   // ============================================================================
 
-  /// Get the stream subscription for a conversation.
-  StreamSubscription<dynamic>? getStreamSubscription(String conversationId) {
-    return _conversationStreams[conversationId];
+  /// Get the stream subscription for a generated assistant message.
+  StreamSubscription<dynamic>? getStreamSubscription(String messageId) {
+    return _generationStreams[messageId];
   }
 
-  /// Set a stream subscription for a conversation.
+  /// Set a stream subscription for a generated assistant message.
   void setStreamSubscription(
-    String conversationId,
+    String messageId,
     StreamSubscription<dynamic> subscription,
   ) {
-    _conversationStreams[conversationId] = subscription;
+    _generationStreams[messageId] = subscription;
   }
 
   /// Cancel and remove a stream subscription.
-  Future<void> cancelStreamSubscription(String conversationId) async {
-    final sub = _conversationStreams.remove(conversationId);
+  Future<void> cancelStreamSubscription(String messageId) async {
+    final sub = _generationStreams.remove(messageId);
     await sub?.cancel();
   }
 
   /// Cancel all stream subscriptions.
   Future<void> cancelAllStreams() async {
-    for (final sub in _conversationStreams.values) {
+    for (final sub in _generationStreams.values) {
       await sub.cancel();
     }
-    _conversationStreams.clear();
+    _generationStreams.clear();
   }
 
   // ============================================================================
@@ -915,6 +978,7 @@ class ChatController extends ChangeNotifier {
         for (final entry in groupedMessages.entries)
           entry.key: entry.value.length,
       },
+      generationStates: _generationStatesByMessageId,
       contextDividerIndex: _collapsedContextDividerIndex(),
     );
   }

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -273,6 +273,9 @@ class HomePageController extends ChangeNotifier {
     return loadingConversationIds.contains(cid);
   }
 
+  bool get canStopCurrentGeneration =>
+      _chatController.isSelectedAnswerStreaming;
+
   QueuedChatInput? get currentQueuedInput => _viewModel.currentQueuedInput;
 
   ValueNotifier<bool> get isProcessingFiles => _viewModel.isProcessingFiles;
@@ -445,9 +448,17 @@ class HomePageController extends ChangeNotifier {
   }
 
   String _localizeGenerationError(AppLocalizations l10n, String error) {
+    const incompatiblePrefix = 'multi_model_attachment_unsupported:';
+    if (error.startsWith(incompatiblePrefix)) {
+      return l10n.multiModelAttachmentUnsupported(
+        error.substring(incompatiblePrefix.length),
+      );
+    }
     switch (error) {
       case 'audio_attachment_unsupported':
         return l10n.homePageAudioAttachmentUnsupported;
+      case 'selected_model_answer_unavailable':
+        return l10n.multiModelSelectedAnswerUnavailable;
       default:
         return '${l10n.generationInterrupted}: $error';
     }
@@ -553,7 +564,9 @@ class HomePageController extends ChangeNotifier {
           }
           break;
         case ChatAction.switchModel:
-          unawaited(showModelSelectSheet(ctx));
+          unawaited(
+            showModelSelectSheet(ctx, conversationId: currentConversation?.id),
+          );
           break;
         case ChatAction.enterGlobalSearch:
           enterGlobalSearchMode(preserveQuery: true);

--- a/lib/features/home/controllers/message_render_model.dart
+++ b/lib/features/home/controllers/message_render_model.dart
@@ -1,4 +1,5 @@
 import '../../../core/models/chat_message.dart';
+import '../../../core/database/generation_run.dart';
 
 /// Immutable, precomputed input for one logical timeline slot.
 ///
@@ -11,6 +12,11 @@ final class MessageRenderModel {
     required this.versions,
     required this.versionCount,
     required this.selectedVersionIndex,
+    required this.selectedVersion,
+    required this.previousVersion,
+    required this.nextVersion,
+    required this.hasMultipleModelTargets,
+    required this.targetGenerationStates,
     required this.showContextDivider,
     required this.isLatestCompleteAssistant,
   });
@@ -20,6 +26,18 @@ final class MessageRenderModel {
   final List<ChatMessage> versions;
   final int versionCount;
   final int selectedVersionIndex;
+
+  /// Persisted version values are identifiers, not list indexes. These fields
+  /// keep navigation correct after a sibling revision is deleted and versions
+  /// become sparse.
+  final int selectedVersion;
+  final int? previousVersion;
+  final int? nextVersion;
+
+  /// Whether this slot contains answers from at least two provider/model
+  /// targets. Such slots use model chips instead of the legacy branch arrows.
+  final bool hasMultipleModelTargets;
+  final Map<String, GenerationRunState> targetGenerationStates;
   final bool showContextDivider;
   final bool isLatestCompleteAssistant;
 }
@@ -32,6 +50,8 @@ final class MessageRenderModelProjector {
     required Map<String, List<ChatMessage>> byGroup,
     required Map<String, int> versionSelections,
     Map<String, int> versionCounts = const <String, int>{},
+    Map<String, GenerationRunState> generationStates =
+        const <String, GenerationRunState>{},
     required int contextDividerIndex,
   }) {
     var latestCompleteAssistantIndex = -1;
@@ -52,6 +72,7 @@ final class MessageRenderModelProjector {
           selectedVersion: versionSelections[message.groupId ?? message.id],
           authoritativeVersionCount:
               versionCounts[message.groupId ?? message.id],
+          generationStates: generationStates,
           contextDividerIndex: contextDividerIndex,
           latestCompleteAssistantIndex: latestCompleteAssistantIndex,
         ),
@@ -64,6 +85,7 @@ final class MessageRenderModelProjector {
     required List<ChatMessage>? versions,
     required int? selectedVersion,
     required int? authoritativeVersionCount,
+    required Map<String, GenerationRunState> generationStates,
     required int contextDividerIndex,
     required int latestCompleteAssistantIndex,
   }) {
@@ -76,16 +98,52 @@ final class MessageRenderModelProjector {
     final versionCount = (authoritativeVersionCount ?? loadedVersionCount)
         .clamp(loadedVersionCount, 1 << 31)
         .toInt();
-    final selectedIndex = (selectedVersion ?? message.version).clamp(
-      0,
-      versionCount - 1,
+    final requestedVersion = selectedVersion ?? message.version;
+    var selectedIndex = sortedVersions.indexWhere(
+      (candidate) => candidate.version == requestedVersion,
     );
+    if (selectedIndex < 0) {
+      selectedIndex = sortedVersions.indexWhere(
+        (candidate) => candidate.id == message.id,
+      );
+    }
+    if (selectedIndex < 0) selectedIndex = 0;
+
+    // Lazy timelines can temporarily expose only the selected revision while
+    // still knowing the authoritative count. Preserve the familiar n/m label
+    // in that case; actual navigation remains bound to the loaded real values.
+    final displayIndex = sortedVersions.length == 1 && versionCount > 1
+        ? message.version.clamp(0, versionCount - 1)
+        : selectedIndex;
+    final actualSelectedVersion = sortedVersions.isEmpty
+        ? message.version
+        : sortedVersions[selectedIndex].version;
+    final modelTargets = <String>{
+      for (final candidate in sortedVersions)
+        if (candidate.role == 'assistant' &&
+            candidate.providerId != null &&
+            candidate.modelId != null)
+          '${candidate.providerId}\u0000${candidate.modelId}',
+    };
     return MessageRenderModel(
       slotId: message.groupId ?? message.id,
       message: message,
       versions: List<ChatMessage>.unmodifiable(sortedVersions),
       versionCount: versionCount,
-      selectedVersionIndex: selectedIndex,
+      selectedVersionIndex: displayIndex,
+      selectedVersion: actualSelectedVersion,
+      previousVersion: selectedIndex > 0
+          ? sortedVersions[selectedIndex - 1].version
+          : null,
+      nextVersion: selectedIndex + 1 < sortedVersions.length
+          ? sortedVersions[selectedIndex + 1].version
+          : null,
+      hasMultipleModelTargets: modelTargets.length >= 2,
+      targetGenerationStates: Map<String, GenerationRunState>.unmodifiable({
+        for (final candidate in sortedVersions)
+          if (generationStates[candidate.id] case final state?)
+            candidate.id: state,
+      }),
       showContextDivider:
           contextDividerIndex >= 0 && index == contextDividerIndex,
       isLatestCompleteAssistant: index == latestCompleteAssistantIndex,

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -15,6 +15,8 @@ import '../../../theme/app_font_weights.dart';
 import '../../../theme/design_tokens.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/chat_model_selection_provider.dart';
+import '../../../core/models/chat_model_target.dart';
 import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
@@ -605,6 +607,27 @@ class _HomePageState extends State<HomePage>
     final assistant = context.watch<AssistantProvider>().currentAssistant;
 
     final modelInfo = getModelDisplayInfo(settings, assistant: assistant);
+    final selectionProvider = context.watch<ChatModelSelectionProvider?>();
+    final fallbackTarget =
+        modelInfo.providerKey != null && modelInfo.modelId != null
+        ? ChatModelTarget(
+            providerKey: modelInfo.providerKey!,
+            modelId: modelInfo.modelId!,
+          )
+        : null;
+    final activeTargets = fallbackTarget == null
+        ? const <ChatModelTarget>[]
+        : selectionProvider?.effectiveTargets(
+                fallback: fallbackTarget,
+                assistantId: assistant?.id,
+                conversationId: _controller.currentConversation?.id,
+              ) ??
+              <ChatModelTarget>[fallbackTarget];
+    final multiModelActive = activeTargets.length > 1;
+    final providerName = multiModelActive ? null : modelInfo.providerName;
+    final modelDisplay = multiModelActive
+        ? AppLocalizations.of(context)!.multiModelCount(activeTargets.length)
+        : modelInfo.modelDisplay;
 
     final title = _controller.isTemporaryConversation
         ? AppLocalizations.of(context)!.temporaryChatTitle
@@ -616,8 +639,8 @@ class _HomePageState extends State<HomePage>
       return _buildTabletLayout(
         context,
         title: title,
-        providerName: modelInfo.providerName,
-        modelDisplay: modelInfo.modelDisplay,
+        providerName: providerName,
+        modelDisplay: modelDisplay,
         cs: cs,
       );
     }
@@ -625,8 +648,8 @@ class _HomePageState extends State<HomePage>
     return _buildMobileLayout(
       context,
       title: title,
-      providerName: modelInfo.providerName,
-      modelDisplay: modelInfo.modelDisplay,
+      providerName: providerName,
+      modelDisplay: modelDisplay,
       cs: cs,
     );
   }
@@ -678,7 +701,10 @@ class _HomePageState extends State<HomePage>
       canToggleTemporaryConversation:
           _controller.canToggleTemporaryConversation,
       temporaryConversationEnabled: _controller.isTemporaryConversation,
-      onSelectModel: () => showModelSelectSheet(context),
+      onSelectModel: () => showModelSelectSheet(
+        context,
+        conversationId: _controller.currentConversation?.id,
+      ),
       globalSearchMode: _controller.isGlobalSearchMode,
       globalSearchQuery: _controller.globalSearchQuery,
       onGlobalSearchQueryChanged: _controller.setGlobalSearchQuery,
@@ -815,7 +841,10 @@ class _HomePageState extends State<HomePage>
       onGlobalSearchQueryChanged: _controller.setGlobalSearchQuery,
       onOpenGlobalSearchResult: (convId, msgId) => _controller
           .openGlobalSearchResult(conversationId: convId, messageId: msgId),
-      onSelectModel: () => showModelSelectSheet(context),
+      onSelectModel: () => showModelSelectSheet(
+        context,
+        conversationId: _controller.currentConversation?.id,
+      ),
       onSidebarWidthChanged: _controller.updateSidebarWidth,
       onSidebarWidthChangeEnd: _controller.saveSidebarWidth,
       onRightSidebarWidthChanged: _controller.updateRightSidebarWidth,
@@ -1208,6 +1237,7 @@ class _HomePageState extends State<HomePage>
       mediaController: _mediaController,
       isTablet: isTablet,
       isLoading: _controller.isCurrentConversationLoading,
+      canStop: _controller.canStopCurrentGeneration,
       isToolModel: _controller.isToolModel,
       isReasoningModel: _controller.isReasoningModel,
       isReasoningEnabled: _controller.isReasoningEnabled,
@@ -1216,7 +1246,10 @@ class _HomePageState extends State<HomePage>
           ? AppLocalizations.of(context)!.messageEditPageSaveAndSend
           : null,
       onMore: _toggleTools,
-      onSelectModel: () => showModelSelectSheet(context),
+      onSelectModel: () => showModelSelectSheet(
+        context,
+        conversationId: _controller.currentConversation?.id,
+      ),
       onLongPressSelectModel: () {
         Navigator.of(
           context,

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -94,10 +94,16 @@ class MessageBuilderService {
     for (final gid in order) {
       final vers = byGroup[gid]!;
       final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
+      ChatMessage? selected;
+      if (sel != null) {
+        for (final candidate in vers) {
+          if (candidate.version == sel) {
+            selected = candidate;
+            break;
+          }
+        }
+      }
+      out.add(selected ?? vers.last);
     }
 
     return out;

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/chat_model_target.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
@@ -121,6 +122,7 @@ class MessageGenerationService {
     required String modelId,
     ToolApprovalService? approvalService,
     AskUserInteractionService? askUserService,
+    bool restrictToSearchTools = false,
   }) async {
     final cfg = settings.getProviderConfig(providerKey);
     final kind = ProviderConfig.classify(
@@ -197,13 +199,16 @@ class MessageGenerationService {
     await messageBuilderService.inlineLocalImages(apiMessages);
 
     // Prepare tools
-    final toolDefs = generationController.buildToolDefinitions(
+    var toolDefs = generationController.buildToolDefinitions(
       settings,
       assistant,
       providerKey,
       modelId,
       hasBuiltInSearch,
     );
+    if (restrictToSearchTools) {
+      toolDefs = multiModelSafeToolDefinitions(toolDefs);
+    }
     final onToolCall = toolDefs.isNotEmpty
         ? generationController.buildToolCallHandler(
             settings,
@@ -220,6 +225,21 @@ class MessageGenerationService {
       hasBuiltInSearch: hasBuiltInSearch,
       lastUserImagePaths: lastUserImagePaths,
     );
+  }
+
+  /// Multi-model branches may run concurrently, so only the side-effect-free
+  /// external search function is exposed. Provider-native web search is wired
+  /// separately and remains available without appearing in this list.
+  @visibleForTesting
+  static List<Map<String, dynamic>> multiModelSafeToolDefinitions(
+    Iterable<Map<String, dynamic>> definitions,
+  ) {
+    return definitions
+        .where((definition) {
+          final function = definition['function'];
+          return function is Map && function['name'] == 'search_web';
+        })
+        .toList(growable: false);
   }
 
   /// Create user message from input data.
@@ -248,37 +268,35 @@ class MessageGenerationService {
     required String modelId,
     required String providerKey,
   }) async {
-    final userContent = buildPersistedUserMessageContent(
-      input,
-      assistant: assistant,
-    );
-    if (chatService.isTemporaryConversation(conversationId)) {
-      final userMessage = await chatService.addMessage(
-        conversationId: conversationId,
-        role: 'user',
-        content: userContent,
-      );
-      final assistantMessage = await createAssistantPlaceholder(
-        conversationId: conversationId,
-        modelId: modelId,
-        providerKey: providerKey,
-      );
-      return (
-        userMessage: userMessage,
-        assistantMessage: assistantMessage,
-        runId: null,
-      );
-    }
-    final result = await chatService.beginSendGeneration(
+    final result = await beginSendGenerationBatch(
       conversationId: conversationId,
-      userContent: userContent,
-      modelId: modelId,
-      providerId: providerKey,
+      input: input,
+      assistant: assistant,
+      targets: <ChatModelTarget>[
+        ChatModelTarget(providerKey: providerKey, modelId: modelId),
+      ],
     );
+    final primary = result.primaryTarget;
     return (
-      userMessage: result.userMessage!,
-      assistantMessage: result.assistantMessage,
-      runId: result.run.id,
+      userMessage: result.userMessage,
+      assistantMessage: primary.assistantMessage,
+      runId: primary.run?.id,
+    );
+  }
+
+  Future<ChatGenerationBatchResult> beginSendGenerationBatch({
+    required String conversationId,
+    required ChatInputData input,
+    required Assistant? assistant,
+    required List<ChatModelTarget> targets,
+  }) {
+    return chatService.beginSendGenerationBatch(
+      conversationId: conversationId,
+      userContent: buildPersistedUserMessageContent(
+        input,
+        assistant: assistant,
+      ),
+      targets: targets,
     );
   }
 

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -54,6 +54,7 @@ class ChatInputBar extends StatefulWidget {
     super.key,
     this.onSend,
     this.onStop,
+    this.canStop = true,
     this.onSelectModel,
     this.onLongPressSelectModel,
     this.onOpenMcp,
@@ -95,6 +96,7 @@ class ChatInputBar extends StatefulWidget {
     this.ocrActive = false,
     this.onToggleOcr,
     this.conversationId,
+    this.allowImagesApiRouting = true,
     this.sendButtonTooltip,
     this.backgroundImageActive = false,
     this.inputBackgroundOpacityLight =
@@ -105,6 +107,7 @@ class ChatInputBar extends StatefulWidget {
 
   final Future<ChatInputSubmissionResult> Function(ChatInputData)? onSend;
   final VoidCallback? onStop;
+  final bool canStop;
   final VoidCallback? onSelectModel;
   final VoidCallback? onLongPressSelectModel;
   final VoidCallback? onOpenMcp;
@@ -146,6 +149,7 @@ class ChatInputBar extends StatefulWidget {
   final bool ocrActive;
   final VoidCallback? onToggleOcr;
   final String? conversationId;
+  final bool allowImagesApiRouting;
   final String? sendButtonTooltip;
   final bool backgroundImageActive;
   final double inputBackgroundOpacityLight;
@@ -212,6 +216,10 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   bool _supportsImagesApiRouting(BuildContext context) {
+    if (!widget.allowImagesApiRouting) {
+      _imageModeModelKey = null;
+      return false;
+    }
     final settings = context.watch<SettingsProvider>();
     final ap = context.watch<AssistantProvider>();
     final a = ap.currentAssistant;
@@ -243,6 +251,7 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   bool get _allowImagesApiRouting {
+    if (!widget.allowImagesApiRouting) return false;
     final key = _imageModeModelKey;
     return key == null || key != _dismissedImageModeModelKey;
   }
@@ -1993,7 +2002,9 @@ class _ChatInputBarState extends State<ChatInputBar>
                                       loading: widget.loading,
                                       onSend: _handleSend,
                                       onStop: widget.loading
-                                          ? widget.onStop
+                                          ? (widget.canStop
+                                                ? widget.onStop
+                                                : null)
                                           : null,
                                       color: theme.colorScheme.primary,
                                       icon: Lucide.ArrowUp,
@@ -2340,12 +2351,13 @@ class _CompactSendButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = (enabled || loading)
+    final active = enabled || (loading && onStop != null);
+    final bg = active
         ? color
         : (isDark
               ? Colors.white12
               : Colors.grey.shade300.withValues(alpha: 0.84));
-    final fg = (enabled || loading)
+    final fg = active
         ? (isDark ? Colors.black : Colors.white)
         : (isDark ? Colors.white70 : Colors.grey.shade600);
 

--- a/lib/features/home/widgets/chat_input_section.dart
+++ b/lib/features/home/widgets/chat_input_section.dart
@@ -5,6 +5,8 @@ import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/chat_model_selection_provider.dart';
+import '../../../core/models/chat_model_target.dart';
 import '../../../core/providers/mcp_provider.dart';
 import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
@@ -36,6 +38,7 @@ class ChatInputSection extends StatelessWidget {
     required this.mediaController,
     required this.isTablet,
     required this.isLoading,
+    this.canStop = true,
     required this.isToolModel,
     required this.isReasoningModel,
     required this.isReasoningEnabled,
@@ -74,6 +77,7 @@ class ChatInputSection extends StatelessWidget {
   final ChatInputBarController mediaController;
   final bool isTablet;
   final bool isLoading;
+  final bool canStop;
 
   // Model capability checkers
   final IsToolModelCallback isToolModel;
@@ -120,9 +124,21 @@ class ChatInputSection extends StatelessWidget {
     final modelIds = getActiveModelIds(settings, assistant: a);
     final pk = modelIds.providerKey;
     final mid = modelIds.modelId;
+    final selectionProvider = context.watch<ChatModelSelectionProvider?>();
+    final targets = pk != null && mid != null
+        ? selectionProvider?.effectiveTargets(
+                fallback: ChatModelTarget(providerKey: pk, modelId: mid),
+                assistantId: assistantId,
+                conversationId: conversationId,
+              ) ??
+              <ChatModelTarget>[ChatModelTarget(providerKey: pk, modelId: mid)]
+        : const <ChatModelTarget>[];
+    final multiModelActive = targets.length > 1;
 
     // Enforce model capabilities: disable MCP selection if model doesn't support tools
-    _enforceModelCapabilities(context, settings, ap, a, pk, mid);
+    if (!multiModelActive) {
+      _enforceModelCapabilities(context, settings, ap, a, pk, mid);
+    }
 
     final isDesktop = _isDesktopPlatform(context);
     final hasWorldBooks =
@@ -134,10 +150,14 @@ class ChatInputSection extends StatelessWidget {
       onSelectModel: onSelectModel,
       onLongPressSelectModel: onLongPressSelectModel,
       conversationId: conversationId,
+      allowImagesApiRouting: !multiModelActive,
       onOpenMcp: onOpenMcp,
       onLongPressMcp: onLongPressMcp,
       onStop: onStop,
-      modelIcon: (pk != null && mid != null)
+      canStop: canStop,
+      modelIcon: multiModelActive
+          ? _MultiModelIcon(targets: targets)
+          : (pk != null && mid != null)
           ? CurrentModelIcon(
               providerKey: pk,
               modelId: mid,
@@ -170,7 +190,9 @@ class ChatInputSection extends StatelessWidget {
       hasQueuedInput: hasQueuedInput,
       queuedPreviewText: queuedPreviewText,
       onCancelQueuedInput: onCancelQueuedInput,
-      showMcpButton: _shouldShowMcpButton(context, settings, a, pk, mid),
+      showMcpButton:
+          !multiModelActive &&
+          _shouldShowMcpButton(context, settings, a, pk, mid),
       mcpActive: _isMcpActive(context, a),
       showQuickPhraseButton: _hasQuickPhrases(context, a),
       onQuickPhrase: onQuickPhrase,
@@ -284,5 +306,57 @@ class ChatInputSection extends StatelessWidget {
         ? quickPhraseProvider.getForAssistant(a.id).length
         : 0;
     return (globalCount + assistantCount) > 0;
+  }
+}
+
+class _MultiModelIcon extends StatelessWidget {
+  const _MultiModelIcon({required this.targets});
+
+  final List<ChatModelTarget> targets;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final visible = targets.take(3).toList(growable: false);
+    return SizedBox(
+      width: 40,
+      height: 40,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          for (final (index, target) in visible.indexed)
+            Positioned(
+              left: index * 7,
+              top: index * 3,
+              child: CurrentModelIcon(
+                providerKey: target.providerKey,
+                modelId: target.modelId,
+                size: 25,
+              ),
+            ),
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: Container(
+              constraints: const BoxConstraints(minWidth: 18, minHeight: 18),
+              alignment: Alignment.center,
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              decoration: BoxDecoration(
+                color: cs.primary,
+                borderRadius: BorderRadius.circular(9),
+              ),
+              child: Text(
+                '${targets.length}',
+                style: TextStyle(
+                  color: cs.onPrimary,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -9,6 +9,7 @@ import 'package:super_sliver_list/super_sliver_list.dart';
 
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/assistant.dart';
+import '../../../core/database/generation_run.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_checkbox.dart';
 import '../../chat/widgets/chat_message_widget.dart';
@@ -772,6 +773,8 @@ class _MessageListViewState extends State<MessageListView> {
     final gid = model.slotId;
     final selectedIdx = model.selectedVersionIndex;
     final total = model.versionCount;
+    final usesModelTargetSelector = model.hasMultipleModelTargets;
+    final selectedGenerationState = model.targetGenerationStates[message.id];
     final messageSuggestions =
         !widget.selecting &&
             model.isLatestCompleteAssistant &&
@@ -835,6 +838,8 @@ class _MessageListViewState extends State<MessageListView> {
                               gid: gid,
                               selectedIdx: selectedIdx,
                               total: total,
+                              hideLegacyVersionSwitcher:
+                                  usesModelTargetSelector,
                               isProcessingFiles: isProcessingFiles,
                               suggestions: messageSuggestions,
                               presentation: presentation,
@@ -851,6 +856,8 @@ class _MessageListViewState extends State<MessageListView> {
                               gid: gid,
                               selectedIdx: selectedIdx,
                               total: total,
+                              hideLegacyVersionSwitcher:
+                                  usesModelTargetSelector,
                               isProcessingFiles: isProcessingFiles,
                               suggestions: messageSuggestions,
                               presentation: presentation,
@@ -876,6 +883,19 @@ class _MessageListViewState extends State<MessageListView> {
             ),
           ],
         ),
+        if (usesModelTargetSelector &&
+            selectedGenerationState != null &&
+            selectedGenerationState.isTerminal &&
+            selectedGenerationState != GenerationRunState.completed)
+          _GenerationStatusBadge(state: selectedGenerationState),
+        if (usesModelTargetSelector && message.role == 'assistant')
+          _ModelAnswerSelector(
+            groupId: gid,
+            versions: model.versions,
+            selectedVersion: model.selectedVersion,
+            generationStates: model.targetGenerationStates,
+            onSelected: widget.onVersionChange,
+          ),
         if (model.showContextDivider)
           Padding(
             padding: widget.dividerPadding,
@@ -939,6 +959,7 @@ class _MessageListViewState extends State<MessageListView> {
     required String gid,
     required int selectedIdx,
     required int total,
+    required bool hideLegacyVersionSwitcher,
     required bool isProcessingFiles,
     required List<String> suggestions,
     required _MessagePresentation presentation,
@@ -990,6 +1011,7 @@ class _MessageListViewState extends State<MessageListView> {
             gid: gid,
             selectedIdx: selectedIdx,
             total: total,
+            hideLegacyVersionSwitcher: hideLegacyVersionSwitcher,
             isProcessingFiles: isProcessingFiles,
             suggestions: suggestions,
             presentation: presentation,
@@ -1013,6 +1035,7 @@ class _MessageListViewState extends State<MessageListView> {
     required String gid,
     required int selectedIdx,
     required int total,
+    required bool hideLegacyVersionSwitcher,
     required bool isProcessingFiles,
     required List<String> suggestions,
     required _MessagePresentation presentation,
@@ -1022,12 +1045,22 @@ class _MessageListViewState extends State<MessageListView> {
       message: message,
       enableStreamingTextMotion: enableStreamingTextMotion,
       versionIndex: selectedIdx,
-      versionCount: total > 0 ? total : 1,
-      onPrevVersion: (selectedIdx > 0)
-          ? () => widget.onVersionChange?.call(gid, selectedIdx - 1)
+      versionCount: hideLegacyVersionSwitcher ? 1 : (total > 0 ? total : 1),
+      onPrevVersion:
+          (!hideLegacyVersionSwitcher &&
+              modelForVersion(message, gid)?.previousVersion != null)
+          ? () => widget.onVersionChange?.call(
+              gid,
+              modelForVersion(message, gid)!.previousVersion!,
+            )
           : null,
-      onNextVersion: (selectedIdx < total - 1)
-          ? () => widget.onVersionChange?.call(gid, selectedIdx + 1)
+      onNextVersion:
+          (!hideLegacyVersionSwitcher &&
+              modelForVersion(message, gid)?.nextVersion != null)
+          ? () => widget.onVersionChange?.call(
+              gid,
+              modelForVersion(message, gid)!.nextVersion!,
+            )
           : null,
       modelIcon:
           (!useAssistAvatar &&
@@ -1158,6 +1191,262 @@ class _MessageListViewState extends State<MessageListView> {
           ? null
           : (part, result) =>
                 widget.onRecoveredAskUserAnswer!(message, part, result),
+    );
+  }
+
+  MessageRenderModel? modelForVersion(ChatMessage message, String groupId) {
+    for (final model in _effectiveRenderModels) {
+      if (model.slotId == groupId && model.message.id == message.id) {
+        return model;
+      }
+    }
+    for (final model in _effectiveRenderModels) {
+      if (model.slotId == groupId) return model;
+    }
+    return null;
+  }
+}
+
+class _ModelAnswerSelector extends StatelessWidget {
+  const _ModelAnswerSelector({
+    required this.groupId,
+    required this.versions,
+    required this.selectedVersion,
+    required this.generationStates,
+    required this.onSelected,
+  });
+
+  final String groupId;
+  final List<ChatMessage> versions;
+  final int selectedVersion;
+  final Map<String, GenerationRunState> generationStates;
+  final OnVersionChange? onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final assistantVersions =
+        versions
+            .where(
+              (message) =>
+                  message.role == 'assistant' &&
+                  message.providerId != null &&
+                  message.modelId != null,
+            )
+            .toList(growable: false)
+          ..sort((left, right) => left.version.compareTo(right.version));
+    if (assistantVersions.length < 2) return const SizedBox.shrink();
+
+    final providersByModel = <String, Set<String>>{};
+    final targetTotals = <String, int>{};
+    for (final message in assistantVersions) {
+      providersByModel
+          .putIfAbsent(message.modelId!, () => <String>{})
+          .add(message.providerId!);
+      final key = '${message.providerId}\u0000${message.modelId}';
+      targetTotals[key] = (targetTotals[key] ?? 0) + 1;
+    }
+    final targetOccurrences = <String, int>{};
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: SizedBox(
+        width: double.infinity,
+        height: 36,
+        child: SingleChildScrollView(
+          key: ValueKey<String>('model-answer-selector:$groupId'),
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final message in assistantVersions) ...[
+                Builder(
+                  builder: (context) {
+                    final targetKey =
+                        '${message.providerId}\u0000${message.modelId}';
+                    final occurrence = (targetOccurrences[targetKey] ?? 0) + 1;
+                    targetOccurrences[targetKey] = occurrence;
+                    final disambiguateProvider =
+                        (providersByModel[message.modelId!]?.length ?? 0) > 1;
+                    final repeatTarget = (targetTotals[targetKey] ?? 0) > 1;
+                    final label = StringBuffer(message.modelId!)
+                      ..write(
+                        disambiguateProvider ? ' · ${message.providerId}' : '',
+                      )
+                      ..write(repeatTarget ? ' $occurrence' : '');
+                    final isSelected = message.version == selectedVersion;
+                    final generationState = generationStates[message.id];
+                    final isGenerating =
+                        message.isStreaming ||
+                        (generationState != null &&
+                            !generationState.isTerminal);
+                    final hasNoUsableBody =
+                        !message.isStreaming && message.content.trim().isEmpty;
+                    final statusLabel = switch (generationState) {
+                      GenerationRunState.preparing ||
+                      GenerationRunState.requesting ||
+                      GenerationRunState.streaming ||
+                      GenerationRunState.waitingTool =>
+                        l10n.multiModelStatusGenerating,
+                      GenerationRunState.failed => l10n.multiModelStatusFailed,
+                      GenerationRunState.cancelled =>
+                        l10n.multiModelStatusCancelled,
+                      GenerationRunState.interrupted =>
+                        l10n.multiModelStatusInterrupted,
+                      GenerationRunState.completed || null => null,
+                    };
+
+                    return Semantics(
+                      button: true,
+                      selected: isSelected,
+                      label: statusLabel == null
+                          ? label.toString()
+                          : '${label.toString()}, $statusLabel',
+                      child: Material(
+                        color: isSelected
+                            ? cs.primaryContainer
+                            : cs.surfaceContainerLow,
+                        borderRadius: BorderRadius.circular(18),
+                        child: InkWell(
+                          key: ValueKey<String>(
+                            'model-answer:${message.version}',
+                          ),
+                          borderRadius: BorderRadius.circular(18),
+                          onTap: onSelected == null
+                              ? null
+                              : () => onSelected!(groupId, message.version),
+                          child: Container(
+                            height: 32,
+                            padding: const EdgeInsets.symmetric(horizontal: 9),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(18),
+                              border: Border.all(
+                                color: isSelected
+                                    ? cs.primary.withValues(alpha: 0.55)
+                                    : cs.outlineVariant.withValues(alpha: 0.45),
+                              ),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                CurrentModelIcon(
+                                  providerKey: message.providerId,
+                                  modelId: message.modelId,
+                                  size: 18,
+                                ),
+                                const SizedBox(width: 6),
+                                Text(
+                                  label.toString(),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: isSelected
+                                        ? FontWeight.w600
+                                        : FontWeight.w500,
+                                    color: isSelected
+                                        ? cs.onPrimaryContainer
+                                        : cs.onSurfaceVariant,
+                                  ),
+                                ),
+                                if (isGenerating) ...[
+                                  const SizedBox(width: 7),
+                                  SizedBox(
+                                    width: 12,
+                                    height: 12,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 1.8,
+                                      color: isSelected
+                                          ? cs.primary
+                                          : cs.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ] else if (generationState ==
+                                        GenerationRunState.cancelled ||
+                                    generationState ==
+                                        GenerationRunState.interrupted) ...[
+                                  const SizedBox(width: 6),
+                                  Icon(
+                                    generationState ==
+                                            GenerationRunState.cancelled
+                                        ? Icons.stop_circle_outlined
+                                        : Icons.pause_circle_outline,
+                                    size: 14,
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ] else if (generationState ==
+                                        GenerationRunState.failed ||
+                                    hasNoUsableBody) ...[
+                                  const SizedBox(width: 6),
+                                  Icon(
+                                    Icons.error_outline,
+                                    size: 14,
+                                    color: cs.error,
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                const SizedBox(width: 6),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GenerationStatusBadge extends StatelessWidget {
+  const _GenerationStatusBadge({required this.state});
+
+  final GenerationRunState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final (icon, label, color) = switch (state) {
+      GenerationRunState.failed => (
+        Icons.error_outline,
+        l10n.multiModelStatusFailed,
+        cs.error,
+      ),
+      GenerationRunState.cancelled => (
+        Icons.stop_circle_outlined,
+        l10n.multiModelStatusCancelled,
+        cs.onSurfaceVariant,
+      ),
+      GenerationRunState.interrupted => (
+        Icons.pause_circle_outline,
+        l10n.multiModelStatusInterrupted,
+        cs.onSurfaceVariant,
+      ),
+      _ => (
+        Icons.info_outline,
+        l10n.multiModelStatusGenerating,
+        cs.onSurfaceVariant,
+      ),
+    };
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 6),
+      child: Semantics(
+        key: ValueKey<String>('model-answer-status:${state.databaseValue}'),
+        label: label,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: color),
+            const SizedBox(width: 5),
+            Text(label, style: TextStyle(fontSize: 12, color: color)),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/model/widgets/model_select_sheet.dart
+++ b/lib/features/model/widgets/model_select_sheet.dart
@@ -7,6 +7,8 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/model_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/chat_model_selection_provider.dart';
+import '../../../core/models/chat_model_target.dart';
 import '../../../icons/lucide_adapter.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'model_detail_sheet.dart';
@@ -26,6 +28,43 @@ class ModelSelection {
   final String providerKey;
   final String modelId;
   ModelSelection(this.providerKey, this.modelId);
+}
+
+/// Result returned only by the chat entry point. A normal row tap contains one
+/// target and keeps the legacy immediate-selection behavior; confirming the
+/// @ mode contains an ordered multi-target combination.
+final class ChatModelSelectionResult {
+  const ChatModelSelectionResult({
+    required this.targets,
+    required this.isMultiModel,
+  });
+
+  final List<ChatModelTarget> targets;
+  final bool isMultiModel;
+}
+
+final class _MultiModelSelectionResult {
+  const _MultiModelSelectionResult(this.selections);
+
+  final List<ModelSelection> selections;
+}
+
+String _selectionKey(String providerKey, String modelId) =>
+    '$providerKey::$modelId';
+
+List<ModelSelection> _deduplicateSelections(
+  Iterable<ModelSelection> selections,
+) {
+  final seen = <String>{};
+  final result = <ModelSelection>[];
+  for (final selection in selections) {
+    if (!seen.add(_selectionKey(selection.providerKey, selection.modelId))) {
+      continue;
+    }
+    result.add(selection);
+    if (result.length == ChatModelSelectionProvider.maximumTargets) break;
+  }
+  return result;
 }
 
 // Prevent re-entrant model selector dialogs
@@ -203,6 +242,65 @@ Future<ModelSelection?> showModelSelector(
   String? initialProviderKey,
   String? initialModelId,
 }) async {
+  final result = await _showModelSelectorInternal(
+    context,
+    limitProviderKey: limitProviderKey,
+    initialProviderKey: initialProviderKey,
+    initialModelId: initialModelId,
+  );
+  return result is ModelSelection ? result : null;
+}
+
+Future<ChatModelSelectionResult?> showChatModelSelector(
+  BuildContext context, {
+  String? initialProviderKey,
+  String? initialModelId,
+  List<ChatModelTarget> initialTargets = const <ChatModelTarget>[],
+}) async {
+  final result = await _showModelSelectorInternal(
+    context,
+    initialProviderKey: initialProviderKey,
+    initialModelId: initialModelId,
+    allowMultiSelect: true,
+    initialMultiSelections: [
+      for (final target in initialTargets)
+        ModelSelection(target.providerKey, target.modelId),
+    ],
+  );
+  if (result is ModelSelection) {
+    return ChatModelSelectionResult(
+      targets: <ChatModelTarget>[
+        ChatModelTarget(
+          providerKey: result.providerKey,
+          modelId: result.modelId,
+        ),
+      ],
+      isMultiModel: false,
+    );
+  }
+  if (result is _MultiModelSelectionResult) {
+    return ChatModelSelectionResult(
+      targets: List<ChatModelTarget>.unmodifiable([
+        for (final selection in result.selections)
+          ChatModelTarget(
+            providerKey: selection.providerKey,
+            modelId: selection.modelId,
+          ),
+      ]),
+      isMultiModel: true,
+    );
+  }
+  return null;
+}
+
+Future<Object?> _showModelSelectorInternal(
+  BuildContext context, {
+  String? limitProviderKey,
+  String? initialProviderKey,
+  String? initialModelId,
+  bool allowMultiSelect = false,
+  List<ModelSelection> initialMultiSelections = const <ModelSelection>[],
+}) async {
   if (_modelSelectorOpen) return null;
   _modelSelectorOpen = true;
   try {
@@ -216,10 +314,12 @@ Future<ModelSelection?> showModelSelector(
         limitProviderKey: limitProviderKey,
         initialProviderKey: initialProviderKey,
         initialModelId: initialModelId,
+        allowMultiSelect: allowMultiSelect,
+        initialMultiSelections: initialMultiSelections,
       );
     }
     final cs = Theme.of(context).colorScheme;
-    return await showModalBottomSheet<ModelSelection>(
+    return await showModalBottomSheet<Object>(
       context: context,
       isScrollControlled: true,
       backgroundColor: cs.surface,
@@ -230,6 +330,8 @@ Future<ModelSelection?> showModelSelector(
         limitProviderKey: limitProviderKey,
         initialProviderKey: initialProviderKey,
         initialModelId: initialModelId,
+        allowMultiSelect: allowMultiSelect,
+        initialMultiSelections: initialMultiSelections,
       ),
     );
   } finally {
@@ -240,26 +342,64 @@ Future<ModelSelection?> showModelSelector(
 Future<void> showModelSelectSheet(
   BuildContext context, {
   bool updateAssistant = true,
+  String? conversationId,
 }) async {
   final assistantProvider = context.read<AssistantProvider>();
   final settings = context.read<SettingsProvider>();
-  final sel = await showModelSelector(context);
-  if (sel != null) {
+  final multiSelection = context.read<ChatModelSelectionProvider>();
+  await multiSelection.ready;
+  await multiSelection.pruneTargets((target) {
+    final config = settings.getProviderConfig(target.providerKey);
+    return config.enabled && config.models.contains(target.modelId);
+  });
+  if (!context.mounted) return;
+  final assistant = assistantProvider.currentAssistant;
+  final initialProvider =
+      assistant?.chatModelProvider ?? settings.currentModelProvider;
+  final initialModel = assistant?.chatModelId ?? settings.currentModelId;
+  final configured = multiSelection.targetsForScope(
+    assistantId: assistant?.id,
+    conversationId: conversationId,
+  );
+  final fallbackTargets = initialProvider != null && initialModel != null
+      ? <ChatModelTarget>[
+          ChatModelTarget(providerKey: initialProvider, modelId: initialModel),
+        ]
+      : const <ChatModelTarget>[];
+  final sel = await showChatModelSelector(
+    context,
+    initialProviderKey: initialProvider,
+    initialModelId: initialModel,
+    initialTargets: configured.isNotEmpty ? configured : fallbackTargets,
+  );
+  if (sel != null && sel.targets.isNotEmpty) {
+    if (sel.isMultiModel) {
+      await multiSelection.setTargets(
+        targets: sel.targets,
+        assistantId: assistant?.id,
+        conversationId: conversationId,
+      );
+      return;
+    }
+    final selected = sel.targets.single;
     if (updateAssistant) {
       // Update assistant's model instead of global default
-      final assistant = assistantProvider.currentAssistant;
       if (assistant != null) {
         await assistantProvider.updateAssistant(
           assistant.copyWith(
-            chatModelProvider: sel.providerKey,
-            chatModelId: sel.modelId,
+            chatModelProvider: selected.providerKey,
+            chatModelId: selected.modelId,
           ),
         );
       }
     } else {
       // Only update global default when explicitly requested (e.g., from settings)
-      await settings.setCurrentModel(sel.providerKey, sel.modelId);
+      await settings.setCurrentModel(selected.providerKey, selected.modelId);
     }
+    await multiSelection.clearActiveOverride(
+      assistantId: assistant?.id,
+      conversationId: conversationId,
+    );
   }
 }
 
@@ -268,10 +408,14 @@ class _ModelSelectSheet extends StatefulWidget {
     this.limitProviderKey,
     this.initialProviderKey,
     this.initialModelId,
+    this.allowMultiSelect = false,
+    this.initialMultiSelections = const <ModelSelection>[],
   });
   final String? limitProviderKey;
   final String? initialProviderKey;
   final String? initialModelId;
+  final bool allowMultiSelect;
+  final List<ModelSelection> initialMultiSelections;
   @override
   State<_ModelSelectSheet> createState() => _ModelSelectSheetState();
 }
@@ -316,6 +460,8 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
   Map<String, _ProviderGroup> _groups = {};
   List<String> _orderedKeys = [];
   bool _autoScrolled = false; // ensure we only auto-scroll once per open
+  bool _multiMode = false;
+  late List<ModelSelection> _multiSelections;
 
   dynamic _sanitizeJsonValue(dynamic value) {
     if (value == null || value is num || value is bool || value is String) {
@@ -382,6 +528,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
   @override
   void initState() {
     super.initState();
+    _multiSelections = _deduplicateSelections(widget.initialMultiSelections);
     _itemPositionsListener.itemPositions.addListener(
       _scheduleActiveProviderUpdate,
     );
@@ -391,6 +538,87 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         _loadModelsAsync();
       }
     });
+  }
+
+  bool _isMultiSelected(_ModelItem model) => _multiSelections.any(
+    (selection) =>
+        selection.providerKey == model.providerKey &&
+        selection.modelId == model.id,
+  );
+
+  void _enterMultiMode() {
+    if (_multiMode) return;
+    if (_multiSelections.isEmpty &&
+        widget.initialProviderKey != null &&
+        widget.initialModelId != null) {
+      _multiSelections.add(
+        ModelSelection(widget.initialProviderKey!, widget.initialModelId!),
+      );
+    }
+    setState(() => _multiMode = true);
+  }
+
+  void _cancelMultiMode() {
+    setState(() {
+      _multiMode = false;
+      _multiSelections = _deduplicateSelections(widget.initialMultiSelections);
+    });
+  }
+
+  void _toggleMultiModel(_ModelItem model) {
+    final existing = _multiSelections.indexWhere(
+      (selection) =>
+          selection.providerKey == model.providerKey &&
+          selection.modelId == model.id,
+    );
+    setState(() {
+      if (existing >= 0) {
+        _multiSelections.removeAt(existing);
+      } else if (_multiSelections.length <
+          ChatModelSelectionProvider.maximumTargets) {
+        _multiSelections.add(ModelSelection(model.providerKey, model.id));
+      }
+    });
+  }
+
+  void _confirmMultiMode() {
+    if (_multiSelections.length < ChatModelSelectionProvider.minimumTargets) {
+      return;
+    }
+    Navigator.of(
+      context,
+    ).pop(_MultiModelSelectionResult(List.unmodifiable(_multiSelections)));
+  }
+
+  Widget _buildMultiActions(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Material(
+      color: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 4, 12, 2),
+        child: Row(
+          children: [
+            TextButton(
+              key: const ValueKey('model-multi-cancel'),
+              onPressed: _cancelMultiMode,
+              child: Text(l10n.homePageCancel),
+            ),
+            const Spacer(),
+            FilledButton.tonal(
+              key: const ValueKey('model-multi-done'),
+              onPressed:
+                  _multiSelections.length >=
+                      ChatModelSelectionProvider.minimumTargets
+                  ? _confirmMultiMode
+                  : null,
+              child: Text(
+                '${l10n.homePageDone} ${_multiSelections.length}/${ChatModelSelectionProvider.maximumTargets}',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Future<void> _loadModelsAsync() async {
@@ -863,29 +1091,61 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                             ),
                             // Use IconButton for reliable alignment at the far right
                             suffixIcon:
-                                (widget.limitProviderKey == null &&
-                                    context
-                                        .watch<SettingsProvider>()
-                                        .pinnedModels
-                                        .isNotEmpty)
-                                ? ExcludeSemantics(
-                                    child: IconButton(
-                                      icon: Icon(
-                                        Lucide.Bookmark,
-                                        size: 18,
-                                        color: cs.onSurface.withValues(
-                                          alpha: _isLoading ? 0.35 : 0.7,
+                                widget.allowMultiSelect ||
+                                    (widget.limitProviderKey == null &&
+                                        context
+                                            .watch<SettingsProvider>()
+                                            .pinnedModels
+                                            .isNotEmpty)
+                                ? Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      if (widget.allowMultiSelect)
+                                        IconButton(
+                                          key: const ValueKey(
+                                            'model-multi-toggle',
+                                          ),
+                                          icon: Icon(
+                                            Icons.alternate_email,
+                                            size: 19,
+                                            color: _multiMode
+                                                ? cs.primary
+                                                : cs.onSurface.withValues(
+                                                    alpha: _isLoading
+                                                        ? 0.35
+                                                        : 0.75,
+                                                  ),
+                                          ),
+                                          onPressed: _isLoading
+                                              ? null
+                                              : _enterMultiMode,
+                                          tooltip: '@',
                                         ),
-                                      ),
-                                      onPressed: _isLoading
-                                          ? null
-                                          : _jumpToFavorites,
-                                      splashColor: Colors.transparent,
-                                      highlightColor: Colors.transparent,
-                                      hoverColor: Colors.transparent,
-                                      tooltip:
-                                          l10n.modelSelectSheetFavoritesSection,
-                                    ),
+                                      if (widget.limitProviderKey == null &&
+                                          context
+                                              .watch<SettingsProvider>()
+                                              .pinnedModels
+                                              .isNotEmpty)
+                                        ExcludeSemantics(
+                                          child: IconButton(
+                                            icon: Icon(
+                                              Lucide.Bookmark,
+                                              size: 18,
+                                              color: cs.onSurface.withValues(
+                                                alpha: _isLoading ? 0.35 : 0.7,
+                                              ),
+                                            ),
+                                            onPressed: _isLoading
+                                                ? null
+                                                : _jumpToFavorites,
+                                            splashColor: Colors.transparent,
+                                            highlightColor: Colors.transparent,
+                                            hoverColor: Colors.transparent,
+                                            tooltip: l10n
+                                                .modelSelectSheetFavoritesSection,
+                                          ),
+                                        ),
+                                    ],
                                   )
                                 : null,
                             suffixIconConstraints: const BoxConstraints(
@@ -943,6 +1203,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                         : _buildContent(context),
                   ),
                 ),
+                if (_multiMode) _buildMultiActions(context),
                 // Fixed bottom tabs
                 Container(
                   color: cs.surface, // Ensure background color continuity
@@ -1259,7 +1520,8 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     final cs = Theme.of(context).colorScheme;
     final settings = context.read<SettingsProvider>();
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = m.selected
+    final multiSelected = _isMultiSelected(m);
+    final bg = (_multiMode ? multiSelected : m.selected)
         ? (isDark
               ? cs.primary.withValues(alpha: 0.12)
               : cs.primary.withValues(alpha: 0.08))
@@ -1272,8 +1534,11 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
           borderRadius: BorderRadius.circular(14),
           pressedBlendStrength: 0.10,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          onTap: () =>
-              Navigator.of(context).pop(ModelSelection(m.providerKey, m.id)),
+          onTap: _multiMode
+              ? () => _toggleMultiModel(m)
+              : () => Navigator.of(
+                  context,
+                ).pop(ModelSelection(m.providerKey, m.id)),
           onLongPress: () async {
             await showModelDetailSheet(
               context,
@@ -1290,6 +1555,17 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
             width: double.infinity,
             child: Row(
               children: [
+                if (_multiMode) ...[
+                  Checkbox(
+                    key: ValueKey<String>(
+                      'model-multi-checkbox:${m.providerKey}::${m.id}',
+                    ),
+                    value: multiSelected,
+                    onChanged: (_) => _toggleMultiModel(m),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  const SizedBox(width: 2),
+                ],
                 _BrandAvatar(name: m.id, assetOverride: m.asset, size: 28),
                 const SizedBox(width: 10),
                 Expanded(
@@ -1644,13 +1920,15 @@ class _BrandAvatar extends StatelessWidget {
 
 // ===== Desktop dialog implementation =====
 
-Future<ModelSelection?> _showDesktopModelSelector(
+Future<Object?> _showDesktopModelSelector(
   BuildContext context, {
   String? limitProviderKey,
   String? initialProviderKey,
   String? initialModelId,
+  bool allowMultiSelect = false,
+  List<ModelSelection> initialMultiSelections = const <ModelSelection>[],
 }) async {
-  return showGeneralDialog<ModelSelection>(
+  return showGeneralDialog<Object>(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'model-select-desktop',
@@ -1659,6 +1937,8 @@ Future<ModelSelection?> _showDesktopModelSelector(
       limitProviderKey: limitProviderKey,
       initialProviderKey: initialProviderKey,
       initialModelId: initialModelId,
+      allowMultiSelect: allowMultiSelect,
+      initialMultiSelections: initialMultiSelections,
     ),
     transitionBuilder: (ctx, anim, _, child) {
       final curved = CurvedAnimation(parent: anim, curve: Curves.easeOutCubic);
@@ -1678,10 +1958,14 @@ class _DesktopModelSelectDialogBody extends StatefulWidget {
     this.limitProviderKey,
     this.initialProviderKey,
     this.initialModelId,
+    this.allowMultiSelect = false,
+    this.initialMultiSelections = const <ModelSelection>[],
   });
   final String? limitProviderKey;
   final String? initialProviderKey;
   final String? initialModelId;
+  final bool allowMultiSelect;
+  final List<ModelSelection> initialMultiSelections;
   @override
   State<_DesktopModelSelectDialogBody> createState() =>
       _DesktopModelSelectDialogBodyState();
@@ -1706,12 +1990,93 @@ class _DesktopModelSelectDialogBodyState
   final Map<String, int> _favModelIndexMap =
       <String, int>{}; // 'pk::modelId' in favorites -> index
   bool _autoScrolled = false; // auto-scroll once when dialog opens
+  bool _multiMode = false;
+  late List<ModelSelection> _multiSelections;
 
   @override
   void initState() {
     super.initState();
+    _multiSelections = _deduplicateSelections(widget.initialMultiSelections);
     WidgetsBinding.instance.addPostFrameCallback((_) => _focusSearchField());
     Future.microtask(_loadModels);
+  }
+
+  bool _isMultiSelected(_ModelItem model) => _multiSelections.any(
+    (selection) =>
+        selection.providerKey == model.providerKey &&
+        selection.modelId == model.id,
+  );
+
+  void _enterMultiMode() {
+    if (_multiMode) return;
+    if (_multiSelections.isEmpty &&
+        widget.initialProviderKey != null &&
+        widget.initialModelId != null) {
+      _multiSelections.add(
+        ModelSelection(widget.initialProviderKey!, widget.initialModelId!),
+      );
+    }
+    setState(() => _multiMode = true);
+  }
+
+  void _cancelMultiMode() {
+    setState(() {
+      _multiMode = false;
+      _multiSelections = _deduplicateSelections(widget.initialMultiSelections);
+    });
+  }
+
+  void _toggleMultiModel(_ModelItem model) {
+    final existing = _multiSelections.indexWhere(
+      (selection) =>
+          selection.providerKey == model.providerKey &&
+          selection.modelId == model.id,
+    );
+    setState(() {
+      if (existing >= 0) {
+        _multiSelections.removeAt(existing);
+      } else if (_multiSelections.length <
+          ChatModelSelectionProvider.maximumTargets) {
+        _multiSelections.add(ModelSelection(model.providerKey, model.id));
+      }
+    });
+  }
+
+  void _confirmMultiMode() {
+    if (_multiSelections.length < ChatModelSelectionProvider.minimumTargets) {
+      return;
+    }
+    Navigator.of(
+      context,
+    ).pop(_MultiModelSelectionResult(List.unmodifiable(_multiSelections)));
+  }
+
+  Widget _buildMultiActions(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 6, 12, 10),
+      child: Row(
+        children: [
+          TextButton(
+            key: const ValueKey('model-multi-cancel'),
+            onPressed: _cancelMultiMode,
+            child: Text(l10n.homePageCancel),
+          ),
+          const Spacer(),
+          FilledButton.tonal(
+            key: const ValueKey('model-multi-done'),
+            onPressed:
+                _multiSelections.length >=
+                    ChatModelSelectionProvider.minimumTargets
+                ? _confirmMultiMode
+                : null,
+            child: Text(
+              '${l10n.homePageDone} ${_multiSelections.length}/${ChatModelSelectionProvider.maximumTargets}',
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -1987,24 +2352,54 @@ class _DesktopModelSelectDialogBodyState
                                 color: cs.onSurface.withValues(alpha: 0.7),
                               ),
                               suffixIcon:
-                                  (widget.limitProviderKey == null &&
-                                      context
-                                          .watch<SettingsProvider>()
-                                          .pinnedModels
-                                          .isNotEmpty)
-                                  ? Tooltip(
-                                      message:
-                                          l10n.modelSelectSheetFavoritesSection,
-                                      child: IconButton(
-                                        icon: Icon(
-                                          Lucide.Bookmark,
-                                          size: 16,
-                                          color: cs.onSurface.withValues(
-                                            alpha: 0.7,
+                                  widget.allowMultiSelect ||
+                                      (widget.limitProviderKey == null &&
+                                          context
+                                              .watch<SettingsProvider>()
+                                              .pinnedModels
+                                              .isNotEmpty)
+                                  ? Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        if (widget.allowMultiSelect)
+                                          IconButton(
+                                            key: const ValueKey(
+                                              'model-multi-toggle',
+                                            ),
+                                            icon: Icon(
+                                              Icons.alternate_email,
+                                              size: 18,
+                                              color: _multiMode
+                                                  ? cs.primary
+                                                  : cs.onSurface.withValues(
+                                                      alpha: 0.75,
+                                                    ),
+                                            ),
+                                            onPressed: _loading
+                                                ? null
+                                                : _enterMultiMode,
+                                            tooltip: '@',
                                           ),
-                                        ),
-                                        onPressed: _jumpToFavorites,
-                                      ),
+                                        if (widget.limitProviderKey == null &&
+                                            context
+                                                .watch<SettingsProvider>()
+                                                .pinnedModels
+                                                .isNotEmpty)
+                                          Tooltip(
+                                            message: l10n
+                                                .modelSelectSheetFavoritesSection,
+                                            child: IconButton(
+                                              icon: Icon(
+                                                Lucide.Bookmark,
+                                                size: 16,
+                                                color: cs.onSurface.withValues(
+                                                  alpha: 0.7,
+                                                ),
+                                              ),
+                                              onPressed: _jumpToFavorites,
+                                            ),
+                                          ),
+                                      ],
                                     )
                                   : null,
                               border: OutlineInputBorder(
@@ -2037,6 +2432,7 @@ class _DesktopModelSelectDialogBodyState
                               ? const Center(child: CircularProgressIndicator())
                               : _buildList(context),
                         ),
+                        if (_multiMode) _buildMultiActions(context),
                       ],
                     ),
                   ),
@@ -2162,7 +2558,8 @@ class _DesktopModelSelectDialogBodyState
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
-    final bg = m.selected
+    final multiSelected = _isMultiSelected(m);
+    final bg = (_multiMode ? multiSelected : m.selected)
         ? (isDark
               ? cs.primary.withValues(alpha: 0.12)
               : cs.primary.withValues(alpha: 0.08))
@@ -2175,10 +2572,24 @@ class _DesktopModelSelectDialogBodyState
         borderRadius: BorderRadius.circular(14),
         pressedBlendStrength: 0.10,
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-        onTap: () =>
-            Navigator.of(context).pop(ModelSelection(m.providerKey, m.id)),
+        onTap: _multiMode
+            ? () => _toggleMultiModel(m)
+            : () => Navigator.of(
+                context,
+              ).pop(ModelSelection(m.providerKey, m.id)),
         child: Row(
           children: [
+            if (_multiMode) ...[
+              Checkbox(
+                key: ValueKey<String>(
+                  'model-multi-checkbox:${m.providerKey}::${m.id}',
+                ),
+                value: multiSelected,
+                onChanged: (_) => _toggleMultiModel(m),
+                visualDensity: VisualDensity.compact,
+              ),
+              const SizedBox(width: 2),
+            ],
             _BrandAvatar(name: m.id, assetOverride: m.asset, size: 18),
             const SizedBox(width: 6),
             Expanded(

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -9,6 +9,8 @@ import '../../../icons/lucide_adapter.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
 import '../../../core/providers/settings_provider.dart';
+import '../../../core/providers/chat_model_selection_provider.dart';
+import '../../../core/models/chat_model_target.dart';
 import 'theme_settings_page.dart';
 import '../../../theme/palettes.dart';
 import '../../../l10n/app_localizations.dart';
@@ -1720,6 +1722,72 @@ Future<void> _showMobileMessageNavModeSheet(BuildContext context) async {
   await context.read<SettingsProvider>().setMobileMessageNavButtonsMode(choice);
 }
 
+String _multiModelScopeLabel(
+  AppLocalizations l10n,
+  MultiModelSelectionScope scope,
+) => switch (scope) {
+  MultiModelSelectionScope.assistant => l10n.multiModelScopeAssistant,
+  MultiModelSelectionScope.conversation => l10n.multiModelScopeConversation,
+  MultiModelSelectionScope.nextMessage => l10n.multiModelScopeNextMessage,
+};
+
+Future<void> _showMultiModelScopeSheet(
+  BuildContext context,
+  MultiModelSelectionScope currentScope,
+) async {
+  final cs = Theme.of(context).colorScheme;
+  final l10n = AppLocalizations.of(context)!;
+  final choice = await showModalBottomSheet<MultiModelSelectionScope>(
+    context: context,
+    backgroundColor: cs.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.multiModelScopeTitle,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: AppFontWeights.semibold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    l10n.multiModelScopeSubtitle,
+                    style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                  ),
+                ],
+              ),
+            ),
+            for (final scope in MultiModelSelectionScope.values) ...[
+              _sheetOption(
+                ctx,
+                label: _multiModelScopeLabel(l10n, scope),
+                onTap: () => Navigator.of(ctx).pop(scope),
+              ),
+              if (scope != MultiModelSelectionScope.values.last)
+                _sheetDividerNoIcon(ctx),
+            ],
+          ],
+        ),
+      ),
+    ),
+  );
+  if (choice == null || choice == currentScope || !context.mounted) return;
+  await context.read<ChatModelSelectionProvider>().setScope(choice);
+}
+
 // --- Subpages ---
 
 class ChatItemDisplaySettingsPage extends StatelessWidget {
@@ -2088,6 +2156,7 @@ class BehaviorStartupSettingsPage extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final sp = context.watch<SettingsProvider>();
+    final multiModelSelection = context.watch<ChatModelSelectionProvider?>();
     return Scaffold(
       appBar: AppBar(
         leading: Tooltip(
@@ -2106,6 +2175,22 @@ class BehaviorStartupSettingsPage extends StatelessWidget {
         children: [
           _iosSectionCard(
             children: [
+              if (multiModelSelection != null) ...[
+                _iosNavRow(
+                  context,
+                  icon: Lucide.MessagesSquare,
+                  label: l10n.multiModelScopeTitle,
+                  detailText: _multiModelScopeLabel(
+                    l10n,
+                    multiModelSelection.scope,
+                  ),
+                  onTap: () => _showMultiModelScopeSheet(
+                    context,
+                    multiModelSelection.scope,
+                  ),
+                ),
+                _iosDivider(context),
+              ],
               _iosSwitchRow(
                 context,
                 icon: Lucide.Brain,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1214,6 +1214,28 @@
   "defaultModelPageTitle": "Default Model",
   "defaultModelPageChatModelTitle": "Chat Model",
   "defaultModelPageChatModelSubtitle": "Global default chat model",
+  "multiModelScopeTitle": "Multi-model selection applies to",
+  "multiModelScopeSubtitle": "Keep separate model combinations for each scope",
+  "multiModelScopeAssistant": "Current assistant",
+  "multiModelScopeConversation": "Current conversation",
+  "multiModelScopeNextMessage": "Next message only",
+  "multiModelSelectedAnswerUnavailable": "The selected model has no usable answer. Switch models or regenerate before sending the next message.",
+  "multiModelCount": "{count} models",
+  "@multiModelCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "multiModelAttachmentUnsupported": "These attachments are not supported by: {models}",
+  "@multiModelAttachmentUnsupported": {
+    "placeholders": {
+      "models": { "type": "String" }
+    }
+  },
+  "multiModelStatusGenerating": "Generating",
+  "multiModelStatusFailed": "Failed",
+  "multiModelStatusCancelled": "Cancelled",
+  "multiModelStatusInterrupted": "Interrupted",
   "defaultModelPageTitleModelTitle": "Title Summary Model",
   "defaultModelPageTitleModelSubtitle": "Used for summarizing conversation titles; prefer fast & cheap models",
   "titleModelThinkingTitle": "Enable Thinking",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5309,6 +5309,78 @@ abstract class AppLocalizations {
   /// **'Global default chat model'**
   String get defaultModelPageChatModelSubtitle;
 
+  /// No description provided for @multiModelScopeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Multi-model selection applies to'**
+  String get multiModelScopeTitle;
+
+  /// No description provided for @multiModelScopeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep separate model combinations for each scope'**
+  String get multiModelScopeSubtitle;
+
+  /// No description provided for @multiModelScopeAssistant.
+  ///
+  /// In en, this message translates to:
+  /// **'Current assistant'**
+  String get multiModelScopeAssistant;
+
+  /// No description provided for @multiModelScopeConversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Current conversation'**
+  String get multiModelScopeConversation;
+
+  /// No description provided for @multiModelScopeNextMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Next message only'**
+  String get multiModelScopeNextMessage;
+
+  /// No description provided for @multiModelSelectedAnswerUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'The selected model has no usable answer. Switch models or regenerate before sending the next message.'**
+  String get multiModelSelectedAnswerUnavailable;
+
+  /// No description provided for @multiModelCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} models'**
+  String multiModelCount(int count);
+
+  /// No description provided for @multiModelAttachmentUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'These attachments are not supported by: {models}'**
+  String multiModelAttachmentUnsupported(String models);
+
+  /// No description provided for @multiModelStatusGenerating.
+  ///
+  /// In en, this message translates to:
+  /// **'Generating'**
+  String get multiModelStatusGenerating;
+
+  /// No description provided for @multiModelStatusFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed'**
+  String get multiModelStatusFailed;
+
+  /// No description provided for @multiModelStatusCancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancelled'**
+  String get multiModelStatusCancelled;
+
+  /// No description provided for @multiModelStatusInterrupted.
+  ///
+  /// In en, this message translates to:
+  /// **'Interrupted'**
+  String get multiModelStatusInterrupted;
+
   /// No description provided for @defaultModelPageTitleModelTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2828,6 +2828,48 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultModelPageChatModelSubtitle => 'Global default chat model';
 
   @override
+  String get multiModelScopeTitle => 'Multi-model selection applies to';
+
+  @override
+  String get multiModelScopeSubtitle =>
+      'Keep separate model combinations for each scope';
+
+  @override
+  String get multiModelScopeAssistant => 'Current assistant';
+
+  @override
+  String get multiModelScopeConversation => 'Current conversation';
+
+  @override
+  String get multiModelScopeNextMessage => 'Next message only';
+
+  @override
+  String get multiModelSelectedAnswerUnavailable =>
+      'The selected model has no usable answer. Switch models or regenerate before sending the next message.';
+
+  @override
+  String multiModelCount(int count) {
+    return '$count models';
+  }
+
+  @override
+  String multiModelAttachmentUnsupported(String models) {
+    return 'These attachments are not supported by: $models';
+  }
+
+  @override
+  String get multiModelStatusGenerating => 'Generating';
+
+  @override
+  String get multiModelStatusFailed => 'Failed';
+
+  @override
+  String get multiModelStatusCancelled => 'Cancelled';
+
+  @override
+  String get multiModelStatusInterrupted => 'Interrupted';
+
+  @override
   String get defaultModelPageTitleModelTitle => 'Title Summary Model';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2731,6 +2731,47 @@ class AppLocalizationsZh extends AppLocalizations {
   String get defaultModelPageChatModelSubtitle => '全局默认的聊天模型';
 
   @override
+  String get multiModelScopeTitle => '多模型选择生效范围';
+
+  @override
+  String get multiModelScopeSubtitle => '每个范围会分别保留上次使用的模型组合';
+
+  @override
+  String get multiModelScopeAssistant => '跟随当前助手';
+
+  @override
+  String get multiModelScopeConversation => '仅当前会话';
+
+  @override
+  String get multiModelScopeNextMessage => '仅下一条消息';
+
+  @override
+  String get multiModelSelectedAnswerUnavailable =>
+      '当前选中的模型没有可用回答，请切换模型或重新生成后再发送下一条消息。';
+
+  @override
+  String multiModelCount(int count) {
+    return '$count 个模型';
+  }
+
+  @override
+  String multiModelAttachmentUnsupported(String models) {
+    return '以下模型不支持这些附件：$models';
+  }
+
+  @override
+  String get multiModelStatusGenerating => '生成中';
+
+  @override
+  String get multiModelStatusFailed => '失败';
+
+  @override
+  String get multiModelStatusCancelled => '已取消';
+
+  @override
+  String get multiModelStatusInterrupted => '已中断';
+
+  @override
   String get defaultModelPageTitleModelTitle => '标题总结模型';
 
   @override
@@ -8276,6 +8317,47 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get defaultModelPageChatModelSubtitle => '全局默认的聊天模型';
 
   @override
+  String get multiModelScopeTitle => '多模型选择生效范围';
+
+  @override
+  String get multiModelScopeSubtitle => '每个范围会分别保留上次使用的模型组合';
+
+  @override
+  String get multiModelScopeAssistant => '跟随当前助手';
+
+  @override
+  String get multiModelScopeConversation => '仅当前会话';
+
+  @override
+  String get multiModelScopeNextMessage => '仅下一条消息';
+
+  @override
+  String get multiModelSelectedAnswerUnavailable =>
+      '当前选中的模型没有可用回答，请切换模型或重新生成后再发送下一条消息。';
+
+  @override
+  String multiModelCount(int count) {
+    return '$count 个模型';
+  }
+
+  @override
+  String multiModelAttachmentUnsupported(String models) {
+    return '以下模型不支持这些附件：$models';
+  }
+
+  @override
+  String get multiModelStatusGenerating => '生成中';
+
+  @override
+  String get multiModelStatusFailed => '失败';
+
+  @override
+  String get multiModelStatusCancelled => '已取消';
+
+  @override
+  String get multiModelStatusInterrupted => '已中断';
+
+  @override
   String get defaultModelPageTitleModelTitle => '标题总结模型';
 
   @override
@@ -13818,6 +13900,47 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get defaultModelPageChatModelSubtitle => '全域預設的聊天模型';
+
+  @override
+  String get multiModelScopeTitle => '多模型選擇生效範圍';
+
+  @override
+  String get multiModelScopeSubtitle => '每個範圍會分別保留上次使用的模型組合';
+
+  @override
+  String get multiModelScopeAssistant => '跟隨目前助理';
+
+  @override
+  String get multiModelScopeConversation => '僅目前對話';
+
+  @override
+  String get multiModelScopeNextMessage => '僅下一則訊息';
+
+  @override
+  String get multiModelSelectedAnswerUnavailable =>
+      '目前選取的模型沒有可用回答，請切換模型或重新產生後再傳送下一則訊息。';
+
+  @override
+  String multiModelCount(int count) {
+    return '$count 個模型';
+  }
+
+  @override
+  String multiModelAttachmentUnsupported(String models) {
+    return '以下模型不支援這些附件：$models';
+  }
+
+  @override
+  String get multiModelStatusGenerating => '生成中';
+
+  @override
+  String get multiModelStatusFailed => '失敗';
+
+  @override
+  String get multiModelStatusCancelled => '已取消';
+
+  @override
+  String get multiModelStatusInterrupted => '已中斷';
 
   @override
   String get defaultModelPageTitleModelTitle => '標題總結模型';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -929,6 +929,28 @@
   "defaultModelPageTitle": "默认模型",
   "defaultModelPageChatModelTitle": "聊天模型",
   "defaultModelPageChatModelSubtitle": "全局默认的聊天模型",
+  "multiModelScopeTitle": "多模型选择生效范围",
+  "multiModelScopeSubtitle": "每个范围会分别保留上次使用的模型组合",
+  "multiModelScopeAssistant": "跟随当前助手",
+  "multiModelScopeConversation": "仅当前会话",
+  "multiModelScopeNextMessage": "仅下一条消息",
+  "multiModelSelectedAnswerUnavailable": "当前选中的模型没有可用回答，请切换模型或重新生成后再发送下一条消息。",
+  "multiModelCount": "{count} 个模型",
+  "@multiModelCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "multiModelAttachmentUnsupported": "以下模型不支持这些附件：{models}",
+  "@multiModelAttachmentUnsupported": {
+    "placeholders": {
+      "models": { "type": "String" }
+    }
+  },
+  "multiModelStatusGenerating": "生成中",
+  "multiModelStatusFailed": "失败",
+  "multiModelStatusCancelled": "已取消",
+  "multiModelStatusInterrupted": "已中断",
   "defaultModelPageTitleModelTitle": "标题总结模型",
   "defaultModelPageTitleModelSubtitle": "用于总结对话标题的模型，推荐使用快速且便宜的模型",
   "titleModelThinkingTitle": "是否开启思考",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -964,6 +964,28 @@
   "defaultModelPageTitle": "默认模型",
   "defaultModelPageChatModelTitle": "聊天模型",
   "defaultModelPageChatModelSubtitle": "全局默认的聊天模型",
+  "multiModelScopeTitle": "多模型选择生效范围",
+  "multiModelScopeSubtitle": "每个范围会分别保留上次使用的模型组合",
+  "multiModelScopeAssistant": "跟随当前助手",
+  "multiModelScopeConversation": "仅当前会话",
+  "multiModelScopeNextMessage": "仅下一条消息",
+  "multiModelSelectedAnswerUnavailable": "当前选中的模型没有可用回答，请切换模型或重新生成后再发送下一条消息。",
+  "multiModelCount": "{count} 个模型",
+  "@multiModelCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "multiModelAttachmentUnsupported": "以下模型不支持这些附件：{models}",
+  "@multiModelAttachmentUnsupported": {
+    "placeholders": {
+      "models": { "type": "String" }
+    }
+  },
+  "multiModelStatusGenerating": "生成中",
+  "multiModelStatusFailed": "失败",
+  "multiModelStatusCancelled": "已取消",
+  "multiModelStatusInterrupted": "已中断",
   "defaultModelPageTitleModelTitle": "标题总结模型",
   "defaultModelPageTitleModelSubtitle": "用于总结对话标题的模型，推荐使用快速且便宜的模型",
   "titleModelThinkingTitle": "是否开启思考",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -922,6 +922,28 @@
   "defaultModelPageTitle": "預設模型",
   "defaultModelPageChatModelTitle": "聊天模型",
   "defaultModelPageChatModelSubtitle": "全域預設的聊天模型",
+  "multiModelScopeTitle": "多模型選擇生效範圍",
+  "multiModelScopeSubtitle": "每個範圍會分別保留上次使用的模型組合",
+  "multiModelScopeAssistant": "跟隨目前助理",
+  "multiModelScopeConversation": "僅目前對話",
+  "multiModelScopeNextMessage": "僅下一則訊息",
+  "multiModelSelectedAnswerUnavailable": "目前選取的模型沒有可用回答，請切換模型或重新產生後再傳送下一則訊息。",
+  "multiModelCount": "{count} 個模型",
+  "@multiModelCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "multiModelAttachmentUnsupported": "以下模型不支援這些附件：{models}",
+  "@multiModelAttachmentUnsupported": {
+    "placeholders": {
+      "models": { "type": "String" }
+    }
+  },
+  "multiModelStatusGenerating": "生成中",
+  "multiModelStatusFailed": "失敗",
+  "multiModelStatusCancelled": "已取消",
+  "multiModelStatusInterrupted": "已中斷",
   "defaultModelPageTitleModelTitle": "標題總結模型",
   "defaultModelPageTitleModelSubtitle": "用於總結對話標題的模型，推薦使用快速且便宜的模型",
   "titleModelThinkingTitle": "是否開啟思考",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'core/providers/settings_provider.dart';
 import 'core/providers/mcp_provider.dart';
 import 'core/providers/tts_provider.dart';
 import 'core/providers/assistant_provider.dart';
+import 'core/providers/chat_model_selection_provider.dart';
 import 'core/providers/tag_provider.dart';
 import 'core/providers/update_provider.dart';
 import 'core/providers/quick_phrase_provider.dart';
@@ -324,6 +325,29 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (ctx) =>
               AssistantProvider(chatService: ctx.read<ChatService>()),
+        ),
+        ChangeNotifierProvider(
+          lazy: false,
+          create: (ctx) {
+            final selectionProvider = ChatModelSelectionProvider();
+            ctx.read<ChatService>().setConversationDeletedCallback(
+              selectionProvider.removeConversation,
+            );
+            ctx.read<AssistantProvider>().setAssistantDeletedCallback(
+              selectionProvider.removeAssistant,
+            );
+            ctx.read<SettingsProvider>().setModelSelectionLifecycleCallbacks(
+              onModelsDeleted: (providerKey, modelIds) =>
+                  selectionProvider.pruneTargets(
+                    (target) =>
+                        target.providerKey != providerKey ||
+                        !modelIds.contains(target.modelId),
+                  ),
+              onProviderUnavailable: (providerKey) => selectionProvider
+                  .pruneTargets((target) => target.providerKey != providerKey),
+            );
+            return selectionProvider;
+          },
         ),
         ChangeNotifierProvider(create: (_) => TagProvider()),
         ChangeNotifierProvider(create: (_) => TtsProvider()),

--- a/test/core/database/generation_begin_commands_test.dart
+++ b/test/core/database/generation_begin_commands_test.dart
@@ -113,6 +113,174 @@ void main() {
     );
   });
 
+  test(
+    'batch begin commits ordered sibling targets and runs atomically',
+    () async {
+      final result = await repository.beginSendGenerationBatch(
+        conversation: conversation,
+        userMessage: user('user-batch'),
+        targets: <GenerationBatchTargetInput>[
+          (
+            assistantMessage: assistant(
+              'answer-a',
+            ).copyWith(providerId: 'provider-a', modelId: 'model-a'),
+            runId: 'run-a',
+          ),
+          (
+            assistantMessage: assistant(
+              'answer-b',
+            ).copyWith(providerId: 'provider-b', modelId: 'model-b'),
+            runId: 'run-b',
+          ),
+          (
+            assistantMessage: assistant(
+              'answer-c',
+            ).copyWith(providerId: 'provider-c', modelId: 'model-c'),
+            runId: 'run-c',
+          ),
+        ],
+      );
+
+      expect(result.targets.map((target) => target.assistantMessage.id), [
+        'answer-a',
+        'answer-b',
+        'answer-c',
+      ]);
+      expect(
+        result.targets.map((target) => target.assistantMessage.groupId),
+        everyElement('answer-a'),
+      );
+      expect(result.targets.map((target) => target.assistantMessage.version), [
+        0,
+        1,
+        2,
+      ]);
+      expect(result.targets.map((target) => target.run.targetRevisionId), [
+        'answer-a',
+        'answer-b',
+        'answer-c',
+      ]);
+      final latestRuns = await repository.getLatestGenerationRunsForTargets([
+        'answer-a',
+        'answer-b',
+        'answer-c',
+      ]);
+      expect(
+        latestRuns.keys,
+        containsAll(<String>['answer-a', 'answer-b', 'answer-c']),
+      );
+      expect(
+        latestRuns.values.map((run) => run.state),
+        everyElement(GenerationRunState.preparing),
+      );
+      expect(result.conversation.versionSelections['answer-a'], 0);
+      expect(await repository.getMessageIds(conversation.id), [
+        'user-batch',
+        'answer-a',
+        'answer-b',
+        'answer-c',
+      ]);
+
+      await repository.setSelectedVersion(
+        conversationId: conversation.id,
+        groupId: 'answer-a',
+        version: 2,
+      );
+      final context = await repository.getSelectedContextMessages(
+        conversation.id,
+        truncateIndex: -1,
+        limit: 20,
+      );
+      expect(context.map((message) => message.id), ['user-batch', 'answer-c']);
+    },
+  );
+
+  test('batch run conflict rolls back every target in the new turn', () async {
+    await beginFirstSend();
+
+    await expectLater(
+      repository.beginSendGenerationBatch(
+        conversation: conversation,
+        userMessage: user('user-conflict'),
+        targets: <GenerationBatchTargetInput>[
+          (assistantMessage: assistant('answer-new'), runId: 'run-new'),
+          (assistantMessage: assistant('answer-conflict'), runId: 'run-1'),
+        ],
+      ),
+      throwsA(anything),
+    );
+
+    expect(await repository.getMessage('user-conflict'), isNull);
+    expect(await repository.getMessage('answer-new'), isNull);
+    expect(await repository.getMessage('answer-conflict'), isNull);
+    expect(await repository.getGenerationRun('run-new'), isNull);
+    expect(await repository.getMessageIds(conversation.id), [
+      'user-1',
+      'assistant-1',
+    ]);
+  });
+
+  test('batch siblings checkpoint and finalize independently', () async {
+    final begin = await repository.beginSendGenerationBatch(
+      conversation: conversation,
+      userMessage: user('user-parallel'),
+      targets: <GenerationBatchTargetInput>[
+        (assistantMessage: assistant('parallel-a'), runId: 'parallel-run-a'),
+        (assistantMessage: assistant('parallel-b'), runId: 'parallel-run-b'),
+      ],
+    );
+    final streamingRuns = await Future.wait(
+      begin.targets.map((target) => advanceToStreaming(target.run)),
+    );
+    final partialMessages = <ChatMessage>[
+      begin.targets[0].assistantMessage.copyWith(content: 'partial-a'),
+      begin.targets[1].assistantMessage.copyWith(content: 'partial-b'),
+    ];
+
+    await Future.wait<void>([
+      for (final (index, run) in streamingRuns.indexed)
+        repository.updateStreamingCheckpoint(
+          partialMessages[index],
+          const [],
+          generationRunId: run.id,
+          checkpointSeq: 1,
+        ),
+    ]);
+
+    final terminalRuns = await Future.wait<GenerationRun>([
+      repository.finalizeGenerationRun(
+        message: partialMessages[0].copyWith(
+          content: 'final-a',
+          isStreaming: false,
+        ),
+        toolEvents: const [],
+        generationRunId: streamingRuns[0].id,
+        expectedState: streamingRuns[0].state,
+        expectedStateRevision: streamingRuns[0].stateRevision,
+        terminalState: GenerationRunState.completed,
+        checkpointSeq: 2,
+      ),
+      repository.finalizeGenerationRun(
+        message: partialMessages[1].copyWith(isStreaming: false),
+        toolEvents: const [],
+        generationRunId: streamingRuns[1].id,
+        expectedState: streamingRuns[1].state,
+        expectedStateRevision: streamingRuns[1].stateRevision,
+        terminalState: GenerationRunState.failed,
+        checkpointSeq: 2,
+        errorCode: 'generation_failed',
+      ),
+    ]);
+
+    expect(terminalRuns.map((run) => run.state), [
+      GenerationRunState.completed,
+      GenerationRunState.failed,
+    ]);
+    expect((await repository.getMessage('parallel-a'))?.content, 'final-a');
+    expect((await repository.getMessage('parallel-b'))?.content, 'partial-b');
+    expect(await repository.getActiveStreamingIds(), isEmpty);
+  });
+
   test('run insert failure rolls back every linear send row', () async {
     final first = await beginFirstSend();
 

--- a/test/core/providers/chat_model_selection_provider_test.dart
+++ b/test/core/providers/chat_model_selection_provider_test.dart
@@ -1,0 +1,128 @@
+import 'package:Kelivo/core/models/chat_model_target.dart';
+import 'package:Kelivo/core/providers/chat_model_selection_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const fallback = ChatModelTarget(providerKey: 'fallback', modelId: 'one');
+  const a = ChatModelTarget(providerKey: 'p1', modelId: 'a');
+  const b = ChatModelTarget(providerKey: 'p2', modelId: 'b');
+  const c = ChatModelTarget(providerKey: 'p3', modelId: 'c');
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('defaults to conversation scope and persists ordered targets', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final provider = ChatModelSelectionProvider(preferences: prefs);
+    await provider.ready;
+
+    expect(provider.scope, MultiModelSelectionScope.conversation);
+    expect(
+      provider.effectiveTargets(
+        fallback: fallback,
+        assistantId: 'assistant',
+        conversationId: 'conversation',
+      ),
+      [fallback],
+    );
+
+    await provider.setTargets(
+      targets: const [b, a, b, c],
+      conversationId: 'conversation',
+    );
+    expect(provider.targetsForScope(conversationId: 'conversation'), [b, a, c]);
+
+    final restored = ChatModelSelectionProvider(preferences: prefs);
+    await restored.ready;
+    expect(restored.targetsForScope(conversationId: 'conversation'), [b, a, c]);
+  });
+
+  test(
+    'keeps scope histories and consumes next-message only explicitly',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final provider = ChatModelSelectionProvider(preferences: prefs);
+      await provider.ready;
+
+      await provider.setTargets(
+        targets: const [a, b],
+        conversationId: 'conversation',
+      );
+      await provider.setScope(MultiModelSelectionScope.assistant);
+      await provider.setTargets(
+        targets: const [b, c],
+        assistantId: 'assistant',
+      );
+      await provider.setScope(MultiModelSelectionScope.nextMessage);
+      await provider.setTargets(
+        targets: const [c, a],
+        conversationId: 'conversation',
+      );
+
+      expect(
+        provider.targetsForScope(
+          scope: MultiModelSelectionScope.conversation,
+          conversationId: 'conversation',
+        ),
+        [a, b],
+      );
+      expect(
+        provider.targetsForScope(
+          scope: MultiModelSelectionScope.assistant,
+          assistantId: 'assistant',
+        ),
+        [b, c],
+      );
+      expect(await provider.consumeNextMessage('conversation'), [c, a]);
+      expect(provider.targetsForScope(conversationId: 'conversation'), isEmpty);
+    },
+  );
+
+  test(
+    'remaps conversations and falls back when pruning leaves one target',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final provider = ChatModelSelectionProvider(preferences: prefs);
+      await provider.ready;
+      await provider.setTargets(
+        targets: const [a, b, c],
+        conversationId: 'old',
+      );
+
+      await provider.remapConversationIds(const {'old': 'new'});
+      expect(provider.targetsForScope(conversationId: 'old'), isEmpty);
+      expect(provider.targetsForScope(conversationId: 'new'), [a, b, c]);
+
+      await provider.pruneTargets((target) => target == a);
+      expect(provider.targetsForScope(conversationId: 'new'), isEmpty);
+      expect(
+        provider.effectiveTargets(fallback: fallback, conversationId: 'new'),
+        [fallback],
+      );
+    },
+  );
+
+  test('rejects combinations with fewer than two unique targets', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final provider = ChatModelSelectionProvider(preferences: prefs);
+    await provider.ready;
+
+    await expectLater(
+      provider.setTargets(targets: const [a, a], conversationId: 'c'),
+      throwsArgumentError,
+    );
+    await expectLater(
+      provider.setTargets(
+        conversationId: 'conversation-a',
+        targets: [
+          for (var index = 0; index < 6; index++)
+            ChatModelTarget(
+              providerKey: 'provider-$index',
+              modelId: 'model-$index',
+            ),
+        ],
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/core/services/backup/backup_settings_validator_test.dart
+++ b/test/core/services/backup/backup_settings_validator_test.dart
@@ -64,5 +64,92 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('merges multi-model selections and remaps only imported chats', () {
+      String selections({
+        required String scope,
+        required Map<String, dynamic> assistants,
+        required Map<String, dynamic> conversations,
+        required Map<String, dynamic> nextMessages,
+      }) => jsonEncode({
+        'version': 1,
+        'scope': scope,
+        'assistants': assistants,
+        'conversations': conversations,
+        'nextMessages': nextMessages,
+      });
+
+      final localTargets = [
+        {'providerKey': 'local', 'modelId': 'one'},
+        {'providerKey': 'local', 'modelId': 'two'},
+      ];
+      final importedTargets = [
+        {'providerKey': 'remote', 'modelId': 'one'},
+        {'providerKey': 'remote', 'modelId': 'two'},
+      ];
+      final merged =
+          jsonDecode(
+                BackupSettingsValidator.mergeChatModelSelectionsForRestore(
+                  existingValue: selections(
+                    scope: 'conversation',
+                    assistants: {'same-assistant': localTargets},
+                    conversations: {'collision': localTargets},
+                    nextMessages: {'local-next': localTargets},
+                  ),
+                  incomingValue: selections(
+                    scope: 'nextMessage',
+                    assistants: {'same-assistant': importedTargets},
+                    conversations: {'collision': importedTargets},
+                    nextMessages: {'incoming-next': importedTargets},
+                  ),
+                  remappedConversationIds: {
+                    'collision': 'imported-copy',
+                    'incoming-next': 'remapped-next',
+                  },
+                ),
+              )
+              as Map<String, dynamic>;
+
+      expect(merged['scope'], 'conversation');
+      expect(merged['assistants']['same-assistant'], localTargets);
+      expect(merged['conversations']['collision'], localTargets);
+      expect(merged['conversations']['imported-copy'], importedTargets);
+      expect(merged['nextMessages']['local-next'], localTargets);
+      expect(merged['nextMessages']['remapped-next'], importedTargets);
+    });
+
+    test('rejects malformed multi-model selection targets', () {
+      expect(
+        () => BackupSettingsValidator.validate({
+          'chat_model_selections_v1': jsonEncode({
+            'scope': 'conversation',
+            'conversations': {
+              'conversation': [
+                {'providerKey': 'provider', 'modelId': 'only-one'},
+              ],
+            },
+          }),
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects unknown multi-model selection storage versions', () {
+      expect(
+        () => BackupSettingsValidator.validate({
+          'chat_model_selections_v1': jsonEncode({
+            'version': 2,
+            'scope': 'conversation',
+            'conversations': {
+              'conversation': [
+                {'providerKey': 'provider', 'modelId': 'one'},
+                {'providerKey': 'provider', 'modelId': 'two'},
+              ],
+            },
+          }),
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 }

--- a/test/features/home/controllers/active_streaming_message_store_test.dart
+++ b/test/features/home/controllers/active_streaming_message_store_test.dart
@@ -6,6 +6,8 @@ ChatMessage _message({
   required String id,
   required String conversationId,
   bool isStreaming = true,
+  String? groupId,
+  int version = 0,
 }) {
   return ChatMessage(
     id: id,
@@ -13,6 +15,8 @@ ChatMessage _message({
     content: id,
     conversationId: conversationId,
     isStreaming: isStreaming,
+    groupId: groupId,
+    version: version,
   );
 }
 
@@ -23,7 +27,7 @@ void main() {
       final active = _message(id: 'off-window', conversationId: 'chat');
       store.put(active);
 
-      final target = store.cancellationTarget('chat', const []);
+      final target = store.cancellationTarget('chat', const [], const {});
 
       expect(target?.id, 'off-window');
     });
@@ -34,7 +38,7 @@ void main() {
         _message(id: 'other', conversationId: 'other-chat'),
         _message(id: 'finished', conversationId: 'chat', isStreaming: false),
         _message(id: 'expected', conversationId: 'chat'),
-      ]);
+      ], const {});
 
       expect(target?.id, 'expected');
     });
@@ -62,6 +66,51 @@ void main() {
       store.removeIfMatches(preparing);
 
       expect(store.isActive(preparing), isFalse);
+    });
+
+    test('同会话多 generation 按当前选择的真实版本取消', () {
+      final store = ActiveStreamingMessageStore();
+      final first = _message(
+        id: 'first',
+        conversationId: 'chat',
+        groupId: 'answer',
+        version: 2,
+      );
+      final second = _message(
+        id: 'second',
+        conversationId: 'chat',
+        groupId: 'answer',
+        version: 7,
+      );
+      store
+        ..put(first)
+        ..put(second);
+
+      expect(store.activeMessages('chat').map((message) => message.id), [
+        'first',
+        'second',
+      ]);
+      expect(
+        store.cancellationTarget('chat', const [], const {'answer': 2})?.id,
+        'first',
+      );
+      expect(
+        store.cancellationTarget('chat', const [], const {'answer': 7})?.id,
+        'second',
+      );
+
+      store.removeIfMatches(second);
+
+      expect(store.hasActiveConversation('chat'), isTrue);
+      expect(
+        store.cancellationTarget('chat', const [], const {'answer': 7}),
+        isNull,
+        reason: '已终态的选中版本不能误停仍在生成的 sibling',
+      );
+      expect(
+        store.cancellationTarget('chat', const [], const {'answer': 2})?.id,
+        'first',
+      );
     });
   });
 }

--- a/test/features/home/controllers/chat_actions_regeneration_context_test.dart
+++ b/test/features/home/controllers/chat_actions_regeneration_context_test.dart
@@ -9,6 +9,8 @@ ChatMessage _message({
   required String role,
   required String groupId,
   required int version,
+  String? providerId,
+  String? modelId,
 }) {
   return ChatMessage(
     id: id,
@@ -17,6 +19,8 @@ ChatMessage _message({
     conversationId: 'conversation-1',
     groupId: groupId,
     version: version,
+    providerId: providerId,
+    modelId: modelId,
   );
 }
 
@@ -79,6 +83,61 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  group('ChatActions.resolveRegenerationModelTarget', () {
+    test('assistant retry keeps the model shown on that reply', () {
+      final target = ChatActions.resolveRegenerationModelTarget(
+        message: _message(
+          id: 'grok-answer',
+          role: 'assistant',
+          groupId: 'answer',
+          version: 2,
+          providerId: 'axonhub-gpt',
+          modelId: 'grok-4.5',
+        ),
+        fallbackProviderKey: 'google',
+        fallbackModelId: 'gemini-3.5-flash',
+      );
+
+      expect(target.providerKey, 'axonhub-gpt');
+      expect(target.modelId, 'grok-4.5');
+    });
+
+    test('complete reply metadata works without a current model fallback', () {
+      final target = ChatActions.resolveRegenerationModelTarget(
+        message: _message(
+          id: 'grok-answer',
+          role: 'assistant',
+          groupId: 'answer',
+          version: 2,
+          providerId: 'axonhub-gpt',
+          modelId: 'grok-4.5',
+        ),
+        fallbackProviderKey: null,
+        fallbackModelId: null,
+      );
+
+      expect(target.providerKey, 'axonhub-gpt');
+      expect(target.modelId, 'grok-4.5');
+    });
+
+    test('messages without a complete target use the current model pair', () {
+      final target = ChatActions.resolveRegenerationModelTarget(
+        message: _message(
+          id: 'legacy-answer',
+          role: 'assistant',
+          groupId: 'answer',
+          version: 0,
+          providerId: 'legacy-provider',
+        ),
+        fallbackProviderKey: 'openai',
+        fallbackModelId: 'gpt-5.6',
+      );
+
+      expect(target.providerKey, 'openai');
+      expect(target.modelId, 'gpt-5.6');
+    });
   });
 
   group('ChatActions.buildRegenerationMessages', () {

--- a/test/features/home/controllers/chat_controller_lazy_history_test.dart
+++ b/test/features/home/controllers/chat_controller_lazy_history_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:Kelivo/core/models/chat_message.dart';
 import 'package:Kelivo/core/models/conversation.dart';
+import 'package:Kelivo/core/database/generation_run.dart';
 import 'package:Kelivo/core/services/chat/chat_service.dart';
 import 'package:Kelivo/features/home/controllers/chat_controller.dart';
 
@@ -241,6 +242,11 @@ class _FakeLazyChatService extends ChatService {
     String conversationId,
     Iterable<String> groupIds,
   ) async => getFirstMessageIndicesForGroups(conversationId, groupIds);
+
+  @override
+  Future<Map<String, GenerationRun>> loadLatestGenerationRunsForTargets(
+    Iterable<String> targetRevisionIds,
+  ) async => const <String, GenerationRun>{};
 
   @override
   List<ChatMessage> getMessagesForGroups(
@@ -744,6 +750,7 @@ void main() {
         expect(controller.loadedStartIndex, 61);
         expect(controller.collapsedMessages.last.id, 'final-v0');
         expect(controller.collapsedMessages.length, 40);
+        expect(controller.groupedMessages['final-group'], finalVersions);
       },
     );
 
@@ -936,6 +943,99 @@ void main() {
       ]);
       expect(controller.totalMessageCount, 102);
     });
+
+    test('atomic batch append reloads the persisted default version', () async {
+      await controller.setCurrentConversationAndLoad(conversation);
+      final user = chatService.appendPersistedMessage(_message(100));
+      final first = chatService.appendPersistedMessage(
+        ChatMessage(
+          id: 'batch-answer-a',
+          role: 'assistant',
+          content: 'answer a',
+          conversationId: conversation.id,
+          groupId: 'batch-answer-a',
+          version: 0,
+          providerId: 'provider-a',
+          modelId: 'model-a',
+        ),
+      );
+      final second = chatService.appendPersistedMessage(
+        ChatMessage(
+          id: 'batch-answer-b',
+          role: 'assistant',
+          content: 'answer b',
+          conversationId: conversation.id,
+          groupId: 'batch-answer-a',
+          version: 1,
+          providerId: 'provider-b',
+          modelId: 'model-b',
+        ),
+      );
+      chatService.versionSelections = const {'batch-answer-a': 0};
+
+      await controller.appendPersistedTailMessages([user, first, second]);
+
+      expect(controller.versionSelections['batch-answer-a'], 0);
+      expect(controller.groupedMessages['batch-answer-a'], [first, second]);
+      expect(
+        controller.collapsedMessages
+            .singleWhere(
+              (message) => (message.groupId ?? message.id) == 'batch-answer-a',
+            )
+            .id,
+        first.id,
+      );
+    });
+
+    test(
+      'terminal sibling outside the selected window requests a UI refresh',
+      () async {
+        final selected = ChatMessage(
+          id: 'answer-a',
+          role: 'assistant',
+          content: 'answer a',
+          conversationId: conversation.id,
+          groupId: 'answer-a',
+          version: 0,
+          providerId: 'provider-a',
+          modelId: 'model-a',
+        );
+        final sibling = ChatMessage(
+          id: 'answer-b',
+          role: 'assistant',
+          content: '',
+          conversationId: conversation.id,
+          groupId: 'answer-a',
+          version: 1,
+          providerId: 'provider-b',
+          modelId: 'model-b',
+          isStreaming: true,
+        );
+        messages = <ChatMessage>[selected, sibling];
+        conversation = Conversation(
+          id: conversation.id,
+          title: conversation.title,
+          messageIds: <String>[selected.id, sibling.id],
+          versionSelections: const <String, int>{'answer-a': 0},
+        );
+        chatService = _FakeLazyChatService(messages)
+          ..versionSelections = const <String, int>{'answer-a': 0};
+        controller.dispose();
+        controller = ChatController(chatService: chatService);
+        await controller.setCurrentConversationAndLoad(conversation);
+
+        expect(
+          controller.messages.any((message) => message.id == sibling.id),
+          isFalse,
+        );
+        expect(
+          controller.publishTerminalMessage(
+            sibling.copyWith(content: 'answer b', isStreaming: false),
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test(
       'mini map source includes all messages without expanding chat window',

--- a/test/features/home/controllers/message_render_model_test.dart
+++ b/test/features/home/controllers/message_render_model_test.dart
@@ -1,4 +1,5 @@
 import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/database/generation_run.dart';
 import 'package:Kelivo/features/home/controllers/message_render_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,6 +10,8 @@ void main() {
     String? groupId,
     int version = 0,
     bool streaming = false,
+    String? providerId,
+    String? modelId,
   }) => ChatMessage(
     id: id,
     role: role,
@@ -17,6 +20,8 @@ void main() {
     groupId: groupId,
     version: version,
     isStreaming: streaming,
+    providerId: providerId,
+    modelId: modelId,
   );
 
   test('projects versions, divider and latest assistant in one snapshot', () {
@@ -77,5 +82,60 @@ void main() {
     expect(models.single.versions, [selected]);
     expect(models.single.versionCount, 2);
     expect(models.single.selectedVersionIndex, 1);
+  });
+
+  test('maps sparse sibling versions to real navigation targets', () {
+    final first = message(
+      'a2',
+      'assistant',
+      groupId: 'answer',
+      version: 2,
+      providerId: 'openai',
+      modelId: 'shared-name',
+    );
+    final selected = message(
+      'a7',
+      'assistant',
+      groupId: 'answer',
+      version: 7,
+      providerId: 'google',
+      modelId: 'shared-name',
+    );
+    final last = message(
+      'a11',
+      'assistant',
+      groupId: 'answer',
+      version: 11,
+      providerId: 'openai',
+      modelId: 'other',
+    );
+
+    final models = MessageRenderModelProjector.project(
+      messages: [selected],
+      byGroup: {
+        'answer': [last, selected, first],
+      },
+      versionSelections: const {'answer': 7},
+      versionCounts: const {'answer': 3},
+      generationStates: const {
+        'a2': GenerationRunState.completed,
+        'a7': GenerationRunState.cancelled,
+        'a11': GenerationRunState.failed,
+      },
+      contextDividerIndex: -1,
+    );
+
+    final model = models.single;
+    expect(model.versions.map((item) => item.version), [2, 7, 11]);
+    expect(model.selectedVersionIndex, 1);
+    expect(model.selectedVersion, 7);
+    expect(model.previousVersion, 2);
+    expect(model.nextVersion, 11);
+    expect(model.hasMultipleModelTargets, isTrue);
+    expect(model.targetGenerationStates, {
+      'a2': GenerationRunState.completed,
+      'a7': GenerationRunState.cancelled,
+      'a11': GenerationRunState.failed,
+    });
   });
 }

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -41,6 +41,8 @@ ChatMessage _message({
   required String role,
   required String content,
   String? reasoningText,
+  String? groupId,
+  int version = 0,
 }) {
   return ChatMessage(
     id: id,
@@ -48,6 +50,8 @@ ChatMessage _message({
     content: content,
     conversationId: 'conversation-1',
     reasoningText: reasoningText,
+    groupId: groupId,
+    version: version,
   );
 }
 
@@ -93,6 +97,43 @@ void main() {
         'clip.mp4',
         'audio.wav',
       ]);
+    });
+  });
+
+  group('MessageBuilderService.collapseVersions', () {
+    test('按真实 version 选择稀疏 sibling 而不是把 version 当列表下标', () {
+      final service = MessageBuilderService(
+        chatService: _FakeChatService(const {}),
+        contextProvider: _FakeBuildContext(),
+      );
+      final version2 = _message(
+        id: 'a2',
+        role: 'assistant',
+        content: 'version 2',
+        groupId: 'answer',
+        version: 2,
+      );
+      final version7 = _message(
+        id: 'a7',
+        role: 'assistant',
+        content: 'version 7',
+        groupId: 'answer',
+        version: 7,
+      );
+      final version11 = _message(
+        id: 'a11',
+        role: 'assistant',
+        content: 'version 11',
+        groupId: 'answer',
+        version: 11,
+      );
+
+      final collapsed = service.collapseVersions(
+        [version11, version2, version7],
+        const {'answer': 7},
+      );
+
+      expect(collapsed, [version7]);
     });
   });
 

--- a/test/features/home/services/message_generation_tool_policy_test.dart
+++ b/test/features/home/services/message_generation_tool_policy_test.dart
@@ -1,0 +1,22 @@
+import 'package:Kelivo/features/home/services/message_generation_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('multi-model policy exposes search but removes side-effect tools', () {
+    Map<String, dynamic> tool(String name) => <String, dynamic>{
+      'type': 'function',
+      'function': <String, dynamic>{'name': name},
+    };
+
+    final safe = MessageGenerationService.multiModelSafeToolDefinitions([
+      tool('search_web'),
+      tool('ask_user'),
+      tool('memory_write'),
+      tool('local_shell'),
+      tool('mcp__filesystem__write_file'),
+      <String, dynamic>{'type': 'function'},
+    ]);
+
+    expect(safe, [tool('search_web')]);
+  });
+}

--- a/test/features/home/widgets/message_list_view_model_selector_test.dart
+++ b/test/features/home/widgets/message_list_view_model_selector_test.dart
@@ -1,0 +1,285 @@
+import 'package:Kelivo/core/database/generation_run.dart';
+import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/providers/assistant_provider.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/providers/tts_provider.dart';
+import 'package:Kelivo/core/providers/user_provider.dart';
+import 'package:Kelivo/features/home/controllers/message_render_model.dart';
+import 'package:Kelivo/features/home/controllers/stream_controller.dart'
+    as stream_ctrl;
+import 'package:Kelivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Kelivo/features/home/services/tool_approval_service.dart';
+import 'package:Kelivo/features/home/widgets/message_list_view.dart';
+import 'package:Kelivo/icons/lucide_adapter.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:Kelivo/shared/widgets/ios_tactile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
+
+ChatMessage _assistant({
+  required String id,
+  required String groupId,
+  required int version,
+  required String providerId,
+  required String modelId,
+  required String content,
+}) {
+  return ChatMessage(
+    id: id,
+    role: 'assistant',
+    content: content,
+    conversationId: 'conversation-1',
+    groupId: groupId,
+    version: version,
+    providerId: providerId,
+    modelId: modelId,
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets(
+    'multi-target group shows horizontal model buttons with real sparse versions and statuses',
+    (tester) async {
+      final selected = _assistant(
+        id: 'answer-v2',
+        groupId: 'answer',
+        version: 2,
+        providerId: 'provider-a',
+        modelId: 'shared-model',
+        content: 'selected answer',
+      );
+      final failed = _assistant(
+        id: 'answer-v7',
+        groupId: 'answer',
+        version: 7,
+        providerId: 'provider-b',
+        modelId: 'shared-model',
+        content: 'partial failed answer',
+      );
+      final cancelled = _assistant(
+        id: 'answer-v11',
+        groupId: 'answer',
+        version: 11,
+        providerId: 'provider-c',
+        modelId: 'other-model',
+        content: 'partial cancelled answer',
+      );
+      final byGroup = <String, List<ChatMessage>>{
+        'answer': [cancelled, selected, failed],
+      };
+      final renderModels = MessageRenderModelProjector.project(
+        messages: [selected],
+        byGroup: byGroup,
+        versionSelections: const {'answer': 2},
+        generationStates: const {
+          'answer-v7': GenerationRunState.failed,
+          'answer-v11': GenerationRunState.cancelled,
+        },
+        contextDividerIndex: -1,
+      );
+      final versionChanges = <(String, int)>[];
+
+      await tester.pumpWidget(
+        _MessageListHarness(
+          messages: [selected],
+          byGroup: byGroup,
+          versionSelections: const {'answer': 2},
+          renderModels: renderModels,
+          onVersionChange: (groupId, version) async {
+            versionChanges.add((groupId, version));
+          },
+        ),
+      );
+      await tester.pump();
+
+      final selector = find.byKey(
+        const ValueKey<String>('model-answer-selector:answer'),
+      );
+      expect(selector, findsOneWidget);
+      expect(
+        tester.widget<SingleChildScrollView>(selector).scrollDirection,
+        Axis.horizontal,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('model-answer:2')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('model-answer:7')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('model-answer:11')),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Failed')), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Cancelled')), findsOneWidget);
+      expect(find.text('1/3'), findsNothing);
+
+      tester
+          .widget<InkWell>(find.byKey(const ValueKey<String>('model-answer:7')))
+          .onTap
+          ?.call();
+      await tester.pump();
+
+      expect(versionChanges, [('answer', 7)]);
+    },
+  );
+
+  testWidgets(
+    'same-target revisions keep legacy arrows and omit model selector',
+    (tester) async {
+      final selected = _assistant(
+        id: 'answer-v2',
+        groupId: 'answer',
+        version: 2,
+        providerId: 'provider-a',
+        modelId: 'same-model',
+        content: 'first answer',
+      );
+      final next = _assistant(
+        id: 'answer-v7',
+        groupId: 'answer',
+        version: 7,
+        providerId: 'provider-a',
+        modelId: 'same-model',
+        content: 'second answer',
+      );
+      final byGroup = <String, List<ChatMessage>>{
+        'answer': [next, selected],
+      };
+      final renderModels = MessageRenderModelProjector.project(
+        messages: [selected],
+        byGroup: byGroup,
+        versionSelections: const {'answer': 2},
+        contextDividerIndex: -1,
+      );
+      final versionChanges = <(String, int)>[];
+
+      await tester.pumpWidget(
+        _MessageListHarness(
+          messages: [selected],
+          byGroup: byGroup,
+          versionSelections: const {'answer': 2},
+          renderModels: renderModels,
+          onVersionChange: (groupId, version) async {
+            versionChanges.add((groupId, version));
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey<String>('model-answer-selector:answer')),
+        findsNothing,
+      );
+      expect(find.text('1/2'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is IosIconButton && widget.icon == Lucide.ChevronLeft,
+        ),
+        findsOneWidget,
+      );
+      final nextButton = find.byWidgetPredicate(
+        (widget) =>
+            widget is IosIconButton && widget.icon == Lucide.ChevronRight,
+      );
+      expect(nextButton, findsOneWidget);
+
+      tester.widget<IosIconButton>(nextButton).onTap?.call();
+      await tester.pump();
+
+      expect(versionChanges, [('answer', 7)]);
+    },
+  );
+}
+
+class _MessageListHarness extends StatefulWidget {
+  const _MessageListHarness({
+    required this.messages,
+    required this.byGroup,
+    required this.versionSelections,
+    required this.renderModels,
+    required this.onVersionChange,
+  });
+
+  final List<ChatMessage> messages;
+  final Map<String, List<ChatMessage>> byGroup;
+  final Map<String, int> versionSelections;
+  final List<MessageRenderModel> renderModels;
+  final OnVersionChange onVersionChange;
+
+  @override
+  State<_MessageListHarness> createState() => _MessageListHarnessState();
+}
+
+class _MessageListHarnessState extends State<_MessageListHarness> {
+  late final ScrollController scrollController;
+  late final ListController listController;
+  late final ValueNotifier<bool> isProcessingFiles;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollController = ScrollController();
+    listController = ListController();
+    isProcessingFiles = ValueNotifier<bool>(false);
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    listController.dispose();
+    isProcessingFiles.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => SettingsProvider()),
+        ChangeNotifierProvider(create: (_) => AssistantProvider()),
+        ChangeNotifierProvider(create: (_) => UserProvider()),
+        ChangeNotifierProvider(create: (_) => TtsProvider()),
+        ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+        ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MessageListView(
+            scrollController: scrollController,
+            listController: listController,
+            messages: widget.messages,
+            renderModels: widget.renderModels,
+            byGroup: widget.byGroup,
+            versionSelections: widget.versionSelections,
+            reasoning: const <String, stream_ctrl.ReasoningData>{},
+            reasoningSegments:
+                const <String, List<stream_ctrl.ReasoningSegmentData>>{},
+            contentSplits: const <String, stream_ctrl.ContentSplitData>{},
+            toolParts: const {},
+            translations: const {},
+            selecting: false,
+            selectedItems: const {},
+            dividerPadding: EdgeInsets.zero,
+            isProcessingFiles: isProcessingFiles,
+            onVersionChange: widget.onVersionChange,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/model/widgets/model_select_sheet_test.dart
+++ b/test/features/model/widgets/model_select_sheet_test.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:Kelivo/core/models/chat_model_target.dart';
 import 'package:Kelivo/core/providers/assistant_provider.dart';
 import 'package:Kelivo/core/providers/settings_provider.dart';
 import 'package:Kelivo/features/model/widgets/model_select_sheet.dart';
@@ -88,6 +89,7 @@ Future<void> _pumpModelSelector(
   String? limitProviderKey,
   String? initialProviderKey,
   String? initialModelId,
+  ValueChanged<ModelSelection?>? onResult,
 }) async {
   await tester.pumpWidget(
     MultiProvider(
@@ -105,13 +107,14 @@ Future<void> _pumpModelSelector(
             builder: (context) {
               return TextButton(
                 key: const ValueKey('open-model-selector'),
-                onPressed: () {
-                  showModelSelector(
+                onPressed: () async {
+                  final result = await showModelSelector(
                     context,
                     limitProviderKey: limitProviderKey,
                     initialProviderKey: initialProviderKey,
                     initialModelId: initialModelId,
                   );
+                  onResult?.call(result);
                 },
                 child: const Text('open'),
               );
@@ -129,6 +132,63 @@ Future<void> _pumpModelSelector(
     await Future<void>.delayed(const Duration(milliseconds: 500));
   });
   await tester.pump(const Duration(milliseconds: 500));
+}
+
+Future<void> _pumpChatModelSelector(
+  WidgetTester tester, {
+  required SettingsProvider settings,
+  List<ChatModelTarget> initialTargets = const <ChatModelTarget>[],
+  ValueChanged<ChatModelSelectionResult?>? onResult,
+}) async {
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+        ChangeNotifierProvider<AssistantProvider>(
+          create: (_) => AssistantProvider(),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return TextButton(
+                key: const ValueKey('open-chat-model-selector'),
+                onPressed: () async {
+                  final result = await showChatModelSelector(
+                    context,
+                    initialTargets: initialTargets,
+                  );
+                  onResult?.call(result);
+                },
+                child: const Text('open chat'),
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.byKey(const ValueKey('open-chat-model-selector')));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 500));
+  await tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+  });
+  await tester.pump(const Duration(milliseconds: 500));
+}
+
+Future<void> _tapModel(WidgetTester tester, String modelId) async {
+  final tile = find.ancestor(
+    of: find.text(modelId),
+    matching: find.byType(IosCardPress),
+  );
+  expect(tile, findsOneWidget);
+  tester.widget<IosCardPress>(tile).onTap?.call();
+  await tester.pump();
 }
 
 bool _providerTabSelected(WidgetTester tester, String providerKey) {
@@ -163,6 +223,224 @@ Future<void> _dismissModelSelector(WidgetTester tester) async {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'normal selector keeps immediate single-select result and omits @ mode',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      ModelSelection? result;
+      try {
+        final settings = await _settingsWithOnlyTestProviders(tester);
+        await _pumpModelSelector(
+          tester,
+          settings: settings,
+          onResult: (selection) => result = selection,
+        );
+
+        expect(find.byKey(const ValueKey('model-multi-toggle')), findsNothing);
+        await _tapModel(tester, 'provider-0-model-01');
+        await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+        expect(result?.providerKey, 'provider-0');
+        expect(result?.modelId, 'provider-0-model-01');
+      } finally {
+        await _dismissModelSelector(tester);
+        debugDefaultTargetPlatformOverride = null;
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 20)),
+  );
+
+  testWidgets(
+    'chat selector confirms two targets in click order from @ mode',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      ChatModelSelectionResult? result;
+      try {
+        final settings = await _settingsWithOnlyTestProviders(tester);
+        await _pumpChatModelSelector(
+          tester,
+          settings: settings,
+          onResult: (selection) => result = selection,
+        );
+
+        final toggle = find.byKey(const ValueKey('model-multi-toggle'));
+        expect(toggle, findsOneWidget);
+        await tester.tap(toggle);
+        await tester.pump();
+
+        final done = find.byKey(const ValueKey('model-multi-done'));
+        expect(tester.widget<FilledButton>(done).onPressed, isNull);
+
+        await _tapModel(tester, 'provider-0-model-02');
+        await _tapModel(tester, 'provider-0-model-00');
+
+        expect(
+          tester
+              .widget<Checkbox>(
+                find.byKey(
+                  const ValueKey(
+                    'model-multi-checkbox:provider-0::provider-0-model-02',
+                  ),
+                ),
+              )
+              .value,
+          isTrue,
+        );
+        expect(tester.widget<FilledButton>(done).onPressed, isNotNull);
+        expect(find.textContaining('2/5'), findsOneWidget);
+
+        await tester.tap(done);
+        await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+        expect(result?.isMultiModel, isTrue);
+        expect(
+          result?.targets
+              .map((target) => '${target.providerKey}::${target.modelId}')
+              .toList(),
+          [
+            'provider-0::provider-0-model-02',
+            'provider-0::provider-0-model-00',
+          ],
+        );
+      } finally {
+        await _dismissModelSelector(tester);
+        debugDefaultTargetPlatformOverride = null;
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 20)),
+  );
+
+  testWidgets(
+    'chat selector cancel discards unconfirmed multi-model edits',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      ChatModelSelectionResult? result;
+      try {
+        final settings = await _settingsWithOnlyTestProviders(tester);
+        await _pumpChatModelSelector(
+          tester,
+          settings: settings,
+          onResult: (selection) => result = selection,
+        );
+
+        final toggle = find.byKey(const ValueKey('model-multi-toggle'));
+        await tester.tap(toggle);
+        await tester.pump();
+        await _tapModel(tester, 'provider-0-model-01');
+        await _tapModel(tester, 'provider-0-model-03');
+
+        await tester.tap(find.byKey(const ValueKey('model-multi-cancel')));
+        await tester.pump();
+
+        expect(result, isNull);
+        expect(find.byKey(const ValueKey('model-multi-done')), findsNothing);
+
+        await tester.tap(toggle);
+        await tester.pump();
+        for (final modelId in ['provider-0-model-01', 'provider-0-model-03']) {
+          expect(
+            tester
+                .widget<Checkbox>(
+                  find.byKey(
+                    ValueKey('model-multi-checkbox:provider-0::$modelId'),
+                  ),
+                )
+                .value,
+            isFalse,
+          );
+        }
+        expect(
+          tester
+              .widget<FilledButton>(
+                find.byKey(const ValueKey('model-multi-done')),
+              )
+              .onPressed,
+          isNull,
+        );
+      } finally {
+        await _dismissModelSelector(tester);
+        debugDefaultTargetPlatformOverride = null;
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 20)),
+  );
+
+  testWidgets(
+    'chat selector enforces the five-target limit',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      ChatModelSelectionResult? result;
+      final initialTargets = <ChatModelTarget>[
+        for (var index = 0; index < 4; index++)
+          ChatModelTarget(
+            providerKey: 'provider-0',
+            modelId: 'provider-0-model-${index.toString().padLeft(2, '0')}',
+          ),
+        const ChatModelTarget(
+          providerKey: 'provider-1',
+          modelId: 'provider-1-model-00',
+        ),
+      ];
+      try {
+        final settings = await _settingsWithOnlyTestProviders(tester);
+        await _pumpChatModelSelector(
+          tester,
+          settings: settings,
+          initialTargets: initialTargets,
+          onResult: (selection) => result = selection,
+        );
+
+        await tester.tap(find.byKey(const ValueKey('model-multi-toggle')));
+        await tester.pump();
+        expect(find.textContaining('5/5'), findsOneWidget);
+
+        await tester.enterText(find.byType(TextField), 'provider-1-model-01');
+        await tester.pump();
+        await _tapModel(tester, 'provider-1-model-01');
+
+        expect(
+          tester
+              .widget<Checkbox>(
+                find.byKey(
+                  const ValueKey(
+                    'model-multi-checkbox:provider-1::provider-1-model-01',
+                  ),
+                ),
+              )
+              .value,
+          isFalse,
+        );
+        expect(find.textContaining('5/5'), findsOneWidget);
+
+        await tester.tap(find.byKey(const ValueKey('model-multi-done')));
+        await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+        expect(result?.isMultiModel, isTrue);
+        expect(result?.targets, initialTargets);
+      } finally {
+        await _dismissModelSelector(tester);
+        debugDefaultTargetPlatformOverride = null;
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 20)),
+  );
 
   testWidgets(
     'mobile model selector uses explicit initial model over global current model',

--- a/test/features/settings/pages/display_settings_page_test.dart
+++ b/test/features/settings/pages/display_settings_page_test.dart
@@ -1,4 +1,6 @@
 import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/providers/chat_model_selection_provider.dart';
+import 'package:Kelivo/core/models/chat_model_target.dart';
 import 'package:Kelivo/features/settings/pages/display_settings_page.dart';
 import 'package:Kelivo/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -45,5 +47,48 @@ void main() {
     expect(find.text('Light'), findsOneWidget);
     expect(find.text('Dark'), findsOneWidget);
     expect(find.byType(SfSlider), findsNWidgets(2));
+  });
+
+  testWidgets('behavior page exposes multi-model scope as its first setting', (
+    tester,
+  ) async {
+    final preferences = await SharedPreferences.getInstance();
+    final settings = SettingsProvider();
+    final selection = ChatModelSelectionProvider(preferences: preferences);
+    addTearDown(settings.dispose);
+    addTearDown(selection.dispose);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+          ChangeNotifierProvider<ChatModelSelectionProvider>.value(
+            value: selection,
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: BehaviorStartupSettingsPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Multi-model selection applies to'), findsOneWidget);
+    expect(find.text('Current conversation'), findsOneWidget);
+
+    await tester.tap(find.text('Multi-model selection applies to'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Keep separate model combinations for each scope'),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Next message only'));
+    await tester.pumpAndSettle();
+
+    expect(selection.scope, MultiModelSelectionScope.nextMessage);
+    expect(find.text('Next message only'), findsOneWidget);
   });
 }

--- a/test/settings_provider_delete_models_test.dart
+++ b/test/settings_provider_delete_models_test.dart
@@ -86,6 +86,27 @@ void main() {
     });
 
     test(
+      'single-model deletion notifies selection lifecycle cleanup',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final settings = SettingsProvider();
+        final deleted = <({String providerKey, Set<String> modelIds})>[];
+        settings.setModelSelectionLifecycleCallbacks(
+          onModelsDeleted: (providerKey, modelIds) async {
+            deleted.add((providerKey: providerKey, modelIds: modelIds));
+          },
+        );
+
+        await _waitForSettingsLoad();
+        await settings.clearSelectionsForModel('TestProvider', 'remove-a');
+
+        expect(deleted, hasLength(1));
+        expect(deleted.single.providerKey, 'TestProvider');
+        expect(deleted.single.modelIds, const <String>{'remove-a'});
+      },
+    );
+
+    test(
       'deleteModels clears orphan overrides when every model is removed',
       () async {
         SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## Summary

- add a chat-only `@` multi-model picker with ordered 2–5 model selection and assistant, conversation, or next-message scopes
- place the scope control first under Preferences → Behavior & startup on desktop and mobile
- create each user turn and all assistant placeholders / GenerationRuns atomically without changing Drift schema 11
- run model branches independently, isolate streaming and cancellation state, and keep the batch loading state until every branch is terminal
- render horizontally scrollable model answer buttons with persisted selection, generation status, sparse-version correctness, and selected-answer context for the next turn
- regenerate the displayed answer with that reply's persisted provider/model, regardless of the current picker selection
- restrict multi-model generations to text, reasoning, attachments, and web search while excluding MCP, local tools, memory writes, `ask_user`, and image-generation routing
- persist, prune, delete, restore, and remap multi-model selections across conversation, assistant, provider, and backup lifecycles

## User impact

Users can compare several model answers in one turn, switch the visible answer while generation is in progress, and choose exactly which answer becomes context for the next message. Clicking regenerate on an answer retries the model shown on that answer; legacy messages without a complete provider/model pair fall back to the current configuration.

## Implementation notes

- reuses `groupId`, real sparse `version` values, `versionSelections`, and `GenerationRun`
- keeps one user message per turn and stores model answers as sibling assistant versions
- resolves regeneration and tool-answer continuation from the reply's complete persisted provider/model pair before consulting the current model
- no database schema or wire-format migration
- the feature commit is based directly on upstream `master`; GPT-5.6 reasoning changes are not included

## Validation

- `dart analyze --fatal-infos lib test` — passed
- `flutter test --no-pub test/features/home/controllers/chat_actions_regeneration_context_test.dart` — 11 passed
- `flutter test --no-pub test/features/settings/pages/display_settings_page_test.dart` — 2 passed
- focused multi-model Flutter tests — 76 passed
- full `flutter test` baseline — 1297 tests executed; 4 unrelated Windows environment failures remained:
  - two Cherry importer temp-directory cleanup failures caused by locked files
  - restore business lease subprocess could not resolve `dart`
  - local font test expected `/` while Windows returned `\\`
