### PR TITLE
Add Atlas Cloud provider preset

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -61,6 +61,7 @@ class SettingsProvider extends ChangeNotifier {
     'SiliconFlow',
     'Gemini',
     'OpenRouter',
+    'Atlas Cloud',
     'KelivoIN',
     'Tensdaq',
     'DeepSeek',
@@ -4648,6 +4649,9 @@ class ProviderConfig {
     if (k.contains('tensdaq')) return 'https://tensdaq-api.x-aio.com/v1';
     if (k.contains('kelivoin')) return 'https://text.pollinations.ai/openai';
     if (k.contains('openrouter')) return 'https://openrouter.ai/api/v1';
+    if (RegExp(r'atlas\s*cloud|atlascloud').hasMatch(k)) {
+      return 'https://api.atlascloud.ai/v1';
+    }
     if (k.contains('aihubmix')) return 'https://aihubmix.com/v1';
     if (RegExp(r'qwen|aliyun|dashscope').hasMatch(k)) {
       return 'https://dashscope.aliyuncs.com/compatible-mode/v1';
@@ -4683,6 +4687,7 @@ class ProviderConfig {
       if (s.contains('gemini') || s.contains('google')) return true;
       if (s.contains('silicon')) return true;
       if (s.contains('openrouter')) return true;
+      if (RegExp(r'atlas\s*cloud|atlascloud').hasMatch(s)) return true;
       if (s.contains('kelivoin')) return true;
       return false; // others disabled by default
     }
@@ -4778,6 +4783,49 @@ class ProviderConfig {
                 'input': ['text'],
                 'output': ['text'],
                 'abilities': ['tool'],
+              },
+            },
+            proxyEnabled: false,
+            proxyHost: '',
+            proxyPort: '8080',
+            proxyUsername: '',
+            proxyPassword: '',
+            multiKeyEnabled: false,
+            apiKeys: const [],
+            keyManagement: const KeyManagementConfig(),
+            aihubmixAppCodeEnabled: false,
+            balanceEnabled: _defaultBalanceEnabled(key),
+            balanceApiPath: _defaultBalanceApiPath(key),
+            balanceResultPath: _defaultBalanceResultPath(key),
+            claudePromptCachingEnabled: false,
+          );
+        }
+        if (RegExp(r'atlas\s*cloud|atlascloud').hasMatch(lowerKey)) {
+          return ProviderConfig(
+            id: key,
+            enabled: defaultEnabled(key),
+            name: displayName ?? key,
+            apiKey: '',
+            baseUrl: _defaultBase(key),
+            providerType: ProviderKind.openai,
+            chatPath: '/chat/completions',
+            useResponseApi: false,
+            models: const [
+              'qwen/qwen3.5-flash',
+              'deepseek-ai/deepseek-v4-pro',
+            ],
+            modelOverrides: const {
+              'qwen/qwen3.5-flash': {
+                'type': 'chat',
+                'input': ['text'],
+                'output': ['text'],
+                'abilities': ['tool'],
+              },
+              'deepseek-ai/deepseek-v4-pro': {
+                'type': 'chat',
+                'input': ['text'],
+                'output': ['text'],
+                'abilities': ['tool', 'reasoning'],
               },
             },
             proxyEnabled: false,

--- a/lib/features/provider/pages/providers_page.dart
+++ b/lib/features/provider/pages/providers_page.dart
@@ -472,6 +472,7 @@ class _ProvidersPageState extends State<ProvidersPage> {
     ),
     _p('Gemini', 'Gemini', enabled: true, models: 0),
     _p('OpenRouter', 'OpenRouter', enabled: true, models: 0),
+    _p('Atlas Cloud', 'Atlas Cloud', enabled: true, models: 0),
     _p('KelivoIN', 'KelivoIN', enabled: true, models: 0),
     _p('Tensdaq', 'Tensdaq', enabled: false, models: 0),
     _p('DeepSeek', 'DeepSeek', enabled: false, models: 0),

--- a/test/settings_provider_business_preferences_test.dart
+++ b/test/settings_provider_business_preferences_test.dart
@@ -94,6 +94,7 @@ void main() {
         'OpenAI',
         'SiliconFlow',
         'OpenRouter',
+        'Atlas Cloud',
         'KelivoIN',
         'Tensdaq',
         'DeepSeek',

--- a/test/settings_provider_reasoning_support_test.dart
+++ b/test/settings_provider_reasoning_support_test.dart
@@ -36,6 +36,28 @@ void main() {
       expect(moonshot.modelOverrides, isEmpty);
     });
 
+    test('default Atlas Cloud preset uses OpenAI-compatible settings', () {
+      final atlas = ProviderConfig.defaultsFor('Atlas Cloud');
+
+      expect(atlas.enabled, isTrue);
+      expect(atlas.providerType, ProviderKind.openai);
+      expect(atlas.baseUrl, 'https://api.atlascloud.ai/v1');
+      expect(atlas.chatPath, '/chat/completions');
+      expect(atlas.useResponseApi, isFalse);
+      expect(atlas.models, const [
+        'qwen/qwen3.5-flash',
+        'deepseek-ai/deepseek-v4-pro',
+      ]);
+
+      final qwen =
+          atlas.modelOverrides['qwen/qwen3.5-flash'] as Map<String, dynamic>;
+      final deepseek =
+          atlas.modelOverrides['deepseek-ai/deepseek-v4-pro']
+              as Map<String, dynamic>;
+      expect(qwen['abilities'], const ['tool']);
+      expect(deepseek['abilities'], const ['tool', 'reasoning']);
+    });
+
     test('built-in provider order does not add Kimi preset', () async {
       final harness = await createBusinessTestHarness(
         initial: {


### PR DESCRIPTION
## Summary

- add Atlas Cloud to the built-in provider list
- seed Atlas Cloud with the OpenAI-compatible base URL, chat completions path, and verified text model IDs
- cover the provider defaults and built-in provider order migration with focused tests

## Validation

- `git diff --check`
- live Atlas Cloud `/v1/models` check returned 119 models and confirmed `qwen/qwen3.5-flash` plus `deepseek-ai/deepseek-v4-pro`

Not run locally:

- `flutter test` / `dart test` because this environment does not have Dart or Flutter installed

No README changes.
