### PR TITLE
fix(ios): load app locale before first frame

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -667,7 +667,7 @@ class SettingsProvider extends ChangeNotifier {
   int get appLaunchCount => _appLaunchCount;
 
   SettingsProvider(this._preferences) {
-    _appLocaleTag = _preferences.getString(_appLocaleKey);
+    _appLocaleTag = _readAppLocaleTag(_preferences);
     _loaded = _load();
   }
 
@@ -1173,9 +1173,9 @@ class SettingsProvider extends ChangeNotifier {
     _desktopRightSidebarWidth =
         prefs.getDouble(_desktopRightSidebarWidthKey) ?? 300;
     // Load app locale; default to follow system on first launch
-    _appLocaleTag = prefs.getString(_appLocaleKey);
-    if (_appLocaleTag == null || _appLocaleTag!.isEmpty) {
-      _appLocaleTag = 'system';
+    final storedAppLocale = prefs.get(_appLocaleKey);
+    _appLocaleTag = _readAppLocaleTag(prefs);
+    if (storedAppLocale != _appLocaleTag) {
       await prefs.setString(_appLocaleKey, 'system');
     }
 
@@ -1990,6 +1990,11 @@ class SettingsProvider extends ChangeNotifier {
 
   // ===== App locale (UI language) =====
   String? _appLocaleTag; // 'system', 'zh_CN', 'zh_Hant', 'en_US'
+  static String _readAppLocaleTag(BusinessPreferences preferences) {
+    final value = preferences.get(_appLocaleKey);
+    return value is String && value.isNotEmpty ? value : 'system';
+  }
+
   Locale get appLocale => _parseLocaleTag(_appLocaleTag ?? 'en_US');
   bool get isFollowingSystemLocale =>
       (_appLocaleTag == null) || (_appLocaleTag == 'system');

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -667,6 +667,7 @@ class SettingsProvider extends ChangeNotifier {
   int get appLaunchCount => _appLaunchCount;
 
   SettingsProvider(this._preferences) {
+    _appLocaleTag = _preferences.getString(_appLocaleKey);
     _loaded = _load();
   }
 

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -1992,7 +1992,8 @@ class SettingsProvider extends ChangeNotifier {
   String? _appLocaleTag; // 'system', 'zh_CN', 'zh_Hant', 'en_US'
   static String _readAppLocaleTag(BusinessPreferences preferences) {
     final value = preferences.get(_appLocaleKey);
-    return value is String && value.isNotEmpty ? value : 'system';
+    const supportedTags = {'system', 'zh_CN', 'zh_Hant', 'en_US'};
+    return value is String && supportedTags.contains(value) ? value : 'system';
   }
 
   Locale get appLocale => _parseLocaleTag(_appLocaleTag ?? 'en_US');

--- a/test/core/providers/settings_provider_locale_test.dart
+++ b/test/core/providers/settings_provider_locale_test.dart
@@ -20,6 +20,8 @@ void main() {
 
   for (final testCase in <({String name, Object value})>[
     (name: 'empty string', value: ''),
+    (name: 'whitespace string', value: ' '),
+    (name: 'unknown string', value: 'fr_FR'),
     (name: 'non-string value', value: 1),
   ]) {
     test('follows the system before loading for ${testCase.name}', () async {

--- a/test/core/providers/settings_provider_locale_test.dart
+++ b/test/core/providers/settings_provider_locale_test.dart
@@ -1,0 +1,20 @@
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../support/business_test_harness.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exposes the persisted app locale before async settings load', () async {
+    final harness = await createBusinessTestHarness(
+      initial: const {'app_locale_v1': 'zh_CN'},
+    );
+
+    final settings = SettingsProvider(harness.preferences);
+
+    expect(settings.appLocaleForMaterialApp, const Locale('zh', 'CN'));
+    await settings.loaded;
+  });
+}

--- a/test/core/providers/settings_provider_locale_test.dart
+++ b/test/core/providers/settings_provider_locale_test.dart
@@ -17,4 +17,22 @@ void main() {
     expect(settings.appLocaleForMaterialApp, const Locale('zh', 'CN'));
     await settings.loaded;
   });
+
+  for (final testCase in <({String name, Object value})>[
+    (name: 'empty string', value: ''),
+    (name: 'non-string value', value: 1),
+  ]) {
+    test('follows the system before loading for ${testCase.name}', () async {
+      final harness = await createBusinessTestHarness(
+        initial: {'app_locale_v1': testCase.value},
+      );
+
+      final settings = SettingsProvider(harness.preferences);
+
+      expect(settings.appLocaleForMaterialApp, isNull);
+      await settings.loaded;
+      expect(settings.appLocaleForMaterialApp, isNull);
+      expect(harness.preferences.get('app_locale_v1'), 'system');
+    });
+  }
 }

--- a/test/features/assistant/pages/assistant_settings_edit_page_mcp_test.dart
+++ b/test/features/assistant/pages/assistant_settings_edit_page_mcp_test.dart
@@ -185,15 +185,24 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Time Info'), findsOneWidget);
+    final timeInfoRow = find
+        .ancestor(of: find.text('Time Info'), matching: find.byType(Row))
+        .first;
     expect(
-      find.byWidgetPredicate(
-        (widget) => widget is Icon && widget.icon == Lucide.clock,
+      find.descendant(
+        of: timeInfoRow,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Icon && widget.icon == Lucide.clock,
+        ),
       ),
       findsOneWidget,
     );
     expect(
-      find.byWidgetPredicate(
-        (widget) => widget is Icon && widget.icon == Lucide.Calendar,
+      find.descendant(
+        of: timeInfoRow,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Icon && widget.icon == Lucide.Calendar,
+        ),
       ),
       findsNothing,
     );


### PR DESCRIPTION
## 概述

  修复 iOS 系统语言与软件语言不一致时，新对话短暂使用系统语言标题的问题。

## 原因

  应用启动前 `BusinessPreferences` 已经加载完成，但此前 `SettingsProvider` 只会在异步加载流程开始后才暴露已保存的软件语言。

  因此当系统语言为英语，软件设置为中文时，首帧可能先使用系统语言，并创建标题为 `New Chat` 的对话。随后界面切换为中文后，标题生成逻辑无法将 `New Chat` 识别为当前语言的默认标题，从而跳过自动标题生成。

## 修改

  - 构造 `SettingsProvider` 时同步读取已保存的软件语言。
  - 不改变现有异步设置加载流程和标题生成规则。
  - 添加回归测试，确保异步设置加载完成前即可取得已保存的软件语言。

## 验证

  - `flutter test test/core/providers/settings_provider_locale_test.dart`
