### PR TITLE
fix(chat): preserve input focus across app resume

### DIFF
--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -217,6 +217,7 @@ class _ChatInputBarState extends State<ChatInputBar>
   static const double _imageRemoveButtonSize = 18;
   // Suppress context menu briefly after app resume to avoid flickering
   bool _suppressContextMenu = false;
+  Timer? _contextMenuResumeTimer;
   bool _isSubmitting = false;
   String? _imageModeModelKey;
   String? _lastImageModeModelKey;
@@ -476,28 +477,34 @@ class _ChatInputBarState extends State<ChatInputBar>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    // When app resumes from background, suppress context menu briefly to avoid flickering
     if (state == AppLifecycleState.resumed) {
-      _suppressContextMenu = true;
-      // Also unfocus to reset any stuck toolbar state
-      widget.focusNode?.unfocus();
-      // Re-enable context menu after a short delay
-      Future.delayed(const Duration(milliseconds: 300), () {
-        if (mounted) {
-          setState(() => _suppressContextMenu = false);
-        }
-      });
+      _suppressContextMenuForLifecycle(restoreAfterTransition: true);
     } else if (state == AppLifecycleState.inactive ||
         state == AppLifecycleState.paused) {
-      // When going to background, hide any open toolbar
-      _suppressContextMenu = true;
-      widget.focusNode?.unfocus();
+      _suppressContextMenuForLifecycle(restoreAfterTransition: false);
     }
+  }
+
+  void _suppressContextMenuForLifecycle({
+    required bool restoreAfterTransition,
+  }) {
+    _contextMenuResumeTimer?.cancel();
+    _contextMenuResumeTimer = null;
+    _suppressContextMenu = true;
+    ContextMenuController.removeAny();
+    if (!restoreAfterTransition) return;
+    _contextMenuResumeTimer = Timer(const Duration(milliseconds: 300), () {
+      _contextMenuResumeTimer = null;
+      if (mounted) {
+        _suppressContextMenu = false;
+      }
+    });
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _contextMenuResumeTimer?.cancel();
     for (final timer in _repeatTimers.values) {
       try {
         timer?.cancel();

--- a/test/features/home/widgets/chat_input_bar_focus_lifecycle_test.dart
+++ b/test/features/home/widgets/chat_input_bar_focus_lifecycle_test.dart
@@ -1,0 +1,174 @@
+import 'package:Kelivo/core/models/chat_input_data.dart';
+import 'package:Kelivo/core/providers/assistant_provider.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/features/home/widgets/chat_input_bar.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../support/business_test_harness.dart';
+
+void _pauseApp(TestWidgetsFlutterBinding binding) {
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+}
+
+void _beginResumeApp(TestWidgetsFlutterBinding binding) {
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+}
+
+void _finishResumeApp(TestWidgetsFlutterBinding binding) {
+  binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+}
+
+void _restoreResumedApp(TestWidgetsFlutterBinding binding) {
+  switch (binding.lifecycleState) {
+    case AppLifecycleState.resumed:
+      return;
+    case AppLifecycleState.paused:
+      _beginResumeApp(binding);
+      _finishResumeApp(binding);
+      return;
+    case AppLifecycleState.hidden:
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      _finishResumeApp(binding);
+      return;
+    case AppLifecycleState.inactive:
+    case AppLifecycleState.detached:
+    case null:
+      _finishResumeApp(binding);
+      return;
+  }
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget buildHarness({
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    TargetPlatform platform = TargetPlatform.android,
+  }) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => SettingsProvider(createBusinessTestPreferences()),
+        ),
+        ChangeNotifierProvider(
+          create: (_) =>
+              AssistantProvider(preferences: createBusinessTestPreferences()),
+        ),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(platform: platform),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ChatInputBar(
+            controller: controller,
+            focusNode: focusNode,
+            onSend: (_) async => ChatInputSubmissionResult.rejected,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'resume must preserve focus acquired during lifecycle transition',
+    (tester) async {
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+      addTearDown(() {
+        _restoreResumedApp(tester.binding);
+        controller.dispose();
+        focusNode.dispose();
+      });
+
+      await tester.pumpWidget(
+        buildHarness(controller: controller, focusNode: focusNode),
+      );
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+
+      tester.testTextInput.closeConnection();
+      await tester.pump();
+
+      _pauseApp(tester.binding);
+      _beginResumeApp(tester.binding);
+      await tester.pump();
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+
+      _finishResumeApp(tester.binding);
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+    },
+  );
+
+  testWidgets(
+    'a stale resume timer must not re-enable menus after pausing again',
+    (tester) async {
+      final controller = TextEditingController(text: 'draft');
+      final focusNode = FocusNode();
+      addTearDown(() {
+        _restoreResumedApp(tester.binding);
+        controller.dispose();
+        focusNode.dispose();
+      });
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          platform: TargetPlatform.iOS,
+        ),
+      );
+
+      var contextMenuRemoved = false;
+      final contextMenuController = ContextMenuController(
+        onRemove: () => contextMenuRemoved = true,
+      );
+      contextMenuController.show(
+        context: tester.element(find.byType(ChatInputBar)),
+        contextMenuBuilder: (_) => const SizedBox(width: 1, height: 1),
+      );
+      await tester.pump();
+      expect(contextMenuController.isShown, isTrue);
+
+      _pauseApp(tester.binding);
+      await tester.pump();
+      expect(contextMenuController.isShown, isFalse);
+      expect(contextMenuRemoved, isTrue);
+
+      _beginResumeApp(tester.binding);
+      _finishResumeApp(tester.binding);
+      _pauseApp(tester.binding);
+      await tester.pump(const Duration(milliseconds: 301));
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      final editableState = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+      final contextMenu = textField.contextMenuBuilder!(
+        editableState.context,
+        editableState,
+      );
+
+      expect(contextMenu, isA<SizedBox>());
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- preserve chat input focus acquired while the app is returning to the foreground
- close any open text context menu without unfocusing the externally owned `FocusNode`
- cancel stale context-menu suppression timers on later lifecycle transitions and disposal
- add regression coverage for the focus-loss sequence and the resume/pause timer race

## Root cause

`ChatInputBar.didChangeAppLifecycleState` unconditionally called `unfocus()` on both pause and resume. A user can tap the input while the app is transitioning through `inactive` back to `resumed`; the final `resumed` notification then unfocused that newly established text-input connection. The field appeared unresponsive until the app was restarted.

The fix keeps focus ownership with the caller and treats context-menu cleanup as a separate concern via `ContextMenuController.removeAny()`.

## Compatibility

No public API, persistence model, localization, dependency, or platform configuration changes.

## Validation

- regression test against the old implementation: 2 expected failures
- `flutter test --no-pub test/features/home/widgets/chat_input_bar_focus_lifecycle_test.dart test/features/home/widgets/chat_input_bar_queue_test.dart test/features/home/widgets/chat_input_overlay_layout_test.dart` — 23 passed
- `flutter analyze --no-pub lib test` — no issues
- `flutter test --no-pub` — 1345 passed
- `git merge-tree --write-tree HEAD upstream/master` — clean
