### PR TITLE
fix: 标准化记忆工具返回格式为 JSON，修复 think 模型重复编辑记忆的问题

### DIFF
--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -552,6 +552,12 @@ class MessageBuilderService {
           buf.writeln('</record>');
         }
         buf.writeln('</memories>');
+        buf.writeln(
+          '注意：上方<memories>中的内容是基于当前会话构建时加载的，'
+          '若你在本次对话中通过工具修改了记忆，<memories>中的内容可能并非最新，'
+          '请以工具返回的结果为准。',
+        );
+        buf.writeln();
         buf.writeln('''
 ## Memory Tool
 你是一个无状态的大模型，你无法存储记忆，因此为了记住信息，你需要使用**记忆工具**。

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -488,7 +488,12 @@ class ToolHandlerService {
           );
         }
         final m = await mp.add(assistantId: assistant!.id, content: content);
-        return m.content;
+        return jsonEncode({
+          'success': true,
+          'id': m.id,
+          'content': m.content,
+          'action': 'create_memory',
+        });
       } else if (name == 'edit_memory') {
         final id = (args['id'] as num?)?.toInt() ?? -1;
         final content = (args['content'] ?? '').toString();
@@ -516,7 +521,12 @@ class ToolHandlerService {
                 'Use the available memory records shown in context, or create a new memory instead of editing a missing one.',
           );
         }
-        return m.content;
+        return jsonEncode({
+          'success': true,
+          'id': id,
+          'content': m.content,
+          'action': 'edit_memory',
+        });
       } else if (name == 'delete_memory') {
         final id = (args['id'] as num?)?.toInt() ?? -1;
         if (id <= 0) {
@@ -536,7 +546,11 @@ class ToolHandlerService {
                 'Use the available memory records shown in context, or skip deleting a missing memory.',
           );
         }
-        return 'deleted';
+        return jsonEncode({
+          'success': true,
+          'id': id,
+          'action': 'delete_memory',
+        });
       }
     } catch (e) {
       return _toolError(

--- a/test/features/home/services/tool_handler_service_test.dart
+++ b/test/features/home/services/tool_handler_service_test.dart
@@ -57,7 +57,11 @@ void main() {
         'content': 'new memory',
       });
 
-      expect(result, 'new memory');
+      final payload = jsonDecode(result) as Map<String, dynamic>;
+      expect(payload['success'], true);
+      expect(payload['id'], memory.id);
+      expect(payload['content'], 'new memory');
+      expect(payload['action'], 'edit_memory');
     });
 
     testWidgets('edit_memory returns tool error when id does not exist', (


### PR DESCRIPTION
修复模型重复编辑记忆的问题
- 记忆工具（create_memory/edit_memory/delete_memory）返回格式改为统一 JSON 结构，包含 success/id/content/action 字段，消除裸字符串导致模型无法 确认操作成功的问题
- System Prompt 中 <memories> 标签后添加提示，说明标签内容为会话构建 时的快照，若通过工具修改了记忆可能并非最新，以工具返回为准