### PR TITLE
feat: quote selected chat text on desktop

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -679,6 +679,7 @@ class ChatMessageWidget extends StatefulWidget {
   final VoidCallback? onRegenerate;
   final VoidCallback? onResend;
   final VoidCallback? onCopy;
+  final ValueChanged<String>? onQuoteSelection;
   final VoidCallback? onTranslate;
   final VoidCallback? onSpeak;
   final VoidCallback? onMore;
@@ -730,6 +731,7 @@ class ChatMessageWidget extends StatefulWidget {
     this.onRegenerate,
     this.onResend,
     this.onCopy,
+    this.onQuoteSelection,
     this.onTranslate,
     this.onSpeak,
     this.onMore,
@@ -774,6 +776,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
   // User message context menu state
   final GlobalKey _userBubbleKey = GlobalKey();
   OverlayEntry? _userMenuOverlay;
+  String? _selectedQuoteText;
   // Desktop anchored menus for bottom action buttons
   final GlobalKey _moreBtnKey1 = GlobalKey();
   final GlobalKey _moreBtnKey2 = GlobalKey();
@@ -1364,14 +1367,16 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
               if (isDesktop) return; // Desktop uses right-click menu
               _showUserContextMenu();
             },
-            onSecondaryTapDown: (details) {
-              final isDesktop =
-                  defaultTargetPlatform == TargetPlatform.macOS ||
-                  defaultTargetPlatform == TargetPlatform.windows ||
-                  defaultTargetPlatform == TargetPlatform.linux;
-              if (!isDesktop) return; // Mobile keeps long-press
-              _showUserContextMenuAt(details.globalPosition);
-            },
+            onSecondaryTapDown: _canQuoteSelection
+                ? null
+                : (details) {
+                    final isDesktop =
+                        defaultTargetPlatform == TargetPlatform.macOS ||
+                        defaultTargetPlatform == TargetPlatform.windows ||
+                        defaultTargetPlatform == TargetPlatform.linux;
+                    if (!isDesktop) return; // Mobile keeps long-press
+                    _showUserContextMenuAt(details.globalPosition);
+                  },
             behavior: HitTestBehavior.translucent,
             child: Container(
               key: _userBubbleKey,
@@ -1580,6 +1585,51 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     } catch (_) {}
   }
 
+  bool get _canQuoteSelection {
+    final isDesktop =
+        defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux;
+    return isDesktop &&
+        widget.onQuoteSelection != null &&
+        !widget.message.isStreaming;
+  }
+
+  Widget _buildSelectableMessageText({
+    required Key key,
+    required Widget child,
+  }) {
+    if (!_canQuoteSelection) {
+      return SelectionArea(key: key, child: child);
+    }
+
+    return SelectionArea(
+      key: key,
+      onSelectionChanged: (selection) {
+        _selectedQuoteText = selection?.plainText;
+      },
+      contextMenuBuilder: (context, selectableRegionState) {
+        return AdaptiveTextSelectionToolbar.buttonItems(
+          anchors: selectableRegionState.contextMenuAnchors,
+          buttonItems: <ContextMenuButtonItem>[
+            ContextMenuButtonItem(
+              label: AppLocalizations.of(context)!.chatMessageWidgetQuote,
+              onPressed: () {
+                final selectedText = _selectedQuoteText;
+                if (selectedText == null || selectedText.trim().isEmpty) return;
+                ContextMenuController.removeAny();
+                selectableRegionState.clearSelection();
+                widget.onQuoteSelection?.call(selectedText);
+              },
+            ),
+            ...selectableRegionState.contextMenuButtonItems,
+          ],
+        );
+      },
+      child: child,
+    );
+  }
+
   Widget _buildUserTextContent(
     BuildContext context,
     String visualText,
@@ -1609,7 +1659,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     }
 
     return isDesktop
