### PR TITLE
fix(dashscope)：修复 Qwen Image 提示词内容格式

### DIFF
--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -596,15 +596,24 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
   required bool allowRemoteImages,
   required _ReasoningContentReplayPolicy reasoningContentReplayPolicy,
   bool stripReasoningContent = false,
+  bool dashScopeQwenImageMode = false,
 }) async {
+  // DashScope's Qwen Image models are exposed through the Chat Completions
+  // endpoint, but differ from regular OpenAI-compatible chat models in two
+  // important ways: text must be a content-part array, and history cannot
+  // include assistant/tool messages. Keep only the current user turn so a
+  // follow-up generation does not fail after Kelivo has stored an image reply.
+  final requestMessages = dashScopeQwenImageMode
+      ? _lastUserMessageOnly(messages)
+      : messages;
   final out = <Map<String, dynamic>>[];
   // Assistant turns cannot carry image_url/video_url; stash for the last user
   // message (same pattern as Responses shouldAttachAssistantImage).
   // Use last *user* index — not array-tail — so tool follow-ups that append
   // assistant tool_calls / tool results still receive stashed assistant media.
   int lastUserIndex = -1;
-  for (int i = messages.length - 1; i >= 0; i--) {
-    if ((messages[i]['role'] ?? '').toString() == 'user') {
+  for (int i = requestMessages.length - 1; i >= 0; i--) {
+    if ((requestMessages[i]['role'] ?? '').toString() == 'user') {
       lastUserIndex = i;
       break;
     }
@@ -614,7 +623,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
   final toolTurnIds = <int>{};
   final messageTurnIds = <int>[];
   var currentTurnId = -1;
-  for (final message in messages) {
+  for (final message in requestMessages) {
     final messageRole = (message['role'] ?? 'user').toString();
     if (messageRole == 'user') currentTurnId++;
     messageTurnIds.add(currentTurnId);
@@ -626,8 +635,8 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
       toolTurnIds.add(currentTurnId);
     }
   }
-  for (int i = 0; i < messages.length; i++) {
-    final m = messages[i];
+  for (int i = 0; i < requestMessages.length; i++) {
+    final m = requestMessages[i];
     final originalContent = m['content'];
     final raw = originalContent is List
         ? ChatApiService._textFromContentParts(originalContent)
@@ -871,7 +880,11 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
         !hasAttachedImages &&
         !hasInternalMedia &&
         !shouldAttachAssistantMedia) {
-      outMsg['content'] = raw;
+      outMsg['content'] = dashScopeQwenImageMode
+          ? [
+              {'type': 'text', 'text': raw},
+            ]
+          : raw;
       out.add(outMsg);
       continue;
     }
@@ -1021,11 +1034,43 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
         outMsg['content'] = textOnly.isEmpty ? raw : textOnly;
       }
     } else {
-      outMsg['content'] = parts.isEmpty ? raw : parts;
+      outMsg['content'] = parts.isEmpty
+          ? (dashScopeQwenImageMode
+                ? [
+                    {'type': 'text', 'text': raw},
+                  ]
+                : raw)
+          : parts;
     }
     out.add(outMsg);
   }
   return out;
+}
+
+List<Map<String, dynamic>> _lastUserMessageOnly(
+  List<Map<String, dynamic>> messages,
+) {
+  for (var i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i]['role'] ?? '').toString() == 'user') {
+      return [messages[i]];
+    }
+  }
+  // Preserve the original request if it is malformed rather than silently
+  // sending an empty messages array.
+  return messages;
+}
+
+bool _isDashScopeQwenImageModel(
+  ProviderConfig config,
+  String upstreamModelId,
+) {
+  final providerLabel = '${config.id} ${config.name}'.toLowerCase();
+  final looksLikeDashScope =
+      BuiltInToolsHelper.isDashScopeProvider(config) ||
+      providerLabel.contains('dashscope') ||
+      providerLabel.contains('aliyun');
+  return looksLikeDashScope &&
+      upstreamModelId.trim().toLowerCase().startsWith('qwen-image');
 }
 
 String _extractOpenAICompatibleDeltaText(Map? delta) {
@@ -1825,6 +1870,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       allowRemoteImages: allowRemoteImages,
       reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
       stripReasoningContent: isClaudeUpstream,
+      dashScopeQwenImageMode: _isDashScopeQwenImageModel(
+        config,
+        upstreamModelId,
+      ),
     );
     body = {
       'model': upstreamModelId,
@@ -2148,6 +2197,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             allowRemoteImages: allowRemoteImages,
             reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
             stripReasoningContent: isClaudeUpstream,
+            dashScopeQwenImageMode: _isDashScopeQwenImageModel(
+              config,
+              upstreamModelId,
+            ),
           );
           reqBody.remove('stream');
           req.body = jsonEncode(reqBody);
