### PR TITLE
refactor(chat): render assistant replies as MessageParts

### DIFF
--- a/lib/core/models/message_part.dart
+++ b/lib/core/models/message_part.dart
@@ -243,3 +243,21 @@ bool _optionalBool(Map<String, dynamic> map, String key) {
   }
   return value;
 }
+
+/// Whether the assistant bubble should walk [parts] instead of contentSplits.
+///
+/// Historical rows keep a single [TextPart] plus persisted split triples.
+/// New streams persist [ReasoningPart] / [ToolCallPart] (and generated
+/// [ImagePart]s). Image-only new rows have no splits, so they also take
+/// this path; old extracted images that still have splits stay on the
+/// read-compat renderer.
+bool renderAssistantFromParts({
+  required List<MessagePart> parts,
+  required bool hasContentSplits,
+}) {
+  for (final part in parts) {
+    if (part is ReasoningPart || part is ToolCallPart) return true;
+  }
+  if (hasContentSplits) return false;
+  return parts.any((part) => part is ImagePart);
+}

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -2304,10 +2304,128 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     return steps;
   }
 
+  bool get _hasContentSplits =>
+      widget.contentSplitOffsets != null &&
+      widget.reasoningCountAtSplit != null &&
+      widget.toolCountAtSplit != null;
+
+  bool get _renderFromParts => renderAssistantFromParts(
+    parts: widget.message.parts,
+    hasContentSplits: _hasContentSplits,
+  );
+
+  ToolUIPart? _toolUiFromPayload(String payloadJson) {
+    try {
+      final decoded = jsonDecode(payloadJson);
+      if (decoded is! Map) return null;
+      final id = (decoded['id'] ?? '').toString();
+      if (id.isEmpty) return null;
+      final args = decoded['arguments'];
+      final content = decoded['content']?.toString();
+      return ToolUIPart(
+        id: id,
+        toolName: (decoded['name'] ?? '').toString(),
+        arguments: args is Map
+            ? args.cast<String, dynamic>()
+            : const <String, dynamic>{},
+        content: content,
+        loading: content == null || content.isEmpty,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  List<_RenderBlock> _buildRenderBlocksFromParts(
+    List<MessagePart> parts, {
+    List<ReasoningSegment>? reasoningSegments,
+  }) {
+    final liveTools = <String, ToolUIPart>{
+      for (final tool in widget.toolParts ?? const <ToolUIPart>[])
+        if (tool.toolName != 'builtin_search' && tool.id.isNotEmpty)
+          tool.id: tool,
+    };
+    final blocks = <_RenderBlock>[];
+    var pendingSteps = <_TimelineStepData>[];
+    var reasoningCount = 0;
+    var toolCount = 0;
+    var reasoningIndex = 0;
+    final assistant = _assistantForMessage();
+
+    void flushSteps() {
+      if (pendingSteps.isEmpty) return;
+      blocks.add(
+        _RenderBlock.thinking(List<_TimelineStepData>.of(pendingSteps)),
+      );
+      pendingSteps = <_TimelineStepData>[];
+    }
+
+    for (final part in parts) {
+      switch (part) {
+        case TextPart(:final text):
+          final visual = _applyVisualAssistantRegexes(
+            text,
+            assistant: assistant,
+            scope: AssistantRegexScope.assistant,
+          );
+          if (visual.trim().isEmpty) continue;
+          flushSteps();
+          blocks.add(_RenderBlock.text(visual));
+        case ImagePart(:final uri):
+          if (uri.trim().isEmpty) continue;
+          flushSteps();
+          blocks.add(_RenderBlock.text('\n\n![image]($uri)'));
+        case ReasoningPart(:final text):
+          if (text.isEmpty) continue;
+          final provided =
+              reasoningSegments != null &&
+                  reasoningIndex < reasoningSegments.length
+              ? reasoningSegments[reasoningIndex]
+              : null;
+          reasoningIndex++;
+          pendingSteps.add(
+            _TimelineStepData.reasoning(
+              reasoning: ReasoningSegment(
+                text: text,
+                expanded: provided?.expanded ?? true,
+                loading: provided?.loading ?? false,
+                startAt: provided?.startAt,
+                finishedAt: provided?.finishedAt,
+                onToggle: provided?.onToggle,
+                toolStartIndex: provided?.toolStartIndex ?? toolCount,
+              ),
+              reasoningCountAfter: ++reasoningCount,
+              toolCountAfter: toolCount,
+            ),
+          );
+        case ToolCallPart(:final payloadJson):
+          final parsed = _toolUiFromPayload(payloadJson);
+          if (parsed == null || parsed.toolName == 'builtin_search') continue;
+          pendingSteps.add(
+            _TimelineStepData.tool(
+              tool: liveTools[parsed.id] ?? parsed,
+              reasoningCountAfter: reasoningCount,
+              toolCountAfter: ++toolCount,
+            ),
+          );
+        default:
+          break;
+      }
+    }
+    flushSteps();
+    return blocks;
+  }
+
   List<_RenderBlock> _buildRenderBlocks(
     String visualContent, {
     List<ReasoningSegment>? reasoningSegments,
   }) {
+    if (_renderFromParts) {
+      return _buildRenderBlocksFromParts(
+        widget.message.parts,
+        reasoningSegments: reasoningSegments,
+      );
+    }
     final visibleTools = (widget.toolParts ?? const <ToolUIPart>[])
         .where((p) => p.toolName != 'builtin_search')
         .toList();
@@ -2405,7 +2523,12 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final mediaPreview = _buildAttachmentPreview(
       context,
-      parts: widget.message.parts,
+      parts: _renderFromParts
+          ? [
+              for (final part in widget.message.parts)
+                if (part is FilePart) part,
+            ]
+          : widget.message.parts,
       isDark: isDark,
       alignEnd: false,
     );

--- a/lib/features/chat/widgets/message_export_sheet.dart
+++ b/lib/features/chat/widgets/message_export_sheet.dart
@@ -178,6 +178,18 @@ class _ThinkingExportData {
 }
 
 _ThinkingExportData _thinkingExportDataForMessage(ChatMessage message) {
+  final structuredReasoning = [
+    for (final part in message.parts)
+      if (part is ReasoningPart && part.text.trim().isNotEmpty)
+        part.text.trim(),
+  ];
+  if (structuredReasoning.isNotEmpty) {
+    return _ThinkingExportData(
+      cleanedContent: message.content.trim(),
+      thinkingTexts: structuredReasoning,
+    );
+  }
+
   final thinkingTexts = <String>[];
   var cleanedContent = message.content.trim();
 

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -670,6 +670,27 @@ class ChatActions {
     required String errorText,
   }) => partialContent.isEmpty ? errorText : partialContent;
 
+  /// Assemble the assistant part list after a stream error.
+  ///
+  /// When no visible text arrived, the error string is written through
+  /// [ChatMessage.partsWithReplacedText] so reasoning / tool / image parts
+  /// already accumulated stay in place.
+  @visibleForTesting
+  static List<MessagePart> assistantPartsForStreamError({
+    required List<MessagePart> parts,
+    required String partialContent,
+    required String errorText,
+  }) {
+    final displayContent = resolveStreamErrorContent(
+      partialContent: partialContent,
+      errorText: errorText,
+    );
+    if (partialContent.isEmpty) {
+      return ChatMessage.partsWithReplacedText(parts, displayContent);
+    }
+    return List<MessagePart>.of(parts);
+  }
+
   @visibleForTesting
   static StreamSubscription<T> listenSequentiallyToStream<T>({
     required Stream<T> stream,
@@ -2271,14 +2292,12 @@ class ChatActions {
     final partialContent = state.fullContentRaw.isEmpty
         ? ''
         : _transformAssistantContent(state, state.fullContentRaw);
-    final displayContent = resolveStreamErrorContent(
-      partialContent: partialContent,
-      errorText: errorText,
-    );
     final errorParts = await _sanitizeAssistantImageParts(
-      partialContent.isEmpty
-          ? <MessagePart>[TextPart(displayContent)]
-          : _assistantPartsForState(state),
+      assistantPartsForStreamError(
+        parts: _assistantPartsForState(state),
+        partialContent: partialContent,
+        errorText: errorText,
+      ),
     );
     final errorMessage = _streamingMessageSnapshot(state).copyWith(
       parts: errorParts,

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -6,6 +6,9 @@ import '../../../core/database/generation_run.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/message_part.dart';
+import '../../../utils/app_directories.dart';
+import '../../../utils/sandbox_path_resolver.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/models/token_usage.dart';
 import '../../../core/providers/assistant_provider.dart';
@@ -19,7 +22,6 @@ import '../../../core/services/ios_background_generation.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../utils/assistant_regex.dart';
 import '../../../core/models/assistant_regex.dart';
-import '../../../utils/markdown_media_sanitizer.dart';
 import '../services/ask_user_interaction_service.dart';
 import '../services/message_generation_service.dart';
 import '../services/tool_approval_service.dart';
@@ -358,6 +360,8 @@ class ChatActions {
       <String, _GenerationCheckpointCursor>{};
   final ActiveStreamingMessageStore _activeAssistantMessages =
       ActiveStreamingMessageStore();
+  final Map<String, stream_ctrl.StreamingState> _streamingStates =
+      <String, stream_ctrl.StreamingState>{};
   final Map<String, Future<void>> _cancelStreamingFutures =
       <String, Future<void>>{};
 
@@ -378,7 +382,6 @@ class ChatActions {
 
   List<ChatMessage> get _messages => chatController.messages;
   Map<String, int> get _versionSelections => chatController.versionSelections;
-  Conversation? get _currentConversation => chatController.currentConversation;
   Set<String> get _loadingConversationIds =>
       chatController.loadingConversationIds;
   Map<String, StreamSubscription<dynamic>> get _conversationStreams =>
@@ -426,15 +429,10 @@ class ChatActions {
     final messageId = message.id;
     final reasoning = streamController.reasoning[messageId];
     final segments = streamController.reasoningSegments[messageId];
-    final splits = streamController.getContentSplitData(messageId);
     final details = streamController.reasoningDetails[messageId];
-    final reasoningSegmentsJson =
-        segments != null || splits != null || details != null
+    final reasoningSegmentsJson = segments != null || details != null
         ? streamController.serializeReasoningSegmentsWithSplits(
             segments ?? const [],
-            contentSplitOffsets: splits?.offsets,
-            reasoningCountAtSplit: splits?.reasoningCounts,
-            toolCountAtSplit: splits?.toolCounts,
             reasoningDetails: details,
           )
         : message.reasoningSegmentsJson;
@@ -462,7 +460,7 @@ class ChatActions {
       index < 0 ? state.ctx.assistantMessage : _messages[index],
     );
     return base.copyWith(
-      content: _transformAssistantContent(state),
+      parts: _assistantPartsForState(state),
       totalTokens: state.totalTokens,
       promptTokens: state.usage?.promptTokens,
       completionTokens: state.usage?.completionTokens,
@@ -558,6 +556,7 @@ class ChatActions {
   void _clearGenerationRuntimeState(ChatMessage message) {
     _generationCheckpointCursors.remove(message.id);
     _streamingToolEvents.remove(message.id);
+    _streamingStates.remove(message.id);
     _activeAssistantMessages.removeIfMatches(message);
   }
 
@@ -880,6 +879,57 @@ class ChatActions {
       scope: AssistantRegexScope.assistant,
       target: AssistantRegexTransformTarget.persist,
     );
+  }
+
+  List<MessagePart> _assistantPartsForState(stream_ctrl.StreamingState state) {
+    final parts = state.shadowHandler.parts;
+    if (parts.isEmpty) {
+      return <MessagePart>[TextPart(_transformAssistantContent(state))];
+    }
+    return [
+      for (final part in parts)
+        if (part is TextPart)
+          TextPart(_transformAssistantContent(state, part.text))
+        else
+          part,
+    ];
+  }
+
+  Future<List<MessagePart>> _sanitizeAssistantImageParts(
+    List<MessagePart> parts,
+  ) async {
+    final out = <MessagePart>[];
+    for (final part in parts) {
+      if (part is! ImagePart || !part.uri.startsWith('data:')) {
+        out.add(part);
+        continue;
+      }
+      final comma = part.uri.indexOf(',');
+      if (comma < 0) {
+        out.add(part);
+        continue;
+      }
+      final header = part.uri.substring(5, comma);
+      final semi = header.indexOf(';');
+      final mime = semi < 0 ? header : header.substring(0, semi);
+      final saved = await AppDirectories.saveBase64Image(
+        mime.isEmpty ? 'image/png' : mime,
+        part.uri.substring(comma + 1),
+      );
+      if (saved == null || saved.isEmpty) {
+        out.add(part);
+        continue;
+      }
+      out.add(
+        ImagePart(
+          uri: SandboxPathResolver.canonicalize(saved),
+          mime: part.mime ?? (mime.isEmpty ? 'image/png' : mime),
+          assetId: part.assetId,
+          unavailable: part.unavailable,
+        ),
+      );
+    }
+    return out;
   }
 
   // ============================================================================
@@ -1640,9 +1690,15 @@ class ChatActions {
       }
 
       streamController.finishReasoningIfNeeded(streaming.id);
-      final finalizedMessage = _messageWithCurrentReasoning(
-        latestStreaming,
-      ).copyWith(isStreaming: false);
+      final state = _streamingStates[streaming.id];
+      final assistantParts = await _sanitizeAssistantImageParts(
+        state == null ? latestStreaming.parts : _assistantPartsForState(state),
+      );
+      final finalizedMessage =
+          (state == null
+                  ? _messageWithCurrentReasoning(latestStreaming)
+                  : _streamingMessageSnapshot(state))
+              .copyWith(parts: assistantParts, isStreaming: false);
       try {
         await _finalizeStreamingCheckpoint(
           finalizedMessage,
@@ -1675,6 +1731,7 @@ class ChatActions {
   /// Execute generation with the given context.
   Future<void> _executeGeneration(stream_ctrl.GenerationContext ctx) async {
     final state = stream_ctrl.StreamingState(ctx);
+    _streamingStates[state.messageId] = state;
     final assistant = ctx.assistant;
     final conversationId = state.conversationId;
     final existingSplit = streamController.getContentSplitData(state.messageId);
@@ -1894,6 +1951,7 @@ class ChatActions {
     stream_ctrl.StreamingState state,
   ) async {
     await streamController.handleReasoningChunk(chunk, state);
+    _publishAssistantParts(state);
   }
 
   /// Handle tool calls chunk from stream.
@@ -1915,6 +1973,7 @@ class ChatActions {
           },
       getToolEventsFromDb: _copyToolEvents,
     );
+    _publishAssistantParts(state);
   }
 
   /// Handle tool results chunk from stream.
@@ -1944,6 +2003,18 @@ class ChatActions {
             );
           },
     );
+    _publishAssistantParts(state);
+  }
+
+  void _publishAssistantParts(stream_ctrl.StreamingState state) {
+    if (!state.ctx.streamOutput || state.finishHandled) return;
+    streamController.streamingContentNotifier.getNotifier(state.messageId);
+    streamController.streamingContentNotifier.updateContent(
+      state.messageId,
+      _transformAssistantContent(state),
+      state.totalTokens,
+      parts: _assistantPartsForState(state),
+    );
   }
 
   /// Handle content chunk from stream (non-done).
@@ -1968,59 +2039,6 @@ class ChatActions {
       state.totalTokens = state.usage!.totalTokens;
     }
 
-    final probe = state.inlineBase64TailProbe + chunkContent;
-    if (!state.hasInlineBase64 && probe.contains('data:image')) {
-      state.hasInlineBase64 = true;
-    }
-    if (chunkContent.isNotEmpty) {
-      state.inlineBase64TailProbe = chunkContent.length > 16
-          ? chunkContent.substring(chunkContent.length - 16)
-          : chunkContent;
-    }
-
-    if (state.hasInlineBase64) {
-      String streamingProcessed = _transformAssistantContent(state);
-      if (streamingProcessed.contains('data:image') &&
-          streamingProcessed.contains('base64,')) {
-        try {
-          final sanitized =
-              await MarkdownMediaSanitizer.replaceInlineBase64Images(
-                streamingProcessed,
-              );
-          if (sanitized != streamingProcessed) {
-            streamingProcessed = sanitized;
-            state.fullContentRaw = sanitized;
-          }
-        } catch (e) {
-          // ignore
-        }
-      }
-
-      // After any await point, _finishStreaming may have already run and
-      // updated _messages[index] with the FULL final content. If we continue
-      // with this stale streamingProcessed we would overwrite the final content
-      // with a partial snapshot. Bail out early to prevent that.
-      if (state.finishHandled) return;
-
-      onScheduleImageSanitize?.call(
-        messageId,
-        streamingProcessed,
-        immediate: true,
-      );
-      if (state.ctx.streamOutput &&
-          _currentConversation?.id == conversationId) {
-        final index = _messages.indexWhere((m) => m.id == messageId);
-        if (index != -1) {
-          chatController.replaceMessageSnapshot(
-            _messages[index].copyWith(
-              content: streamingProcessed,
-              totalTokens: state.totalTokens,
-            ),
-          );
-        }
-      }
-    }
-
     // End reasoning when content starts
     if (state.ctx.streamOutput && chunkContent.isNotEmpty) {
       await _finishReasoningOnContent(state);
@@ -2039,10 +2057,8 @@ class ChatActions {
         messageId,
         conversationId,
         () => _transformAssistantContent(state),
+        partsBuilder: () => _assistantPartsForState(state),
         totalTokens: state.totalTokens,
-        contentSplitOffsets: state.contentSplitOffsets,
-        reasoningCountAtSplit: state.reasoningCountAtSplit,
-        toolCountAtSplit: state.toolCountAtSplit,
         promptTokens: state.usage?.promptTokens,
         completionTokens: state.usage?.completionTokens,
         cachedTokens: state.usage?.cachedTokens,
@@ -2180,25 +2196,22 @@ class ChatActions {
     // This ensures any intermediate rebuild (e.g., from isProcessingFiles change
     // or onDone firing concurrently) still shows the correct content via the
     // notifier-based streaming path.
+    final assistantParts = await _sanitizeAssistantImageParts(
+      _assistantPartsForState(state),
+    );
     streamController.streamingContentNotifier.updateContent(
       messageId,
       processedContent,
       state.totalTokens,
-      contentSplitOffsets: state.contentSplitOffsets,
-      reasoningCountAtSplit: state.reasoningCountAtSplit,
-      toolCountAtSplit: state.toolCountAtSplit,
+      parts: assistantParts,
       promptTokens: finalPromptTokens,
       completionTokens: finalCompletionTokens,
       cachedTokens: finalCachedTokens,
       durationMs: finalDurationMs,
     );
 
-    final sanitizedContent =
-        await MarkdownMediaSanitizer.replaceInlineBase64Images(
-          processedContent,
-        );
     final finalizedMessage = _streamingMessageSnapshot(state).copyWith(
-      content: sanitizedContent,
+      parts: assistantParts,
       totalTokens: state.totalTokens,
       isStreaming: false,
       promptTokens: finalPromptTokens,
@@ -2262,8 +2275,13 @@ class ChatActions {
       partialContent: partialContent,
       errorText: errorText,
     );
+    final errorParts = await _sanitizeAssistantImageParts(
+      partialContent.isEmpty
+          ? <MessagePart>[TextPart(displayContent)]
+          : _assistantPartsForState(state),
+    );
     final errorMessage = _streamingMessageSnapshot(state).copyWith(
-      content: displayContent,
+      parts: errorParts,
       totalTokens: state.totalTokens,
       isStreaming: false,
     );
@@ -2360,15 +2378,10 @@ class ChatActions {
     final r = streamController.reasoning[streaming.id];
     final segs = streamController.reasoningSegments[streaming.id];
 
-    final splits = streamController.getContentSplitData(streaming.id);
     final details = streamController.reasoningDetails[streaming.id];
-    final reasoningSegmentsJson =
-        segs != null || splits != null || details != null
+    final reasoningSegmentsJson = segs != null || details != null
         ? streamController.serializeReasoningSegmentsWithSplits(
             segs ?? const [],
-            contentSplitOffsets: splits?.offsets,
-            reasoningCountAtSplit: splits?.reasoningCounts,
-            toolCountAtSplit: splits?.toolCounts,
             reasoningDetails: details,
           )
         : streaming.reasoningSegmentsJson;
@@ -2404,7 +2417,7 @@ class ChatActions {
       reasoningCounts: state.reasoningCountAtSplit,
       toolCounts: state.toolCountAtSplit,
     );
-    final recorded = bookkeeping.addContent(
+    bookkeeping.addContent(
       chunkContent,
       reasoningCount: streamController.getReasoningSegmentCount(
         state.messageId,
@@ -2413,15 +2426,9 @@ class ChatActions {
     );
     state
       ..hadThinkingBlock = bookkeeping.hadThinkingBlock
-      ..fullContentRaw = bookkeeping.fullContentRaw;
-    if (!recorded) return;
-    streamController.setContentSplitData(
-      state.messageId,
-      stream_ctrl.ContentSplitData(
-        offsets: List<int>.of(state.contentSplitOffsets),
-        reasoningCounts: List<int>.of(state.reasoningCountAtSplit),
-        toolCounts: List<int>.of(state.toolCountAtSplit),
-      ),
-    );
+      ..fullContentRaw = bookkeeping.fullContentRaw
+      ..contentSplitOffsets = bookkeeping.offsets
+      ..reasoningCountAtSplit = bookkeeping.reasoningCounts
+      ..toolCountAtSplit = bookkeeping.toolCounts;
   }
 }

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/message_part.dart';
 import '../../../core/models/token_usage.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
@@ -534,6 +535,7 @@ class StreamController {
     String messageId,
     String conversationId,
     String Function() contentBuilder, {
+    List<MessagePart> Function()? partsBuilder,
     required void Function(String messageId, String content, int totalTokens)
     updateMessageInList,
     required int totalTokens,
@@ -552,6 +554,7 @@ class StreamController {
     state
       ..conversationId = conversationId
       ..contentBuilder = contentBuilder
+      ..partsBuilder = partsBuilder
       ..totalTokens = totalTokens
       ..contentSplitOffsets = contentSplitOffsets
       ..reasoningCountAtSplit = reasoningCountAtSplit
@@ -631,6 +634,7 @@ class StreamController {
       messageId,
       content,
       state.totalTokens,
+      parts: state.partsBuilder?.call(),
       contentSplitOffsets: state.contentSplitOffsets,
       reasoningCountAtSplit: state.reasoningCountAtSplit,
       toolCountAtSplit: state.toolCountAtSplit,
@@ -830,13 +834,6 @@ class StreamController {
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     state.hadThinkingBlock = true;
-    _contentSplits[messageId] = _normalizeContentSplitData(
-      ContentSplitData(
-        offsets: List<int>.of(state.contentSplitOffsets),
-        reasoningCounts: List<int>.of(state.reasoningCountAtSplit),
-        toolCounts: List<int>.of(state.toolCountAtSplit),
-      ),
-    );
 
     if (state.ctx.streamOutput) {
       final initialExpanded = !getSettingsProvider().autoCollapseThinking;
@@ -917,13 +914,6 @@ class StreamController {
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     state.hadThinkingBlock = true;
-    _contentSplits[messageId] = _normalizeContentSplitData(
-      ContentSplitData(
-        offsets: List<int>.of(state.contentSplitOffsets),
-        reasoningCounts: List<int>.of(state.reasoningCountAtSplit),
-        toolCounts: List<int>.of(state.toolCountAtSplit),
-      ),
-    );
 
     // Finish any unfinished reasoning segment when tools start
     final segments = _reasoningSegments[messageId] ?? <ReasoningSegmentData>[];
@@ -938,12 +928,7 @@ class StreamController {
       _reasoningSegments[messageId] = segments;
       await updateReasoningSegmentsInDb(
         messageId,
-        serializeReasoningSegmentsWithSplits(
-          segments,
-          contentSplitOffsets: state.contentSplitOffsets,
-          reasoningCountAtSplit: state.reasoningCountAtSplit,
-          toolCountAtSplit: state.toolCountAtSplit,
-        ),
+        serializeReasoningSegmentsWithSplits(segments),
       );
     }
 
@@ -1008,13 +993,6 @@ class StreamController {
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     state.hadThinkingBlock = true;
-    _contentSplits[messageId] = _normalizeContentSplitData(
-      ContentSplitData(
-        offsets: List<int>.of(state.contentSplitOffsets),
-        reasoningCounts: List<int>.of(state.reasoningCountAtSplit),
-        toolCounts: List<int>.of(state.toolCountAtSplit),
-      ),
-    );
 
     final parts = List<ToolUIPart>.of(_toolParts[messageId] ?? const []);
     for (final r in chunk.toolResults!) {
@@ -1120,12 +1098,7 @@ class StreamController {
       _safeNotifyStateChanged();
       await updateReasoningInDb(
         messageId,
-        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(
-          segments,
-          contentSplitOffsets: _contentSplits[messageId]?.offsets,
-          reasoningCountAtSplit: _contentSplits[messageId]?.reasoningCounts,
-          toolCountAtSplit: _contentSplits[messageId]?.toolCounts,
-        ),
+        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(segments),
       );
     }
   }
@@ -1173,12 +1146,7 @@ class StreamController {
     if (segments != null && segments.isNotEmpty) {
       await updateReasoningInDb(
         messageId,
-        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(
-          segments,
-          contentSplitOffsets: _contentSplits[messageId]?.offsets,
-          reasoningCountAtSplit: _contentSplits[messageId]?.reasoningCounts,
-          toolCountAtSplit: _contentSplits[messageId]?.toolCounts,
-        ),
+        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(segments),
       );
     }
   }
@@ -1280,12 +1248,7 @@ class StreamController {
     if (segments.isNotEmpty || splits != null) {
       await updateReasoningInDb(
         messageId,
-        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(
-          segments,
-          contentSplitOffsets: splits?.offsets,
-          reasoningCountAtSplit: splits?.reasoningCounts,
-          toolCountAtSplit: splits?.toolCounts,
-        ),
+        reasoningSegmentsJson: serializeReasoningSegmentsWithSplits(segments),
       );
     }
   }
@@ -1466,8 +1429,6 @@ class StreamingState {
   int? generationStateRevision;
   bool generationStreamingStarted = false;
   bool hadThinkingBlock = false;
-  bool hasInlineBase64 = false;
-  String inlineBase64TailProbe = '';
   List<int> contentSplitOffsets = <int>[];
   List<int> reasoningCountAtSplit = <int>[];
   List<int> toolCountAtSplit = <int>[];
@@ -1597,6 +1558,7 @@ class _StreamSmoothState {
   String targetContent = '';
   String visibleContent = '';
   String Function()? contentBuilder;
+  List<MessagePart> Function()? partsBuilder;
   int totalTokens = 0;
   List<int>? contentSplitOffsets;
   List<int>? reasoningCountAtSplit;

--- a/lib/features/home/controllers/streaming_content_notifier.dart
+++ b/lib/features/home/controllers/streaming_content_notifier.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/foundation.dart';
 
+import '../../../core/models/message_part.dart';
+
 /// Lightweight notifier for streaming message content updates.
 ///
 /// This class provides a way to update streaming message content without
@@ -36,6 +38,7 @@ class StreamingContentNotifier {
     String messageId,
     String content,
     int totalTokens, {
+    List<MessagePart>? parts,
     List<int>? contentSplitOffsets,
     List<int>? reasoningCountAtSplit,
     List<int>? toolCountAtSplit,
@@ -50,6 +53,7 @@ class StreamingContentNotifier {
       notifier.value = StreamingContentData(
         content: content,
         totalTokens: totalTokens,
+        parts: parts ?? current.parts,
         reasoningText: current.reasoningText,
         reasoningStartAt: current.reasoningStartAt,
         reasoningFinishedAt: current.reasoningFinishedAt,
@@ -83,6 +87,7 @@ class StreamingContentNotifier {
       notifier.value = StreamingContentData(
         content: current.content,
         totalTokens: current.totalTokens,
+        parts: current.parts,
         reasoningText: reasoningText ?? current.reasoningText,
         reasoningStartAt: reasoningStartAt ?? current.reasoningStartAt,
         reasoningFinishedAt: reasoningFinishedAt ?? current.reasoningFinishedAt,
@@ -114,6 +119,7 @@ class StreamingContentNotifier {
       notifier.value = StreamingContentData(
         content: current.content,
         totalTokens: current.totalTokens,
+        parts: current.parts,
         reasoningText: current.reasoningText,
         reasoningStartAt: current.reasoningStartAt,
         reasoningFinishedAt: current.reasoningFinishedAt,
@@ -140,6 +146,7 @@ class StreamingContentNotifier {
       notifier.value = StreamingContentData(
         content: current.content,
         totalTokens: current.totalTokens,
+        parts: current.parts,
         reasoningText: current.reasoningText,
         reasoningStartAt: current.reasoningStartAt,
         reasoningFinishedAt: current.reasoningFinishedAt,
@@ -179,6 +186,7 @@ class StreamingContentData {
   const StreamingContentData({
     required this.content,
     required this.totalTokens,
+    this.parts,
     this.reasoningText,
     this.reasoningStartAt,
     this.reasoningFinishedAt,
@@ -195,6 +203,7 @@ class StreamingContentData {
 
   final String content;
   final int totalTokens;
+  final List<MessagePart>? parts;
   final String? reasoningText;
   final DateTime? reasoningStartAt;
   final DateTime? reasoningFinishedAt;
@@ -221,6 +230,7 @@ class StreamingContentData {
           runtimeType == other.runtimeType &&
           content == other.content &&
           totalTokens == other.totalTokens &&
+          parts == other.parts &&
           reasoningText == other.reasoningText &&
           reasoningStartAt == other.reasoningStartAt &&
           reasoningFinishedAt == other.reasoningFinishedAt &&
@@ -238,6 +248,7 @@ class StreamingContentData {
   int get hashCode =>
       content.hashCode ^
       totalTokens.hashCode ^
+      parts.hashCode ^
       reasoningText.hashCode ^
       reasoningStartAt.hashCode ^
       reasoningFinishedAt.hashCode ^

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -1556,7 +1556,8 @@ class _MessageListViewState extends State<MessageListView> {
 
         // Create a modified message with streaming content
         final streamingMessage = message.copyWith(
-          content: displayContent,
+          parts: data.parts,
+          content: data.parts == null ? displayContent : null,
           totalTokens: displayTokens,
           promptTokens: data.promptTokens,
           completionTokens: data.completionTokens,

--- a/test/core/models/message_part_test.dart
+++ b/test/core/models/message_part_test.dart
@@ -184,4 +184,52 @@ void main() {
       expect((video as FilePart).mime, 'video/mp4');
     });
   });
+
+  group('renderAssistantFromParts', () {
+    test('uses parts when reasoning or tool_call is present', () {
+      expect(
+        renderAssistantFromParts(
+          parts: const [ReasoningPart('plan'), TextPart('hi')],
+          hasContentSplits: true,
+        ),
+        isTrue,
+      );
+      expect(
+        renderAssistantFromParts(
+          parts: const [
+            ToolCallPart('{"id":"c1","name":"lookup"}'),
+            TextPart('done'),
+          ],
+          hasContentSplits: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps split renderer for historical text plus extracted images', () {
+      expect(
+        renderAssistantFromParts(
+          parts: const [
+            TextPart('caption'),
+            ImagePart(uri: 'kelivo-file:///images/a.png', mime: 'image/png'),
+          ],
+          hasContentSplits: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('uses parts for new image-only rows without splits', () {
+      expect(
+        renderAssistantFromParts(
+          parts: const [
+            ImagePart(uri: 'https://example.com/a.png', mime: 'image/png'),
+            TextPart('Done'),
+          ],
+          hasContentSplits: false,
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/core/services/backup/chatbox_importer_business_test.dart
+++ b/test/core/services/backup/chatbox_importer_business_test.dart
@@ -423,6 +423,17 @@ void main() {
         assistant.parts.whereType<ReasoningPart>().single.text,
         'first thought\nsecond thought',
       );
+      expect(
+        renderAssistantFromParts(
+          parts: assistant.parts,
+          hasContentSplits: false,
+        ),
+        isTrue,
+      );
+      expect(assistant.parts.map((part) => part.kind).toList(), [
+        'reasoning',
+        'text',
+      ]);
     });
 
     test('preserves newline across attachment boundary', () async {
@@ -600,6 +611,14 @@ void main() {
         'before\nafter',
       );
       expect(assistant.content, 'before\nafter');
+      expect(
+        renderAssistantFromParts(
+          parts: assistant.parts,
+          hasContentSplits: false,
+        ),
+        isTrue,
+      );
+      expect(assistant.parts.first, isA<ReasoningPart>());
     });
   });
 }

--- a/test/features/chat/widgets/chat_message_widget_mcp_and_assistant_attachments_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_mcp_and_assistant_attachments_test.dart
@@ -207,68 +207,73 @@ more text
     );
   });
 
-  testWidgets('assistant ImagePart/FilePart previews render in parts order', (
-    tester,
-  ) async {
-    const messageId = 'assistant-with-attachments';
+  testWidgets(
+    'assistant FilePart stays in the strip; ImagePart renders in the timeline',
+    (tester) async {
+      const messageId = 'assistant-with-attachments';
 
-    await tester.pumpWidget(
-      _harness(
-        ChatMessageWidget(
-          showModelIcon: false,
-          message: ChatMessage(
-            id: messageId,
-            role: 'assistant',
-            conversationId: 'conversation-assistant-attachments',
-            parts: const [
-              TextPart('这是助手附图'),
-              FilePart(
-                uri: '/tmp/report.pdf',
-                name: 'report.pdf',
-                mime: 'application/pdf',
-              ),
-              ImagePart(uri: 'https://example.com/assistant.png'),
-            ],
+      await tester.pumpWidget(
+        _harness(
+          ChatMessageWidget(
+            showModelIcon: false,
+            message: ChatMessage(
+              id: messageId,
+              role: 'assistant',
+              conversationId: 'conversation-assistant-attachments',
+              parts: const [
+                TextPart('这是助手附图'),
+                FilePart(
+                  uri: '/tmp/report.pdf',
+                  name: 'report.pdf',
+                  mime: 'application/pdf',
+                ),
+                ImagePart(uri: 'https://example.com/assistant.png'),
+              ],
+            ),
           ),
         ),
-      ),
-    );
-    await tester.pump();
+      );
+      await tester.pump();
 
-    final attachmentsFinder = find.byKey(
-      const ValueKey('assistant-message-attachments:$messageId'),
-    );
-    expect(attachmentsFinder, findsOneWidget);
-    expect(
-      find.descendant(of: attachmentsFinder, matching: find.text('report.pdf')),
-      findsOneWidget,
-    );
+      final attachmentsFinder = find.byKey(
+        const ValueKey('assistant-message-attachments:$messageId'),
+      );
+      expect(attachmentsFinder, findsOneWidget);
+      expect(
+        find.descendant(
+          of: attachmentsFinder,
+          matching: find.text('report.pdf'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('assistant-message-attachment:$messageId:0')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('assistant-message-attachment:$messageId:1')),
+        findsNothing,
+      );
 
-    final fileFinder = find.byKey(
-      const ValueKey('assistant-message-attachment:$messageId:1'),
-    );
-    final imageFinder = find.byKey(
-      const ValueKey('assistant-message-attachment:$messageId:2'),
-    );
-    expect(fileFinder, findsOneWidget);
-    expect(imageFinder, findsOneWidget);
-    expect(
-      tester.getRect(fileFinder).left,
-      lessThan(tester.getRect(imageFinder).left),
-    );
+      final images = tester.widgetList<Image>(find.byType(Image)).toList();
+      expect(
+        images.any((image) {
+          final provider = image.image;
+          final network = provider is NetworkImage
+              ? provider
+              : provider is ResizeImage &&
+                    provider.imageProvider is NetworkImage
+              ? provider.imageProvider as NetworkImage
+              : null;
+          return network?.url == 'https://example.com/assistant.png';
+        }),
+        isTrue,
+      );
 
-    final image = tester.widget<Image>(
-      find.descendant(of: imageFinder, matching: find.byType(Image)),
-    );
-    expect(image.image, isA<NetworkImage>());
-    expect(
-      (image.image as NetworkImage).url,
-      'https://example.com/assistant.png',
-    );
-
-    final align = tester.widget<Align>(attachmentsFinder);
-    expect(align.alignment, Alignment.centerLeft);
-  });
+      final align = tester.widget<Align>(attachmentsFinder);
+      expect(align.alignment, Alignment.centerLeft);
+    },
+  );
 
   testWidgets('assistant data URI ImagePart uses MemoryImage', (tester) async {
     const messageId = 'assistant-data-image';
@@ -293,7 +298,17 @@ more text
     );
     await tester.pump();
 
+    expect(
+      find.byKey(const ValueKey('assistant-message-attachments:$messageId')),
+      findsNothing,
+    );
     final image = tester.widget<Image>(find.byType(Image));
-    expect(image.image, isA<MemoryImage>());
+    final provider = image.image;
+    final memory = provider is MemoryImage
+        ? provider
+        : provider is ResizeImage && provider.imageProvider is MemoryImage
+        ? provider.imageProvider as MemoryImage
+        : null;
+    expect(memory, isA<MemoryImage>());
   });
 }

--- a/test/features/chat/widgets/chat_message_widget_parts_render_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_parts_render_test.dart
@@ -95,4 +95,58 @@ void main() {
     expect(find.textContaining('lookup'), findsWidgets);
     expect(find.textContaining('done'), findsWidgets);
   });
+
+  testWidgets('ChatBox imported reasoning-then-text parts render both blocks', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildHarness(
+        child: ChatMessageWidget(
+          message: ChatMessage(
+            id: 'chatbox-reasoning',
+            role: 'assistant',
+            conversationId: 'c1',
+            parts: const [
+              ReasoningPart('first thought\nsecond thought'),
+              TextPart('Because.'),
+            ],
+          ),
+          showModelIcon: false,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('first thought'), findsWidgets);
+    expect(find.textContaining('second thought'), findsWidgets);
+    expect(find.textContaining('Because.'), findsWidgets);
+  });
+
+  testWidgets(
+    'ChatBox imported text-reasoning-text loads as thinking then body',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildHarness(
+          child: ChatMessageWidget(
+            message: ChatMessage(
+              id: 'chatbox-split',
+              role: 'assistant',
+              conversationId: 'c1',
+              parts: const [
+                ReasoningPart('think'),
+                TextPart('before'),
+                TextPart('\nafter'),
+              ],
+            ),
+            showModelIcon: false,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('think'), findsWidgets);
+      expect(find.textContaining('before'), findsWidgets);
+      expect(find.textContaining('after'), findsWidgets);
+    },
+  );
 }

--- a/test/features/chat/widgets/chat_message_widget_parts_render_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_parts_render_test.dart
@@ -1,0 +1,98 @@
+import '../../../support/business_test_harness.dart';
+import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/providers/tts_provider.dart';
+import 'package:Kelivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Kelivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Kelivo/features/home/services/tool_approval_service.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildHarness({required Widget child}) {
+  SharedPreferences.setMockInitialValues(const {});
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(
+        create: (_) => SettingsProvider(createBusinessTestPreferences()),
+      ),
+      ChangeNotifierProvider(
+        create: (_) =>
+            TtsProvider(preferences: createBusinessTestPreferences()),
+      ),
+      ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+      ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('historical contentSplits still render reasoning then text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildHarness(
+        child: ChatMessageWidget(
+          message: ChatMessage(
+            id: 'legacy-splits',
+            role: 'assistant',
+            content: 'hello',
+            conversationId: 'c1',
+          ),
+          showModelIcon: false,
+          reasoningSegments: const [
+            ReasoningSegment(text: 'plan', expanded: true, loading: false),
+          ],
+          contentSplitOffsets: const [0],
+          reasoningCountAtSplit: const [1],
+          toolCountAtSplit: const [0],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('plan'), findsWidgets);
+    expect(find.textContaining('hello'), findsWidgets);
+  });
+
+  testWidgets('structured parts render reasoning, text, and tool in order', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildHarness(
+        child: ChatMessageWidget(
+          message: ChatMessage(
+            id: 'structured-parts',
+            role: 'assistant',
+            conversationId: 'c1',
+            parts: const [
+              ReasoningPart('plan'),
+              TextPart('hello'),
+              ToolCallPart(
+                '{"id":"c1","name":"lookup","arguments":{},"content":"ok"}',
+              ),
+              TextPart('done'),
+            ],
+          ),
+          showModelIcon: false,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('plan'), findsWidgets);
+    expect(find.textContaining('hello'), findsWidgets);
+    expect(find.textContaining('lookup'), findsWidgets);
+    expect(find.textContaining('done'), findsWidgets);
+  });
+}

--- a/test/features/home/controllers/chat_actions_stream_error_parts_test.dart
+++ b/test/features/home/controllers/chat_actions_stream_error_parts_test.dart
@@ -1,0 +1,42 @@
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk_handler.dart';
+import 'package:Kelivo/features/home/controllers/chat_actions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('stream error without text keeps reasoning, tool, and image parts', () {
+    final handler = StreamChunkHandler();
+    handler.handle(const ReasoningStart(id: 'r1'));
+    handler.handle(const ReasoningDelta(id: 'r1', text: 'plan'));
+    handler.handle(const ReasoningEnd(id: 'r1'));
+    handler.handle(const ToolCallStart(id: 'call_1', toolName: 'lookup'));
+    handler.handle(const ToolCallEnd('call_1'));
+    handler.handle(
+      const ImageSnapshot(id: 'img', data: 'https://example.com/gen.png'),
+    );
+
+    expect(handler.parts.whereType<TextPart>(), isEmpty);
+
+    final errorParts = ChatActions.assistantPartsForStreamError(
+      parts: handler.parts,
+      partialContent: '',
+      errorText: 'Connection failed',
+    );
+
+    expect(
+      errorParts.whereType<TextPart>().map((part) => part.text),
+      contains('Connection failed'),
+    );
+    expect(errorParts.whereType<ReasoningPart>().map((part) => part.text), [
+      'plan',
+    ]);
+    expect(
+      errorParts.whereType<ToolCallPart>().map((part) => part.payloadJson),
+      everyElement(contains('lookup')),
+    );
+    expect(errorParts.whereType<ImagePart>().map((part) => part.uri), [
+      'https://example.com/gen.png',
+    ]);
+  });
+}

--- a/test/features/home/controllers/stream_controller_content_split_test.dart
+++ b/test/features/home/controllers/stream_controller_content_split_test.dart
@@ -141,42 +141,37 @@ void main() {
     expect(state.fullContentRaw, '先确认一下。');
   });
 
-  test(
-    'finishReasoningAndPersist writes v2 payload for tool-only splits',
-    () async {
-      final controller = buildController();
-      const messageId = 'assistant-message';
-      controller.setContentSplitData(
-        messageId,
-        const ContentSplitData(
-          offsets: [8],
-          reasoningCounts: [0],
-          toolCounts: [1],
-        ),
-      );
+  test('finishReasoningAndPersist no longer writes content splits', () async {
+    final controller = buildController();
+    const messageId = 'assistant-message';
+    controller.setContentSplitData(
+      messageId,
+      const ContentSplitData(
+        offsets: [8],
+        reasoningCounts: [0],
+        toolCounts: [1],
+      ),
+    );
 
-      String? persistedJson;
-      await controller.finishReasoningAndPersist(
-        messageId,
-        updateReasoningInDb:
-            (
-              messageId, {
-              String? reasoningText,
-              DateTime? reasoningFinishedAt,
-              String? reasoningSegmentsJson,
-            }) async {
-              expect(messageId, 'assistant-message');
-              persistedJson = reasoningSegmentsJson ?? persistedJson;
-            },
-      );
+    String? persistedJson;
+    await controller.finishReasoningAndPersist(
+      messageId,
+      updateReasoningInDb:
+          (
+            messageId, {
+            String? reasoningText,
+            DateTime? reasoningFinishedAt,
+            String? reasoningSegmentsJson,
+          }) async {
+            expect(messageId, 'assistant-message');
+            persistedJson = reasoningSegmentsJson ?? persistedJson;
+          },
+    );
 
-      expect(persistedJson, isNotNull);
-      expect(controller.deserializeReasoningSegments(persistedJson), isEmpty);
-      final restoredSplits = controller.deserializeContentSplits(persistedJson);
-      expect(restoredSplits, isNotNull);
-      expect(restoredSplits!.toolCounts, const [1]);
-    },
-  );
+    expect(persistedJson, isNotNull);
+    expect(controller.deserializeReasoningSegments(persistedJson), isEmpty);
+    expect(controller.deserializeContentSplits(persistedJson), isNull);
+  });
 
   test('streaming reasoning honors disabled auto-collapse setting', () async {
     final harness = await createBusinessTestHarness(


### PR DESCRIPTION
## Summary
- Persist and render new assistant streams as `List<MessagePart>` (reasoning / text / tool / generated image in handler order).
- Stop writing `contentSplits` (read-compat kept for historical `reasoningSegmentsJson`); drop the `hasInlineBase64` mid-stream probe.
- Export sheet prefers `ReasoningPart` text; generated images stay in the timeline so they are not double-rendered in the attachment strip.
- Stream error / cancel-via-error with no visible text now uses `partsWithReplacedText`, so already-accumulated reasoning / tool / image parts are kept.
- ChatBox imports that write `ReasoningPart` now take the parts renderer. After persist/load this is thinking-then-body (same as the old `reasoningText` path), not a regression.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed lib test`
- [x] `dart analyze --fatal-infos lib test`
- [x] `flutter test`
- [x] Controller test: reasoning + tool + image, no TextDelta, error keeps all three part kinds
- [x] ChatBox import fixtures take `renderAssistantFromParts` and still show thinking + body