-        ? SelectionArea(
+        ? _buildSelectableMessageText(
             key: ValueKey('user_${widget.message.id}'),
             child: content,
           )
@@ -1904,7 +1954,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     );
 
     return RepaintBoundary(
-      child: SelectionArea(
+      child: _buildSelectableMessageText(
         key: ValueKey('assistant_${widget.message.id}'),
         child: DefaultTextStyle.merge(
           style: TextStyle(fontSize: baseAssistant, height: 1.5),
@@ -2378,7 +2428,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
                           Padding(
                             padding: const EdgeInsets.fromLTRB(8, 2, 8, 6),
                             child: RepaintBoundary(
-                              child: SelectionArea(
+                              child: _buildSelectableMessageText(
                                 key: ValueKey(
                                   'translation_${widget.message.id}',
                                 ),

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -41,6 +41,7 @@ import '../services/ocr_service.dart';
 import '../services/translation_service.dart';
 import '../services/file_upload_service.dart';
 import '../widgets/chat_input_bar.dart';
+import '../utils/quoted_selection_formatter.dart';
 import '../../model/widgets/model_select_sheet.dart';
 
 enum ChatSelectionMode { share, delete }
@@ -709,6 +710,21 @@ class HomePageController extends ChangeNotifier {
       return;
     }
     await sendMessage(ChatInputData(text: text));
+  }
+
+  void insertQuotedSelection(String selectedText) {
+    if (_userMessageEditState != null || currentQueuedInput != null) return;
+    final current = _inputController.value;
+    final next = insertQuotedSelectionIntoDraft(current, selectedText);
+    if (next == current) return;
+
+    _inputController.value = next;
+    notifyListeners();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_context.mounted) return;
+      forceScrollToBottomSoon(animate: false);
+      _inputFocus.requestFocus();
+    });
   }
 
   void _replaceInputWithSuggestion(String text) {

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1181,6 +1181,11 @@ class _HomePageState extends State<HomePage>
               mode: ChatSelectionMode.delete,
             ),
         onSpeakMessage: (message) => _controller.speakMessage(message),
+        onQuoteSelection:
+            _controller.isUserMessageEditActive ||
+                _controller.currentQueuedInput != null
+            ? null
+            : _controller.insertQuotedSelection,
         onSuggestionTap: (suggestion) => _controller.sendSuggestion(suggestion),
         onRecoveredAskUserAnswer: (message, part, result) =>
             _controller.submitRecoveredAskUserAnswer(message, part, result),

--- a/lib/features/home/utils/quoted_selection_formatter.dart
+++ b/lib/features/home/utils/quoted_selection_formatter.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/services.dart';
+
+/// Inserts selected message text into a chat draft as a Markdown blockquote.
+TextEditingValue insertQuotedSelectionIntoDraft(
+  TextEditingValue current,
+  String selectedText,
+) {
+  var normalizedSelection = selectedText
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\r', '\n');
+  if (normalizedSelection.trim().isEmpty) return current;
+  normalizedSelection = normalizedSelection
+      .replaceFirst(RegExp(r'^(?:[ \t]*\n)+'), '')
+      .replaceFirst(RegExp(r'(?:\n[ \t]*)+$'), '');
+
+  final quote = normalizedSelection
+      .split('\n')
+      .map((line) => line.isEmpty ? '>' : '> $line')
+      .join('\n');
+  final selection = current.selection;
+  final hasValidSelection =
+      selection.isValid &&
+      selection.start >= 0 &&
+      selection.end >= selection.start &&
+      selection.end <= current.text.length;
+  final start = hasValidSelection ? selection.start : current.text.length;
+  final end = hasValidSelection ? selection.end : current.text.length;
+  final prefix = current.text.substring(0, start);
+  var suffix = current.text.substring(end);
+
+  final leading = prefix.isEmpty
+      ? ''
+      : prefix.endsWith('\n\n')
+      ? ''
+      : prefix.endsWith('\n')
+      ? '\n'
+      : '\n\n';
+  suffix = suffix.replaceFirst(RegExp(r'^\n{1,2}'), '');
+  final inserted = '$leading$quote\n\n';
+  final nextText = '$prefix$inserted$suffix';
+  final caretOffset = prefix.length + inserted.length;
+
+  return TextEditingValue(
+    text: nextText,
+    selection: TextSelection.collapsed(offset: caretOffset),
+    composing: TextRange.empty,
+  );
+}

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -121,6 +121,7 @@ class MessageListView extends StatefulWidget {
     this.onShareMessage,
     this.onSelectMessages,
     this.onSpeakMessage,
+    this.onQuoteSelection,
     this.suggestions = const <String>[],
     this.onSuggestionTap,
     this.onRecoveredAskUserAnswer,
@@ -197,6 +198,7 @@ class MessageListView extends StatefulWidget {
   final OnShareMessage? onShareMessage;
   final OnSelectMessages? onSelectMessages;
   final OnSpeakMessage? onSpeakMessage;
+  final ValueChanged<String>? onQuoteSelection;
   final List<String> suggestions;
   final OnSuggestionTap? onSuggestionTap;
   final OnRecoveredAskUserAnswer? onRecoveredAskUserAnswer;
@@ -1082,6 +1084,9 @@ class _MessageListViewState extends State<MessageListView> {
           : null,
       onTranslate: message.role == 'assistant'
           ? () => widget.onTranslateMessage?.call(message)
+          : null,
+      onQuoteSelection: (message.role == 'assistant' || message.role == 'user')
+          ? widget.onQuoteSelection
           : null,
       onSpeak: message.role == 'assistant'
           ? () => widget.onSpeakMessage?.call(message)

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -859,6 +859,7 @@
     }
   },
   "chatMessageWidgetCopiedToClipboard": "Copied to clipboard",
+  "chatMessageWidgetQuote": "Quote",
   "chatMessageWidgetResendTooltip": "Resend",
   "chatMessageWidgetMoreTooltip": "More",
   "chatMessageWidgetThinking": "Thinking...",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4031,6 +4031,12 @@ abstract class AppLocalizations {
   /// **'Copied to clipboard'**
   String get chatMessageWidgetCopiedToClipboard;
 
+  /// No description provided for @chatMessageWidgetQuote.
+  ///
+  /// In en, this message translates to:
+  /// **'Quote'**
+  String get chatMessageWidgetQuote;
+
   /// No description provided for @chatMessageWidgetResendTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2118,6 +2118,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatMessageWidgetCopiedToClipboard => 'Copied to clipboard';
 
   @override
+  String get chatMessageWidgetQuote => 'Quote';
+
+  @override
   String get chatMessageWidgetResendTooltip => 'Resend';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2046,6 +2046,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chatMessageWidgetCopiedToClipboard => '已复制到剪贴板';
 
   @override
+  String get chatMessageWidgetQuote => '引用';
+
+  @override
   String get chatMessageWidgetResendTooltip => '重新发送';
 
   @override
@@ -7581,6 +7584,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get chatMessageWidgetCopiedToClipboard => '已复制到剪贴板';
 
   @override
+  String get chatMessageWidgetQuote => '引用';
+
+  @override
   String get chatMessageWidgetResendTooltip => '重新发送';
 
   @override
@@ -13113,6 +13119,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get chatMessageWidgetCopiedToClipboard => '已複製到剪貼簿';
+
+  @override
+  String get chatMessageWidgetQuote => '引用';
 
   @override
   String get chatMessageWidgetResendTooltip => '重新傳送';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -706,6 +706,7 @@
   "chatMessageWidgetCannotOpenFile": "无法打开文件: {message}",
   "chatMessageWidgetOpenFileError": "打开文件失败: {error}",
   "chatMessageWidgetCopiedToClipboard": "已复制到剪贴板",
+  "chatMessageWidgetQuote": "引用",
   "chatMessageWidgetResendTooltip": "重新发送",
   "chatMessageWidgetMoreTooltip": "更多",
   "chatMessageWidgetThinking": "正在思考...",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -751,6 +751,7 @@
   "chatMessageWidgetCannotOpenFile": "无法打开文件: {message}",
   "chatMessageWidgetOpenFileError": "打开文件失败: {error}",
   "chatMessageWidgetCopiedToClipboard": "已复制到剪贴板",
+  "chatMessageWidgetQuote": "引用",
   "chatMessageWidgetResendTooltip": "重新发送",
   "chatMessageWidgetMoreTooltip": "更多",
   "chatMessageWidgetThinking": "正在思考...",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -709,6 +709,7 @@
   "chatMessageWidgetCannotOpenFile": "無法開啟檔案: {message}",
   "chatMessageWidgetOpenFileError": "開啟檔案失敗: {error}",
   "chatMessageWidgetCopiedToClipboard": "已複製到剪貼簿",
+  "chatMessageWidgetQuote": "引用",
   "chatMessageWidgetResendTooltip": "重新傳送",
   "chatMessageWidgetMoreTooltip": "更多",
   "chatMessageWidgetThinking": "正在思考...",

--- a/test/features/chat/widgets/chat_message_widget_quote_selection_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_quote_selection_test.dart
@@ -1,0 +1,114 @@
+import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/providers/tts_provider.dart';
+import 'package:Kelivo/core/providers/user_provider.dart';
+import 'package:Kelivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  for (final role in <String>['user', 'assistant']) {
+    testWidgets('desktop $role message selection exposes Quote action', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      try {
+        final quoted = <String>[];
+        final message = ChatMessage(
+          id: '$role-message',
+          role: role,
+          content: '$role selected text',
+          conversationId: 'conversation-1',
+        );
+
+        await tester.pumpWidget(
+          _buildHarness(
+            child: ChatMessageWidget(
+              message: message,
+              showModelIcon: false,
+              showUserAvatar: false,
+              showTokenStats: false,
+              onQuoteSelection: quoted.add,
+            ),
+          ),
+        );
+
+        final areaFinder = find.byKey(ValueKey('${role}_${message.id}'));
+        expect(areaFinder, findsOneWidget);
+        final area = tester.widget<SelectionArea>(areaFinder);
+        final areaState = tester.state<SelectionAreaState>(areaFinder);
+        areaState.selectableRegion.selectAll();
+        await tester.pump();
+
+        final toolbar = area.contextMenuBuilder!(
+          tester.element(areaFinder),
+          areaState.selectableRegion,
+        );
+        expect(toolbar, isA<AdaptiveTextSelectionToolbar>());
+        final buttons = (toolbar as AdaptiveTextSelectionToolbar).buttonItems!;
+        final quoteButton = buttons.singleWhere(
+          (item) => item.label == 'Quote',
+        );
+        quoteButton.onPressed!();
+        await tester.pump();
+
+        expect(quoted, <String>['$role selected text']);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  }
+
+  testWidgets('mobile assistant selection keeps the default context menu', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(
+        _buildHarness(
+          child: ChatMessageWidget(
+            message: ChatMessage(
+              id: 'assistant-mobile',
+              role: 'assistant',
+              content: 'mobile answer',
+              conversationId: 'conversation-1',
+            ),
+            showModelIcon: false,
+            showTokenStats: false,
+            onQuoteSelection: (_) {},
+          ),
+        ),
+      );
+
+      final area = tester.widget<SelectionArea>(
+        find.byKey(const ValueKey('assistant_assistant-mobile')),
+      );
+      expect(area.onSelectionChanged, isNull);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}
+
+Widget _buildHarness({required Widget child}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (_) => SettingsProvider()),
+      ChangeNotifierProvider(create: (_) => TtsProvider()),
+      ChangeNotifierProvider(create: (_) => UserProvider()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}

--- a/test/features/home/controllers/home_page_controller_startup_test.dart
+++ b/test/features/home/controllers/home_page_controller_startup_test.dart
@@ -10,6 +10,42 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 void main() {
+  testWidgets('inserts a selected message quote into the current draft', (
+    tester,
+  ) async {
+    HomePageController? controller;
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => SettingsProvider()),
+          ChangeNotifierProvider(create: (_) => ChatService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: _ControllerHarness(onCreated: (value) => controller = value),
+        ),
+      ),
+    );
+
+    controller!.inputController.value = const TextEditingValue(
+      text: 'Follow up',
+      selection: TextSelection.collapsed(offset: 9),
+    );
+    controller!.insertQuotedSelection('first line\nsecond line');
+
+    expect(
+      controller!.inputController.text,
+      'Follow up\n\n> first line\n> second line\n\n',
+    );
+    expect(
+      controller!.inputController.selection.baseOffset,
+      controller!.inputController.text.length,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets('initializes chat controller before timeline scroll callbacks', (
     tester,
   ) async {

--- a/test/features/home/utils/quoted_selection_formatter_test.dart
+++ b/test/features/home/utils/quoted_selection_formatter_test.dart
@@ -1,0 +1,75 @@
+import 'package:Kelivo/features/home/utils/quoted_selection_formatter.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('insertQuotedSelectionIntoDraft', () {
+    test('inserts a multiline Markdown quote into an empty draft', () {
+      final result = insertQuotedSelectionIntoDraft(
+        const TextEditingValue(),
+        'first line\r\nsecond line',
+      );
+
+      expect(result.text, '> first line\n> second line\n\n');
+      expect(
+        result.selection,
+        TextSelection.collapsed(offset: result.text.length),
+      );
+      expect(result.composing, TextRange.empty);
+    });
+
+    test('inserts at the caret without overwriting existing text', () {
+      final result = insertQuotedSelectionIntoDraft(
+        const TextEditingValue(
+          text: 'beforeafter',
+          selection: TextSelection.collapsed(offset: 6),
+        ),
+        'selected',
+      );
+
+      expect(result.text, 'before\n\n> selected\n\nafter');
+      expect(result.selection.baseOffset, 'before\n\n> selected\n\n'.length);
+    });
+
+    test('replaces the current draft selection', () {
+      final result = insertQuotedSelectionIntoDraft(
+        const TextEditingValue(
+          text: 'ask about this please',
+          selection: TextSelection(baseOffset: 4, extentOffset: 14),
+        ),
+        'A\n\nB',
+      );
+
+      expect(result.text, 'ask \n\n> A\n>\n> B\n\n please');
+      expect(result.selection.baseOffset, 'ask \n\n> A\n>\n> B\n\n'.length);
+    });
+
+    test('preserves meaningful indentation in the selected text', () {
+      final result = insertQuotedSelectionIntoDraft(
+        const TextEditingValue(),
+        '\n  indented\n    child\n',
+      );
+
+      expect(result.text, '>   indented\n>     child\n\n');
+    });
+
+    test('uses the end of the draft when the selection is invalid', () {
+      final result = insertQuotedSelectionIntoDraft(
+        const TextEditingValue(text: 'question'),
+        'answer',
+      );
+
+      expect(result.text, 'question\n\n> answer\n\n');
+      expect(result.selection.baseOffset, result.text.length);
+    });
+
+    test('ignores whitespace-only selected text', () {
+      const current = TextEditingValue(
+        text: 'draft',
+        selection: TextSelection.collapsed(offset: 2),
+      );
+
+      expect(insertQuotedSelectionIntoDraft(current, ' \r\n '), current);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- add a desktop selection toolbar action for quoting selected chat text
- format selected text as a Markdown quote and insert it into the composer
- add localized labels and focused widget/controller/formatter coverage

## Testing

- `git diff --check origin/master...feat/desktop-message-quote`
- Flutter tests not run because `flutter` is unavailable in the current environment