@@ -2354,6 +2407,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 allowRemoteImages: allowRemoteImages,
                 reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
                 stripReasoningContent: isClaudeUpstream,
+                dashScopeQwenImageMode: _isDashScopeQwenImageModel(
+                  config,
+                  upstreamModelId,
+                ),
               ),
               'stream': true,
               if (temperature != null) 'temperature': temperature,
@@ -3745,6 +3802,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 allowRemoteImages: allowRemoteImages,
                 reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
                 stripReasoningContent: isClaudeUpstream,
+                dashScopeQwenImageMode: _isDashScopeQwenImageModel(
+                  config,
+                  upstreamModelId,
+                ),
               ),
               'stream': true,
               if (temperature != null) 'temperature': temperature,
@@ -4256,6 +4317,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     reasoningContentReplayPolicy:
                         info.reasoningContentReplayPolicy,
                     stripReasoningContent: isClaudeUpstream,
+                    dashScopeQwenImageMode: _isDashScopeQwenImageModel(
+                      config,
+                      upstreamModelId,
+                    ),
                   ),
                   'stream': true,
                   if (temperature != null) 'temperature': temperature,

--- a/test/openai_latest_models_compat_test.dart
+++ b/test/openai_latest_models_compat_test.dart
@@ -176,6 +176,68 @@ void main() {
       expect(openRouterBody['top_p'], 0.8);
     });
 
+    test('DashScope Qwen Image sends only the latest user turn as parts',
+        () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody = (jsonDecode(await utf8.decoder.bind(request).join())
+                as Map)
+            .cast<String, dynamic>();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final config = ProviderConfig(
+        id: 'Aliyun',
+        enabled: true,
+        name: 'Aliyun',
+        apiKey: 'test-key',
+        baseUrl: 'http://${server.address.address}:${server.port}/v1',
+        providerType: ProviderKind.openai,
+      );
+      final chunks = await ChatApiService.sendMessageStream(
+        config: config,
+        modelId: 'qwen-image-3.0-pro',
+        messages: const [
+          {'role': 'user', 'content': 'old prompt'},
+          {'role': 'assistant', 'content': 'old generated image'},
+          {'role': 'user', 'content': 'draw a sunset cottage'},
+        ],
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(requestBody['messages'], [
+        {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': 'draw a sunset cottage'},
+          ],
+        },
+      ]);
+    });
+
     test('GPT-5.6 auto effort omits incompatible sampling params', () async {
       final body = await _captureChatBody(
         modelId: 'openai/gpt-5.6-terra',


### PR DESCRIPTION
## 修复内容

- 为 DashScope 的 `qwen-image*` 模型将纯文本提示词序列化为 OpenAI 内容块数组。
- Qwen Image 请求只保留最新一条用户消息；DashScope 会拒绝包含 assistant/tool 历史的请求。
- 新增回归测试，覆盖含历史 assistant 消息时仍正确发送最新用户提示词的场景。

## 解决的问题

DashScope 调用 `qwen-image-3.0-pro` 时会返回：

```text
invalid_parameter_error: Input should be a valid list: input.messages.0.content
```

Kelivo 原先发送：

```json
{"role":"user","content":"提示词"}
```

该模型要求：

```json
{"role":"user","content":[{"type":"text","text":"提示词"}]}
```

## 验证

- `git diff --check` 通过。
- `flutter test test/openai_latest_models_compat_test.dart`：7/7 通过，包含新增 Qwen Image 回归用例。
- 全量 `flutter test`：2419/2419 通过。

注：第一次全量运行出现的 1 项失败是测试环境未将 Flutter 自带的 `dart` 放入 `PATH`，导致一个会启动独立 Dart 子进程的备份锁测试找不到 `dart`。补齐该临时环境变量后，该用例及完整套件均通过。