### PR TITLE
Fix system prompt time snapshot

### DIFF
--- a/lib/core/services/chat/prompt_transformer.dart
+++ b/lib/core/services/chat/prompt_transformer.dart
@@ -1,6 +1,7 @@
 import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import '../../models/assistant.dart';
+import 'system_prompt_time_snapshot.dart';
 
 class PromptTransformer {
   static Map<String, String> buildPlaceholders({
@@ -10,14 +11,7 @@ class PromptTransformer {
     required String? modelName,
     required String userNickname,
   }) {
-    final now = DateTime.now();
     final locale = Localizations.localeOf(context).toLanguageTag();
-    final tz = now.timeZoneName;
-    final date =
-        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
-    final time =
-        '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
-    final dt = '$date $time';
     final os = Platform.operatingSystem;
     final osv = Platform.operatingSystemVersion;
     final device =
@@ -25,18 +19,37 @@ class PromptTransformer {
     final battery = 'unknown';
 
     return <String, String>{
-      '{cur_date}': date,
-      '{cur_time}': time,
-      '{cur_datetime}': dt,
+      ...buildTimePlaceholders(),
       '{model_id}': modelId ?? '',
       '{model_name}': modelName ?? (modelId ?? ''),
       '{locale}': locale,
-      '{timezone}': tz,
       '{system_version}': '$os $osv',
       '{device_info}': device,
       '{battery_level}': battery,
       '{nickname}': userNickname,
       '{assistant_name}': assistant.name,
+    };
+  }
+
+  /// Builds only the system-prompt time placeholders.
+  ///
+  /// Supplying [snapshot] keeps this formatter deterministic in tests. Normal
+  /// callers use the application-level half-day snapshot service.
+  static Map<String, String> buildTimePlaceholders({
+    SystemPromptTimeSnapshot? snapshot,
+  }) {
+    final value = snapshot ?? SystemPromptTimeSnapshotService.instance.current;
+    final now = value.localDateTime;
+    final date =
+        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+    final time =
+        '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
+
+    return <String, String>{
+      '{cur_date}': date,
+      '{cur_time}': time,
+      '{cur_datetime}': '$date $time',
+      '{timezone}': value.timezone,
     };
   }
 

--- a/lib/core/services/chat/system_prompt_time_snapshot.dart
+++ b/lib/core/services/chat/system_prompt_time_snapshot.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+/// The local time values used by system-prompt placeholders.
+///
+/// Both the date/time and timezone are captured together so every time-related
+/// placeholder remains stable for the lifetime of the snapshot.
+class SystemPromptTimeSnapshot {
+  const SystemPromptTimeSnapshot({
+    required this.localDateTime,
+    required this.timezone,
+  });
+
+  final DateTime localDateTime;
+  final String timezone;
+}
+
+typedef SystemPromptClock = DateTime Function();
+typedef SystemPromptTimerScheduler = Timer Function(
+  Duration delay,
+  void Function() callback,
+);
+typedef SystemPromptTimezoneName = String Function(DateTime localDateTime);
+
+/// Maintains an application-level time snapshot for system prompts.
+///
+/// A snapshot is stable within a local half-day and refreshes at local noon or
+/// midnight. [current] also checks the boundary lazily, which covers suspended
+/// applications and delayed timers.
+class SystemPromptTimeSnapshotService {
+  SystemPromptTimeSnapshotService({
+    SystemPromptClock? clock,
+    SystemPromptTimerScheduler? timerScheduler,
+    SystemPromptTimezoneName? timezoneName,
+  }) : _clock = clock ?? DateTime.now,
+       _timerScheduler = timerScheduler ?? Timer.new,
+       _timezoneName = timezoneName ?? ((value) => value.timeZoneName) {
+    _snapshot = _capture(_clock());
+  }
+
+  static final SystemPromptTimeSnapshotService instance =
+      SystemPromptTimeSnapshotService();
+
+  final SystemPromptClock _clock;
+  final SystemPromptTimerScheduler _timerScheduler;
+  final SystemPromptTimezoneName _timezoneName;
+
+  late SystemPromptTimeSnapshot _snapshot;
+  Timer? _boundaryTimer;
+  bool _initialized = false;
+
+  /// Starts automatic noon/midnight refreshes.
+  ///
+  /// Calling this more than once is harmless.
+  void initialize() {
+    if (_initialized) {
+      _refreshIfNeeded();
+      return;
+    }
+    _initialized = true;
+    _snapshot = _capture(_clock());
+    _scheduleNextBoundary();
+  }
+
+  /// Returns the stable snapshot, refreshing first if a boundary was missed.
+  SystemPromptTimeSnapshot get current {
+    _refreshIfNeeded();
+    return _snapshot;
+  }
+
+  void _refreshIfNeeded() {
+    final now = _clock();
+    if (_halfDayKey(now) == _halfDayKey(_snapshot.localDateTime)) return;
+
+    _snapshot = _capture(now);
+    if (_initialized) _scheduleNextBoundary();
+  }
+
+  SystemPromptTimeSnapshot _capture(DateTime now) {
+    return SystemPromptTimeSnapshot(
+      localDateTime: now,
+      timezone: _timezoneName(now),
+    );
+  }
+
+  void _scheduleNextBoundary() {
+    _boundaryTimer?.cancel();
+
+    final now = _clock();
+    final nextBoundary = now.hour < 12
+        ? DateTime(now.year, now.month, now.day, 12)
+        : DateTime(now.year, now.month, now.day + 1);
+    final delay = nextBoundary.difference(now);
+
+    _boundaryTimer = _timerScheduler(delay, _handleBoundaryTimer);
+  }
+
+  void _handleBoundaryTimer() {
+    _boundaryTimer = null;
+    _refreshIfNeeded();
+    if (_boundaryTimer == null && _initialized) _scheduleNextBoundary();
+  }
+
+  String _halfDayKey(DateTime value) {
+    final half = value.hour < 12 ? 0 : 1;
+    return '${value.year}-${value.month}-${value.day}-$half';
+  }
+
+  /// Stops the timer. Intended for tests and process teardown.
+  void dispose() {
+    _initialized = false;
+    _boundaryTimer?.cancel();
+    _boundaryTimer = null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'core/database/business_repository.dart';
 import 'core/database/business_startup_gate.dart';
 import 'core/database/chat_database_gateway.dart';
 import 'core/services/chat/chat_service.dart';
+import 'core/services/chat/system_prompt_time_snapshot.dart';
 import 'core/services/database_v2_rollout_ledger.dart';
 import 'core/services/backup/restore_business_lease.dart';
 import 'core/services/backup/restore_startup_gate.dart';
@@ -77,6 +78,7 @@ Future<void> main() async {
   await runZoned(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
+      SystemPromptTimeSnapshotService.instance.initialize();
       FlutterLogger.installGlobalHandlers();
       final appDataDirectory = await AppDirectories.getAppDataDirectory();
       final RestoreReceipt? restoreOutcome;

--- a/test/core/services/chat/system_prompt_time_snapshot_test.dart
+++ b/test/core/services/chat/system_prompt_time_snapshot_test.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/services/chat/prompt_transformer.dart';
+import 'package:Kelivo/core/services/chat/system_prompt_time_snapshot.dart';
+
+class _ScheduledTimer implements Timer {
+  _ScheduledTimer(this.delay, this.callback);
+
+  final Duration delay;
+  final void Function() callback;
+  bool _isActive = true;
+
+  void fire() {
+    if (!_isActive) return;
+    _isActive = false;
+    callback();
+  }
+
+  @override
+  void cancel() => _isActive = false;
+
+  @override
+  bool get isActive => _isActive;
+
+  @override
+  int get tick => _isActive ? 0 : 1;
+}
+
+class _TimerHarness {
+  final List<_ScheduledTimer> timers = [];
+
+  Timer schedule(Duration delay, void Function() callback) {
+    final timer = _ScheduledTimer(delay, callback);
+    timers.add(timer);
+    return timer;
+  }
+
+  _ScheduledTimer get active => timers.lastWhere((timer) => timer.isActive);
+}
+
+void main() {
+  group('SystemPromptTimeSnapshotService', () {
+    test('captures the startup time when initialized', () {
+      var now = DateTime(2026, 7, 24, 8);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+      );
+
+      now = DateTime(2026, 7, 24, 9, 15);
+      service.initialize();
+
+      expect(service.current.localDateTime, DateTime(2026, 7, 24, 9, 15));
+      expect(timers.active.delay, const Duration(hours: 2, minutes: 45));
+      service.dispose();
+    });
+
+    test('keeps startup prompt values stable within the same half-day', () {
+      var now = DateTime(2026, 7, 24, 9, 15, 30);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+        timezoneName: (_) => 'CST',
+      );
+
+      service.initialize();
+      final startup = service.current;
+      final startupValues = PromptTransformer.buildTimePlaceholders(
+        snapshot: startup,
+      );
+      now = DateTime(2026, 7, 24, 11, 59, 59);
+      final repeated = service.current;
+      final repeatedValues = PromptTransformer.buildTimePlaceholders(
+        snapshot: repeated,
+      );
+
+      expect(repeated, same(startup));
+      expect(repeatedValues, startupValues);
+      expect(repeatedValues, <String, String>{
+        '{cur_date}': '2026-07-24',
+        '{cur_time}': '09:15',
+        '{cur_datetime}': '2026-07-24 09:15',
+        '{timezone}': 'CST',
+      });
+      expect(
+        timers.active.delay,
+        const Duration(hours: 2, minutes: 44, seconds: 30),
+      );
+      service.dispose();
+    });
+
+    test('refreshes at local noon without restarting the app', () {
+      var now = DateTime(2026, 7, 24, 11, 59, 30);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+      );
+
+      service.initialize();
+      final beforeNoon = service.current;
+      expect(timers.active.delay, const Duration(seconds: 30));
+
+      now = DateTime(2026, 7, 24, 12);
+      timers.active.fire();
+      final afterNoon = service.current;
+
+      expect(afterNoon, isNot(same(beforeNoon)));
+      expect(afterNoon.localDateTime, DateTime(2026, 7, 24, 12));
+      expect(timers.active.delay, const Duration(hours: 12));
+      service.dispose();
+    });
+
+    test('refreshes at local midnight without restarting the app', () {
+      var now = DateTime(2026, 7, 24, 23, 59, 45);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+      );
+
+      service.initialize();
+      final beforeMidnight = service.current;
+      expect(timers.active.delay, const Duration(seconds: 15));
+
+      now = DateTime(2026, 7, 25);
+      timers.active.fire();
+      final afterMidnight = service.current;
+
+      expect(afterMidnight, isNot(same(beforeMidnight)));
+      expect(afterMidnight.localDateTime, DateTime(2026, 7, 25));
+      expect(timers.active.delay, const Duration(hours: 12));
+      service.dispose();
+    });
+
+    test('a delayed timer refreshes using its actual execution time', () {
+      var now = DateTime(2026, 7, 24, 11, 30);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+      );
+
+      service.initialize();
+      final noonTimer = timers.active;
+      now = DateTime(2026, 7, 24, 12, 45);
+      noonTimer.fire();
+
+      expect(service.current.localDateTime, DateTime(2026, 7, 24, 12, 45));
+      expect(timers.active.delay, const Duration(hours: 11, minutes: 15));
+      service.dispose();
+    });
+
+    test('the next read catches a missed boundary before building a prompt', () {
+      var now = DateTime(2026, 7, 24, 10);
+      final timers = _TimerHarness();
+      final service = SystemPromptTimeSnapshotService(
+        clock: () => now,
+        timerScheduler: timers.schedule,
+      );
+
+      service.initialize();
+      final staleNoonTimer = timers.active;
+      now = DateTime(2026, 7, 24, 14, 20);
+
+      final promptValues = PromptTransformer.buildTimePlaceholders(
+        snapshot: service.current,
+      );
+
+      expect(promptValues['{cur_datetime}'], '2026-07-24 14:20');
+      expect(staleNoonTimer.isActive, isFalse);
+      expect(timers.active.delay, const Duration(hours: 9, minutes: 40));
+      service.dispose();
+    });
+  });
+
+  test('message-template date and time still use the request time', () {
+    final first = PromptTransformer.applyMessageTemplate(
+      '{{ date }} {{ time }} {{ message }}',
+      role: 'user',
+      message: 'hello',
+      now: DateTime(2026, 7, 24, 11, 59),
+    );
+    final second = PromptTransformer.applyMessageTemplate(
+      '{{ date }} {{ time }} {{ message }}',
+      role: 'user',
+      message: 'hello',
+      now: DateTime(2026, 7, 24, 12, 1),
+    );
+
+    expect(first, '2026-07-24 11:59 hello');
+    expect(second, '2026-07-24 12:01 hello');
+  });
+}


### PR DESCRIPTION
## Summary
- add an application-level half-day snapshot service for system-prompt time placeholders
- use the snapshot for `{cur_date}`, `{cur_time}`, `{cur_datetime}`, and `{timezone}` in `PromptTransformer`
- initialize the snapshot at app startup and cover noon, midnight, delayed timer, lazy refresh, and message-template behavior with tests

Fixes #809

## Testing
- `git diff --check`
- Not run locally: `dart format`, `dart analyze`, `flutter test` because this environment does not have Dart/Flutter on PATH. The PR workflow should run format, analyze, l10n, and the full Flutter test suite.