### PR TITLE
refactor(api): lift multi-round tool loops into one runner

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -37,6 +37,7 @@ import 'providers/openai/responses_decoder.dart';
 
 part 'chat_api_service_shims.dart';
 part 'stream/stream_chunk_emit.dart';
+part 'generation/tool_loop_runner.dart';
 part 'providers/openai_common.dart';
 part 'providers/openai_chat_completions.dart';
 part 'providers/openai_images.dart';

--- a/lib/core/services/api/generation/tool_loop_runner.dart
+++ b/lib/core/services/api/generation/tool_loop_runner.dart
@@ -1,0 +1,209 @@
+part of '../chat_api_service.dart';
+
+final class ExecutedClientTool {
+  const ExecutedClientTool({required this.call, required this.content});
+
+  final EmitToolCall call;
+  final String content;
+}
+
+List<EmitToolCall> clientToolCallsFromChatAcc(Map<dynamic, dynamic> toolAcc) {
+  final calls = <EmitToolCall>[];
+  final keys = toolAcc.keys.toList()
+    ..sort((a, b) {
+      final ai = a is int ? a : int.tryParse(a.toString()) ?? 0;
+      final bi = b is int ? b : int.tryParse(b.toString()) ?? 0;
+      return ai.compareTo(bi);
+    });
+  for (final key in keys) {
+    final raw = toolAcc[key];
+    if (raw is! Map) continue;
+    final id = _effectiveToolCallId(raw['id'], 'call', key);
+    final name = (raw['name'] ?? '').toString();
+    Map<String, dynamic> arguments;
+    try {
+      arguments = (jsonDecode((raw['args'] ?? '{}').toString()) as Map)
+          .cast<String, dynamic>();
+    } catch (_) {
+      arguments = <String, dynamic>{};
+    }
+    calls.add(emitToolCall(id: id, name: name, arguments: arguments));
+  }
+  return calls;
+}
+
+List<Map<String, dynamic>> openaiToolCallMaps(List<EmitToolCall> calls) {
+  return [
+    for (final call in calls)
+      <String, dynamic>{
+        'id': call.id,
+        'type': 'function',
+        'function': <String, dynamic>{
+          'name': call.name,
+          'arguments': jsonEncode(call.arguments),
+        },
+      },
+  ];
+}
+
+List<Map<String, dynamic>> openaiToolResultMessages(
+  List<ExecutedClientTool> executed,
+) {
+  return [
+    for (final item in executed)
+      <String, dynamic>{
+        'role': 'tool',
+        'tool_call_id': item.call.id,
+        'name': item.call.name,
+        'content': item.content,
+      },
+  ];
+}
+
+/// Execute [calls] and yield [ToolCallResult]s (and optionally [ToolCall*]).
+Stream<StreamChunk> executeClientTools({
+  required List<EmitToolCall> calls,
+  required ToolCallHandler onToolCall,
+  bool emitCalls = false,
+  TokenUsage? usage,
+  int totalTokens = 0,
+}) async* {
+  if (calls.isEmpty) return;
+  if (emitCalls) {
+    yield* emitToolCalls(calls, usage: usage, totalTokens: totalTokens);
+  }
+  final results = <EmitToolResult>[];
+  for (final call in calls) {
+    final content = await onToolCall(
+      call.name,
+      call.arguments,
+      toolCallId: call.id,
+    );
+    results.add(
+      emitToolResult(
+        id: call.id,
+        name: call.name,
+        arguments: call.arguments,
+        content: content,
+        metadata: call.metadata,
+      ),
+    );
+  }
+  yield* emitToolResults(results, usage: usage, totalTokens: totalTokens);
+}
+
+/// After-round client-tool loop: execute → append → send follow-up → repeat.
+///
+/// The host owns protocol-specific HTTP and transcript shape. This runner
+/// owns execute + [ToolCallResult] emit + the loop.
+Stream<StreamChunk> runClientToolFollowUps({
+  required List<EmitToolCall> initialCalls,
+  required ToolCallHandler onToolCall,
+  required void Function(List<ExecutedClientTool> executed) append,
+  required Stream<StreamChunk> Function() sendFollowUp,
+  required List<EmitToolCall> Function() takeCallsAfterRound,
+  required Stream<StreamChunk> Function() finish,
+  bool emitCalls = false,
+  TokenUsage? Function()? usageOf,
+}) async* {
+  var calls = List<EmitToolCall>.from(initialCalls);
+  var shouldEmitCalls = emitCalls;
+  while (calls.isNotEmpty) {
+    final usage = usageOf?.call();
+    final totalTokens = usage?.totalTokens ?? 0;
+    final executed = <ExecutedClientTool>[];
+    if (shouldEmitCalls) {
+      yield* emitToolCalls(calls, usage: usage, totalTokens: totalTokens);
+    }
+    for (final call in calls) {
+      executed.add(
+        ExecutedClientTool(
+          call: call,
+          content: await onToolCall(
+            call.name,
+            call.arguments,
+            toolCallId: call.id,
+          ),
+        ),
+      );
+    }
+    yield* emitToolResults(
+      [
+        for (final item in executed)
+          emitToolResult(
+            id: item.call.id,
+            name: item.call.name,
+            arguments: item.call.arguments,
+            content: item.content,
+            metadata: item.call.metadata,
+          ),
+      ],
+      usage: usage,
+      totalTokens: totalTokens,
+    );
+    append(executed);
+    yield* sendFollowUp();
+    calls = takeCallsAfterRound();
+    shouldEmitCalls = false;
+  }
+  yield* finish();
+}
+
+/// In-round loop used by Claude / Gemini: send (and maybe execute mid-stream),
+/// then append and repeat until [takeCalls] and [continueWithoutCalls] are both
+/// empty/false.
+Stream<StreamChunk> runProviderToolRounds({
+  required Stream<StreamChunk> Function() sendRound,
+  required List<EmitToolCall> Function() takeCalls,
+  required void Function(List<ExecutedClientTool> executed) append,
+  required bool Function() continueWithoutCalls,
+  required Stream<StreamChunk> Function() finish,
+  ToolCallHandler? onToolCall,
+  bool emitCalls = false,
+  bool executeAfterRound = true,
+  TokenUsage? Function()? usageOf,
+}) async* {
+  while (true) {
+    yield* sendRound();
+    final calls = takeCalls();
+    if (calls.isEmpty && !continueWithoutCalls()) {
+      yield* finish();
+      return;
+    }
+    final executed = <ExecutedClientTool>[];
+    if (executeAfterRound && calls.isNotEmpty && onToolCall != null) {
+      final usage = usageOf?.call();
+      final totalTokens = usage?.totalTokens ?? 0;
+      if (emitCalls) {
+        yield* emitToolCalls(calls, usage: usage, totalTokens: totalTokens);
+      }
+      for (final call in calls) {
+        executed.add(
+          ExecutedClientTool(
+            call: call,
+            content: await onToolCall(
+              call.name,
+              call.arguments,
+              toolCallId: call.id,
+            ),
+          ),
+        );
+      }
+      yield* emitToolResults(
+        [
+          for (final item in executed)
+            emitToolResult(
+              id: item.call.id,
+              name: item.call.name,
+              arguments: item.call.arguments,
+              content: item.content,
+              metadata: item.call.metadata,
+            ),
+        ],
+        usage: usage,
+        totalTokens: totalTokens,
+      );
+    }
+    append(executed);
+  }
+}

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -440,267 +440,278 @@ Stream<StreamChunk> _sendClaudeStream(
   );
   TokenUsage? totalUsage;
   var streamRound = 0;
+  var pendingCalls = <EmitToolCall>[];
+  var lastAssistantBlocks = <Map<String, dynamic>>[];
+  var lastStreamResults = <Map<String, dynamic>>[];
+  var lastText = '';
+  var pauseTurn = false;
 
-  while (true) {
-    final omitSamplingParams = _claudeShouldOmitSamplingParams(
-      upstreamModelId,
-      thinkingBudget,
-    );
-    final compatibleTopP = _claudeCompatibleTopP(
-      upstreamModelId,
-      thinkingBudget,
-      topP,
-    );
-    final thinking = isReasoning
-        ? _claudeThinkingConfig(upstreamModelId, thinkingBudget, config: config)
-        : null;
-    final outputConfig = isReasoning
-        ? _claudeOutputConfig(upstreamModelId, thinkingBudget, config: config)
-        : null;
-
-    // Prepare request body per round
-    final body = <String, dynamic>{
-      'model': upstreamModelId,
-      'max_tokens': maxTokens ?? _defaultClaudeMaxOutputTokens(upstreamModelId),
-      'messages': convo,
-      'stream': stream,
-      if (systemPrompt.isNotEmpty) 'system': systemPrompt,
-      if (config.claudePromptCachingEnabled == true)
-        'cache_control': ProviderConfig.claudePromptCacheControl(
-          config.claudePromptCachingTtl,
-        ),
-      if (!omitSamplingParams &&
-          !_isClaudeReasoningEnabled(thinkingBudget) &&
-          temperature != null)
-        'temperature': temperature,
-      if (compatibleTopP != null) 'top_p': compatibleTopP,
-      if (allTools.isNotEmpty) 'tools': allTools,
-      if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
-      if (thinking != null) 'thinking': thinking,
-      if (outputConfig != null) 'output_config': outputConfig,
-    };
-    final extraClaude = _customBody(config, modelId, assistantBody: extraBody);
-    if (extraClaude.isNotEmpty) {
-      body.addAll(extraClaude);
-    }
-
-    final request = http.Request('POST', url);
-    request.headers.addAll(baseHeaders);
-    request.body = jsonEncode(body);
-
-    final response = await client.send(request);
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final errorBody = await response.stream.bytesToString();
-      throw HttpException('HTTP ${response.statusCode}: $errorBody');
-    }
-
-    // Non-streaming path: parse full JSON, handle tool_use, then continue loop if needed.
-    if (!stream) {
-      final txt = await response.stream.bytesToString();
-      final obj = jsonDecode(txt) as Map;
-      // Usage
-      try {
-        final u = (obj['usage'] as Map?)?.cast<String, dynamic>();
-        if (u != null) {
-          totalUsage = (totalUsage ?? const TokenUsage()).merge(
-            _claudeUsageFromMap(u),
-          );
-        }
-      } catch (_) {}
-      final content = (obj['content'] as List?) ?? const <dynamic>[];
-      final List<Map<String, dynamic>> assistantBlocks =
-          <Map<String, dynamic>>[];
-      final Map<String, Map<String, dynamic>> toolUses =
-          <String, Map<String, dynamic>>{}; // id -> {name,args}
-      final buf = StringBuffer();
-      for (final it in content) {
-        if (it is! Map) continue;
-        final type = (it['type'] ?? '').toString();
-        if (type == 'text') {
-          final t = (it['text'] ?? '').toString();
-          if (t.isNotEmpty) {
-            assistantBlocks.add({'type': 'text', 'text': t});
-            buf.write(t);
-          }
-        } else if (type == 'thinking' ||
-            (type == 'redacted_thinking' && !skipRedactedThinkingBlocks)) {
-          // Preserve thinking blocks unmodified for tool-use continuation.
-          // When thinking is enabled, the next request must include the last assistant
-          // message starting with a thinking/redacted_thinking block.
-          try {
-            assistantBlocks.add(
-              Map<String, dynamic>.from(it.cast<String, dynamic>()),
-            );
-          } catch (_) {}
-        } else if (type == 'tool_use') {
-          final id = (it['id'] ?? '').toString();
-          final name = (it['name'] ?? '').toString();
-          final args =
-              (it['input'] as Map?)?.cast<String, dynamic>() ??
-              const <String, dynamic>{};
-          if (id.isNotEmpty) {
-            toolUses[id] = {'name': name, 'args': args};
-            assistantBlocks.add({
-              'type': 'tool_use',
-              'id': id,
-              'name': name,
-              'input': args,
-            });
-          }
-        }
-      }
-      if (toolUses.isNotEmpty && onToolCall != null) {
-        final callInfos = <EmitToolCall>[];
-        for (final e in toolUses.entries) {
-          callInfos.add(
-            emitToolCall(
-              id: e.key,
-              name: (e.value['name'] ?? '').toString(),
-              arguments: (e.value['args'] as Map<String, dynamic>),
-              metadata: {
-                'anthropic': {'assistant_blocks': assistantBlocks},
-              },
-            ),
-          );
-        }
-        yield* emitToolCalls(
-          callInfos,
-          usage: totalUsage,
-          totalTokens: (totalUsage?.totalTokens ?? 0),
-        );
-        final results = <Map<String, dynamic>>[];
-        final resultsInfo = <EmitToolResult>[];
-        for (final e in toolUses.entries) {
-          final name = (e.value['name'] ?? '').toString();
-          final args = (e.value['args'] as Map<String, dynamic>);
-          final res = await onToolCall(name, args, toolCallId: e.key);
-          results.add({
-            'type': 'tool_result',
-            'tool_use_id': e.key,
-            'content': res,
-          });
-          resultsInfo.add(
-            emitToolResult(
-              id: e.key,
-              name: name,
-              arguments: args,
-              content: res,
-              metadata: {
-                'anthropic': {'assistant_blocks': assistantBlocks},
-              },
-            ),
-          );
-        }
-        if (resultsInfo.isNotEmpty) {
-          yield* emitToolResults(
-            resultsInfo,
-            usage: totalUsage,
-            totalTokens: (totalUsage?.totalTokens ?? 0),
-          );
-        }
-        // Extend convo: assistant + user tool_result, loop
-        final assistantMsg = {'role': 'assistant', 'content': assistantBlocks};
-        final userToolMsg = {'role': 'user', 'content': results};
-        convo = [...convo, assistantMsg, userToolMsg];
-        continue; // next round
-      }
-      // No tool use -> return final text
-      yield* emitDone(
-        content: buf.toString(),
-        usage: totalUsage,
-        totalTokens: (totalUsage?.totalTokens ?? 0),
+  yield* runProviderToolRounds(
+    sendRound: () async* {
+      final omitSamplingParams = _claudeShouldOmitSamplingParams(
+        upstreamModelId,
+        thinkingBudget,
       );
-      return;
-    }
+      final compatibleTopP = _claudeCompatibleTopP(
+        upstreamModelId,
+        thinkingBudget,
+        topP,
+      );
+      final thinking = isReasoning
+          ? _claudeThinkingConfig(
+              upstreamModelId,
+              thinkingBudget,
+              config: config,
+            )
+          : null;
+      final outputConfig = isReasoning
+          ? _claudeOutputConfig(upstreamModelId, thinkingBudget, config: config)
+          : null;
 
-    final sse = response.stream.transform(utf8.decoder);
-    final decoder = ClaudeStreamDecoder(
-      skipRedactedThinkingBlocks: skipRedactedThinkingBlocks,
-      sourceId: 'round-${streamRound++}',
-    );
-    final executedToolIds = <String>{};
+      // Prepare request body per round
+      final body = <String, dynamic>{
+        'model': upstreamModelId,
+        'max_tokens':
+            maxTokens ?? _defaultClaudeMaxOutputTokens(upstreamModelId),
+        'messages': convo,
+        'stream': stream,
+        if (systemPrompt.isNotEmpty) 'system': systemPrompt,
+        if (config.claudePromptCachingEnabled == true)
+          'cache_control': ProviderConfig.claudePromptCacheControl(
+            config.claudePromptCachingTtl,
+          ),
+        if (!omitSamplingParams &&
+            !_isClaudeReasoningEnabled(thinkingBudget) &&
+            temperature != null)
+          'temperature': temperature,
+        if (compatibleTopP != null) 'top_p': compatibleTopP,
+        if (allTools.isNotEmpty) 'tools': allTools,
+        if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
+        if (thinking != null) 'thinking': thinking,
+        if (outputConfig != null) 'output_config': outputConfig,
+      };
+      final extraClaude = _customBody(
+        config,
+        modelId,
+        assistantBody: extraBody,
+      );
+      if (extraClaude.isNotEmpty) {
+        body.addAll(extraClaude);
+      }
 
-    await for (final event in parseSseEventStrings(sse)) {
-      _throwIfInBandStreamError(event.data);
-      final decoded = decoder.accept(event);
-      for (final chunk in decoded.chunks) {
-        yield chunk;
-        if (chunk is ToolCallEnd &&
-            decoder.isClientTool(chunk.id) &&
-            onToolCall != null &&
-            executedToolIds.add(chunk.id)) {
-          final tool = decoder.clientTools[chunk.id]!;
-          final args = tool.decodedArguments;
-          final res = await onToolCall(tool.name, args, toolCallId: tool.id);
-          decoder.recordToolResult(tool.id, res);
-          yield* emitToolResults(
-            [
-              emitToolResult(
-                id: tool.id,
-                name: tool.name,
-                arguments: args,
-                content: res,
+      final request = http.Request('POST', url);
+      request.headers.addAll(baseHeaders);
+      request.body = jsonEncode(body);
+
+      final response = await client.send(request);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        final errorBody = await response.stream.bytesToString();
+        throw HttpException('HTTP ${response.statusCode}: $errorBody');
+      }
+
+      pendingCalls = [];
+      lastStreamResults = [];
+      lastText = '';
+      lastAssistantBlocks = [];
+      pauseTurn = false;
+
+      // Non-streaming path: parse full JSON, handle tool_use, then continue loop if needed.
+      if (!stream) {
+        final txt = await response.stream.bytesToString();
+        final obj = jsonDecode(txt) as Map;
+        // Usage
+        try {
+          final u = (obj['usage'] as Map?)?.cast<String, dynamic>();
+          if (u != null) {
+            totalUsage = (totalUsage ?? const TokenUsage()).merge(
+              _claudeUsageFromMap(u),
+            );
+          }
+        } catch (_) {}
+        final content = (obj['content'] as List?) ?? const <dynamic>[];
+        final List<Map<String, dynamic>> assistantBlocks =
+            <Map<String, dynamic>>[];
+        final Map<String, Map<String, dynamic>> toolUses =
+            <String, Map<String, dynamic>>{}; // id -> {name,args}
+        final buf = StringBuffer();
+        for (final it in content) {
+          if (it is! Map) continue;
+          final type = (it['type'] ?? '').toString();
+          if (type == 'text') {
+            final t = (it['text'] ?? '').toString();
+            if (t.isNotEmpty) {
+              assistantBlocks.add({'type': 'text', 'text': t});
+              buf.write(t);
+            }
+          } else if (type == 'thinking' ||
+              (type == 'redacted_thinking' && !skipRedactedThinkingBlocks)) {
+            // Preserve thinking blocks unmodified for tool-use continuation.
+            // When thinking is enabled, the next request must include the last assistant
+            // message starting with a thinking/redacted_thinking block.
+            try {
+              assistantBlocks.add(
+                Map<String, dynamic>.from(it.cast<String, dynamic>()),
+              );
+            } catch (_) {}
+          } else if (type == 'tool_use') {
+            final id = (it['id'] ?? '').toString();
+            final name = (it['name'] ?? '').toString();
+            final args =
+                (it['input'] as Map?)?.cast<String, dynamic>() ??
+                const <String, dynamic>{};
+            if (id.isNotEmpty) {
+              toolUses[id] = {'name': name, 'args': args};
+              assistantBlocks.add({
+                'type': 'tool_use',
+                'id': id,
+                'name': name,
+                'input': args,
+              });
+            }
+          }
+        }
+        lastAssistantBlocks = assistantBlocks;
+        lastText = buf.toString();
+        if (toolUses.isNotEmpty && onToolCall != null) {
+          pendingCalls = [
+            for (final e in toolUses.entries)
+              emitToolCall(
+                id: e.key,
+                name: (e.value['name'] ?? '').toString(),
+                arguments: (e.value['args'] as Map<String, dynamic>),
                 metadata: {
-                  'anthropic': {'assistant_blocks': decoder.assistantBlocks},
+                  'anthropic': {'assistant_blocks': assistantBlocks},
                 },
               ),
-            ],
-            usage: decoder.usage,
-            totalTokens: decoder.usage?.totalTokens ?? 0,
+          ];
+        }
+        return;
+      }
+
+      final sse = response.stream.transform(utf8.decoder);
+      final decoder = ClaudeStreamDecoder(
+        skipRedactedThinkingBlocks: skipRedactedThinkingBlocks,
+        sourceId: 'round-${streamRound++}',
+      );
+      final executedToolIds = <String>{};
+
+      await for (final event in parseSseEventStrings(sse)) {
+        _throwIfInBandStreamError(event.data);
+        final decoded = decoder.accept(event);
+        for (final chunk in decoded.chunks) {
+          yield chunk;
+          if (chunk is ToolCallEnd &&
+              decoder.isClientTool(chunk.id) &&
+              onToolCall != null &&
+              executedToolIds.add(chunk.id)) {
+            final tool = decoder.clientTools[chunk.id]!;
+            final args = tool.decodedArguments;
+            final call = emitToolCall(
+              id: tool.id,
+              name: tool.name,
+              arguments: args,
+              metadata: {
+                'anthropic': {'assistant_blocks': decoder.assistantBlocks},
+              },
+            );
+            await for (final resultChunk in executeClientTools(
+              calls: [call],
+              onToolCall: onToolCall,
+              usage: decoder.usage,
+              totalTokens: decoder.usage?.totalTokens ?? 0,
+            )) {
+              if (resultChunk is ToolCallResult) {
+                decoder.recordToolResult(
+                  tool.id,
+                  (resultChunk.output ?? '').toString(),
+                );
+              }
+              yield resultChunk;
+            }
+          }
+        }
+        if (decoded.completed) break;
+      }
+      for (final chunk in decoder.onClosed()) {
+        yield chunk;
+      }
+
+      final usage = decoder.usage;
+      final assistantBlocks = decoder.assistantBlocks;
+      final lastStopReason = decoder.lastStopReason;
+      final toolResultsContent = decoder.toolResults;
+
+      if (usage != null) {
+        totalUsage = (totalUsage ?? const TokenUsage()).merge(usage);
+      }
+
+      lastAssistantBlocks = assistantBlocks;
+      if (decoder.clientTools.isEmpty) {
+        pauseTurn = (lastStopReason ?? '') == 'pause_turn';
+        return;
+      }
+
+      pendingCalls = [
+        for (final tool in decoder.clientTools.values)
+          emitToolCall(
+            id: tool.id,
+            name: tool.name,
+            arguments: tool.decodedArguments,
+            metadata: {
+              'anthropic': {'assistant_blocks': assistantBlocks},
+            },
+          ),
+      ];
+      for (final tool in decoder.clientTools.values) {
+        var res = toolResultsContent[tool.id] ?? '';
+        if (res.isEmpty && onToolCall != null) {
+          res = await onToolCall(
+            tool.name,
+            tool.decodedArguments,
+            toolCallId: tool.id,
           );
         }
+        lastStreamResults.add({
+          'type': 'tool_result',
+          'tool_use_id': tool.id,
+          if (res.isNotEmpty) 'content': res,
+        });
       }
-      if (decoded.completed) break;
-    }
-    for (final chunk in decoder.onClosed()) {
-      yield chunk;
-    }
-
-    final usage = decoder.usage;
-    final roundTokens = usage?.totalTokens ?? 0;
-    final assistantBlocks = decoder.assistantBlocks;
-    final lastStopReason = decoder.lastStopReason;
-    final toolResultsContent = decoder.toolResults;
-
-    if (usage != null) {
-      totalUsage = (totalUsage ?? const TokenUsage()).merge(usage);
-    }
-
-    if (decoder.clientTools.isEmpty) {
-      final sr = lastStopReason ?? '';
-      if (sr == 'pause_turn') {
+    },
+    takeCalls: () => pendingCalls,
+    continueWithoutCalls: () => pauseTurn,
+    executeAfterRound: !stream,
+    emitCalls: !stream,
+    onToolCall: onToolCall,
+    append: (executed) {
+      if (pauseTurn) {
         convo = [
           ...convo,
-          {'role': 'assistant', 'content': assistantBlocks},
+          {'role': 'assistant', 'content': lastAssistantBlocks},
         ];
-        continue;
+        return;
       }
-      yield* emitDone(
-        usage: totalUsage ?? usage,
-        totalTokens: (totalUsage?.totalTokens ?? roundTokens),
-      );
-      return;
-    }
-
-    final toolResultsBlocks = <Map<String, dynamic>>[];
-    for (final tool in decoder.clientTools.values) {
-      final args = tool.decodedArguments;
-      var res = toolResultsContent[tool.id] ?? '';
-      if (res.isEmpty && onToolCall != null) {
-        res = await onToolCall(tool.name, args, toolCallId: tool.id);
-      }
-      toolResultsBlocks.add({
-        'type': 'tool_result',
-        'tool_use_id': tool.id,
-        if (res.isNotEmpty) 'content': res,
-      });
-    }
-
-    convo = [
-      ...convo,
-      {'role': 'assistant', 'content': assistantBlocks},
-      {'role': 'user', 'content': toolResultsBlocks},
-    ];
-    // Loop to next round; the next response will stream more assistant content
-  }
+      final results = stream
+          ? lastStreamResults
+          : [
+              for (final item in executed)
+                <String, dynamic>{
+                  'type': 'tool_result',
+                  'tool_use_id': item.call.id,
+                  'content': item.content,
+                },
+            ];
+      convo = [
+        ...convo,
+        {'role': 'assistant', 'content': lastAssistantBlocks},
+        {'role': 'user', 'content': results},
+      ];
+    },
+    finish: () => emitDone(
+      content: lastText,
+      usage: totalUsage,
+      totalTokens: totalUsage?.totalTokens ?? 0,
+    ),
+    usageOf: () => totalUsage,
+  );
 }

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -667,202 +667,189 @@ Stream<StreamChunk> _sendGoogleStream(
     TokenUsage? totalUsage;
     List<Map<String, dynamic>> currentContents =
         List<Map<String, dynamic>>.from(contents);
-    while (true) {
-      final req = http.Request('POST', Uri.parse(url));
-      req.headers.addAll(headers);
-      final body = Map<String, dynamic>.from(baseBody);
-      body['contents'] = _googleApiContents(currentContents);
-      req.body = jsonEncode(body);
-      final resp = await client.send(req);
-      if (resp.statusCode < 200 || resp.statusCode >= 300) {
-        final errorBody = await resp.stream.bytesToString();
-        throw HttpException('HTTP ${resp.statusCode}: $errorBody');
-      }
-      final txt = await resp.stream.bytesToString();
-      final obj = jsonDecode(txt) as Map<String, dynamic>;
-      try {
-        final u = (obj['usageMetadata'] as Map?)?.cast<String, dynamic>();
-        if (u != null) {
-          final prompt = (u['promptTokenCount'] ?? 0) as int? ?? 0;
-          final completion = (u['candidatesTokenCount'] ?? 0) as int? ?? 0;
-          totalUsage = (totalUsage ?? const TokenUsage()).merge(
-            TokenUsage(
-              promptTokens: prompt,
-              completionTokens: completion,
-              cachedTokens: 0,
-            ),
-          );
+    var pendingCalls = <EmitToolCall>[];
+    var lastParts = <dynamic>[];
+    var lastFunctionCallParts = <dynamic>[];
+    var lastText = '';
+
+    yield* runProviderToolRounds(
+      sendRound: () async* {
+        pendingCalls = [];
+        lastParts = [];
+        lastFunctionCallParts = [];
+        lastText = '';
+        final req = http.Request('POST', Uri.parse(url));
+        req.headers.addAll(headers);
+        final body = Map<String, dynamic>.from(baseBody);
+        body['contents'] = _googleApiContents(currentContents);
+        req.body = jsonEncode(body);
+        final resp = await client.send(req);
+        if (resp.statusCode < 200 || resp.statusCode >= 300) {
+          final errorBody = await resp.stream.bytesToString();
+          throw HttpException('HTTP ${resp.statusCode}: $errorBody');
         }
-      } catch (_) {}
-      final candidates = (obj['candidates'] as List?) ?? const <dynamic>[];
-      if (candidates.isEmpty) {
-        yield* emitDone(
-          usage: totalUsage,
-          totalTokens: totalUsage?.totalTokens ?? 0,
-        );
-        return;
-      }
-      final cand = (candidates.first as Map).cast<String, dynamic>();
-      final parts = (cand['content']?['parts'] as List?) ?? const <dynamic>[];
-      final functionCallParts = parts
-          .where((e) => e is Map && e.containsKey('functionCall'))
-          .toList();
-      if (functionCallParts.isNotEmpty && onToolCall != null) {
-        final responseParts = <Map<String, dynamic>>[];
-        for (int idx = 0; idx < functionCallParts.length; idx++) {
-          final fc = functionCallParts[idx] as Map;
-          final call = (fc['functionCall'] as Map).cast<String, dynamic>();
-          final name = (call['name'] ?? '').toString();
-          final args =
-              (call['args'] as Map?)?.cast<String, dynamic>() ??
-              const <String, dynamic>{};
-          // Prefer API-provided functionCall id, fall back to synthetic.
-          final partId = _effectiveToolCallId(call['id'], 'fn', idx);
-          // Preserve the raw part (incl. thoughtSignature) so the tool event
-          // metadata can replay this model turn exactly on later requests.
-          final rawPart = fc.cast<String, dynamic>();
-          String? thoughtSigKey;
-          dynamic thoughtSigVal;
-          if (fc.containsKey('thoughtSignature')) {
-            thoughtSigKey = 'thoughtSignature';
-            thoughtSigVal = fc['thoughtSignature'];
-          } else if (fc.containsKey('thought_signature')) {
-            thoughtSigKey = 'thought_signature';
-            thoughtSigVal = fc['thought_signature'];
+        final txt = await resp.stream.bytesToString();
+        final obj = jsonDecode(txt) as Map<String, dynamic>;
+        try {
+          final u = (obj['usageMetadata'] as Map?)?.cast<String, dynamic>();
+          if (u != null) {
+            final prompt = (u['promptTokenCount'] ?? 0) as int? ?? 0;
+            final completion = (u['candidatesTokenCount'] ?? 0) as int? ?? 0;
+            totalUsage = (totalUsage ?? const TokenUsage()).merge(
+              TokenUsage(
+                promptTokens: prompt,
+                completionTokens: completion,
+                cachedTokens: 0,
+              ),
+            );
           }
-          final googleMetadata = <String, dynamic>{
-            'google': {
-              'part': rawPart,
-              if (thoughtSigKey != null && thoughtSigVal != null)
-                'thoughtSigKey': thoughtSigKey,
-              if (thoughtSigKey != null && thoughtSigVal != null)
-                'thoughtSigVal': thoughtSigVal,
-            },
-          };
-          yield* emitToolCalls(
-            [
-              emitToolCall(
-                id: partId,
-                name: name,
-                arguments: args,
-                metadata: googleMetadata,
-              ),
-            ],
-            usage: totalUsage,
-            totalTokens: totalUsage?.totalTokens ?? 0,
-          );
-          final res = await onToolCall(name, args, toolCallId: partId);
-          yield* emitToolResults(
-            [
-              emitToolResult(
-                id: partId,
-                name: name,
-                arguments: args,
-                content: res,
-                metadata: googleMetadata,
-              ),
-            ],
-            usage: totalUsage,
-            totalTokens: totalUsage?.totalTokens ?? 0,
-          );
-          final frPart = <String, dynamic>{
-            'functionResponse': {
-              'name': name,
-              'response': {'result': res},
-              if (call.containsKey('id')) 'id': call['id'],
-            },
-          };
-          responseParts.add(frPart);
+        } catch (_) {}
+        final candidates = (obj['candidates'] as List?) ?? const <dynamic>[];
+        if (candidates.isEmpty) return;
+        final cand = (candidates.first as Map).cast<String, dynamic>();
+        final parts = (cand['content']?['parts'] as List?) ?? const <dynamic>[];
+        final functionCallParts = parts
+            .where((e) => e is Map && e.containsKey('functionCall'))
+            .toList();
+        lastParts = parts;
+        lastFunctionCallParts = functionCallParts;
+        if (functionCallParts.isNotEmpty && onToolCall != null) {
+          pendingCalls = [
+            for (var idx = 0; idx < functionCallParts.length; idx++)
+              () {
+                final fc = functionCallParts[idx] as Map;
+                final call = (fc['functionCall'] as Map)
+                    .cast<String, dynamic>();
+                String? thoughtSigKey;
+                dynamic thoughtSigVal;
+                if (fc.containsKey('thoughtSignature')) {
+                  thoughtSigKey = 'thoughtSignature';
+                  thoughtSigVal = fc['thoughtSignature'];
+                } else if (fc.containsKey('thought_signature')) {
+                  thoughtSigKey = 'thought_signature';
+                  thoughtSigVal = fc['thought_signature'];
+                }
+                return emitToolCall(
+                  id: _effectiveToolCallId(call['id'], 'fn', idx),
+                  name: (call['name'] ?? '').toString(),
+                  arguments:
+                      (call['args'] as Map?)?.cast<String, dynamic>() ??
+                      const <String, dynamic>{},
+                  metadata: {
+                    'google': {
+                      'part': fc.cast<String, dynamic>(),
+                      if (thoughtSigKey != null && thoughtSigVal != null)
+                        'thoughtSigKey': thoughtSigKey,
+                      if (thoughtSigKey != null && thoughtSigVal != null)
+                        'thoughtSigVal': thoughtSigVal,
+                    },
+                  },
+                );
+              }(),
+          ];
+          return;
         }
-        currentContents = [
-          ...currentContents,
-          // Pass ALL parts from model response (preserves server-side tool parts,
-          // thought signatures, and other fields)
-          {'role': 'model', 'parts': parts},
-          {'role': 'user', 'parts': responseParts},
-        ];
-        continue;
-      }
-      // Emit server-side code execution parts as tool cards.
-      // Assumes executableCode and codeExecutionResult alternate in 1:1 pairs
-      // (matching current Gemini API behavior).
-      int codeExecIdx = 0;
-      for (final p in parts) {
-        if (p is! Map) continue;
-        final ec = p['executableCode'] ?? p['executable_code'];
-        if (ec is Map) {
-          final lang = (ec['language'] ?? '').toString().toLowerCase();
-          final code = (ec['code'] ?? '').toString();
-          if (code.isNotEmpty) {
-            final ceId = 'code_exec_$codeExecIdx';
-            codeExecIdx++;
-            yield* emitToolCalls(
-              [
-                emitToolCall(
-                  id: ceId,
-                  name: 'code_execution',
-                  arguments: {'language': lang, 'code': code},
-                ),
-              ],
-              usage: totalUsage,
-              totalTokens: totalUsage?.totalTokens ?? 0,
+        // Provider-hosted code execution stays on ServerTool*, not ToolCallResult.
+        var codeExecIdx = 0;
+        for (final p in parts) {
+          if (p is! Map) continue;
+          final ec = p['executableCode'] ?? p['executable_code'];
+          if (ec is Map) {
+            final lang = (ec['language'] ?? '').toString().toLowerCase();
+            final code = (ec['code'] ?? '').toString();
+            if (code.isNotEmpty) {
+              final ceId = 'code_exec_$codeExecIdx';
+              codeExecIdx++;
+              yield ToolCallStart(id: ceId, toolName: 'code_execution');
+              yield ToolCallDelta(
+                id: ceId,
+                inputDelta: jsonEncode({'language': lang, 'code': code}),
+              );
+              yield ToolCallEnd(ceId);
+            }
+          }
+          final cr = p['codeExecutionResult'] ?? p['code_execution_result'];
+          if (cr is Map) {
+            final outcome = (cr['outcome'] ?? '').toString();
+            final output = (cr['output'] ?? '').toString();
+            final resultId = codeExecIdx > 0
+                ? 'code_exec_${codeExecIdx - 1}'
+                : 'code_exec_0';
+            yield ServerToolStart(id: resultId, toolName: 'code_execution');
+            yield ServerToolEnd(
+              id: resultId,
+              output: output.isEmpty ? outcome : output,
             );
           }
         }
-        final cr = p['codeExecutionResult'] ?? p['code_execution_result'];
-        if (cr is Map) {
-          final outcome = (cr['outcome'] ?? '').toString();
-          final output = (cr['output'] ?? '').toString();
-          final resultId = codeExecIdx > 0
-              ? 'code_exec_${codeExecIdx - 1}'
-              : 'code_exec_0';
-          yield* emitToolResults(
-            [
-              emitToolResult(
-                id: resultId,
-                name: 'code_execution',
-                arguments: const <String, dynamic>{},
-                content: output.isEmpty ? outcome : output,
-              ),
-            ],
+        final buf = StringBuffer();
+        final reasoningBuf = StringBuffer();
+        for (final p in parts) {
+          if (p is! Map) continue;
+          final text = p['text'];
+          if (text is! String || text.isEmpty) continue;
+          final thought = p['thought'] as bool? ?? false;
+          if (thought) {
+            reasoningBuf.write(text);
+          } else {
+            buf.write(text);
+          }
+        }
+        final reasoningStr = reasoningBuf.toString();
+        if (reasoningStr.isNotEmpty) {
+          yield* emitDelta(
+            reasoning: reasoningStr,
             usage: totalUsage,
             totalTokens: totalUsage?.totalTokens ?? 0,
           );
         }
-      }
-      final buf = StringBuffer();
-      final reasoningBuf = StringBuffer();
-      for (final p in parts) {
-        if (p is! Map) continue;
-        final text = p['text'];
-        if (text is! String || text.isEmpty) continue;
-        final thought = p['thought'] as bool? ?? false;
-        if (thought) {
-          reasoningBuf.write(text);
-        } else {
-          buf.write(text);
+        var contentStr = buf.toString();
+        if (persistGeminiThoughtSigs) {
+          final metaComment = _collectThoughtSigCommentFromParts(parts);
+          if (metaComment.isNotEmpty) contentStr += metaComment;
         }
-      }
-      final reasoningStr = reasoningBuf.toString();
-      if (reasoningStr.isNotEmpty) {
-        yield* emitDelta(
-          reasoning: reasoningStr,
-          usage: totalUsage,
-          totalTokens: totalUsage?.totalTokens ?? 0,
-        );
-      }
-      var contentStr = buf.toString();
-      if (persistGeminiThoughtSigs) {
-        final metaComment = _collectThoughtSigCommentFromParts(parts);
-        if (metaComment.isNotEmpty) contentStr += metaComment;
-      }
-      yield* emitDone(
-        content: contentStr,
+        lastText = contentStr;
+      },
+      takeCalls: () => pendingCalls,
+      continueWithoutCalls: () => false,
+      executeAfterRound: true,
+      emitCalls: true,
+      onToolCall: onToolCall,
+      append: (executed) {
+        currentContents = [
+          ...currentContents,
+          {'role': 'model', 'parts': lastParts},
+          {
+            'role': 'user',
+            'parts': [
+              for (var i = 0; i < executed.length; i++)
+                <String, dynamic>{
+                  'functionResponse': {
+                    'name': executed[i].call.name,
+                    'response': {'result': executed[i].content},
+                    if (i < lastFunctionCallParts.length &&
+                        lastFunctionCallParts[i] is Map &&
+                        ((lastFunctionCallParts[i] as Map)['functionCall']
+                                    as Map?)
+                                ?.containsKey('id') ==
+                            true)
+                      'id':
+                          ((lastFunctionCallParts[i] as Map)['functionCall']
+                              as Map)['id'],
+                  },
+                },
+            ],
+          },
+        ];
+      },
+      finish: () => emitDone(
+        content: lastText,
         usage: totalUsage,
         totalTokens: totalUsage?.totalTokens ?? 0,
-      );
-      return;
-    }
+      ),
+      usageOf: () => totalUsage,
+    );
+    return;
   }
 
   // Implement SSE streaming via :streamGenerateContent with alt=sse
@@ -1106,295 +1093,325 @@ Stream<StreamChunk> _sendGoogleStream(
   final List<Map<String, dynamic>> builtinCitations = <Map<String, dynamic>>[];
   int malformedResponseRetryCount = 0;
   var streamRound = 0;
+  var pendingCalls = <EmitToolCall>[];
+  var lastRoundCalls = <Map<String, dynamic>>[];
+  var lastRoundModelParts = <dynamic>[];
+  var retryMalformed = false;
 
-  while (true) {
-    final defaultMaxOutputTokens = _defaultGeminiMaxOutputTokens(
-      upstreamModelId,
-    );
-    final omitSamplingParams = _shouldOmitGeminiSamplingParams(upstreamModelId);
-    final gen = <String, dynamic>{
-      if (!omitSamplingParams && temperature != null)
-        'temperature': temperature,
-      if (!omitSamplingParams && topP != null) 'topP': topP,
-      if (maxTokens ?? defaultMaxOutputTokens case final resolvedMaxTokens?)
-        'maxOutputTokens': resolvedMaxTokens,
-      // Enable IMAGE+TEXT output modalities when model is configured to output images
-      if (wantsImageOutput) 'responseModalities': ['TEXT', 'IMAGE'],
-      if (isReasoning)
-        ...() {
-          final thinkingConfig = _googleThinkingConfig(
-            upstreamModelId,
-            thinkingBudget,
-          );
-          if (thinkingConfig.isEmpty) return const <String, dynamic>{};
-          return {'thinkingConfig': thinkingConfig};
-        }(),
-    };
-    final body = <String, dynamic>{
-      'contents': convo,
-      if (systemPrompt.isNotEmpty)
-        'systemInstruction': {
-          'parts': [
-            {'text': systemPrompt},
-          ],
-        },
-      if (gen.isNotEmpty) 'generationConfig': gen,
-      if (toolsArr.isNotEmpty) 'tools': toolsArr,
-      if (geminiToolConfig != null) 'toolConfig': geminiToolConfig,
-    };
+  yield* runProviderToolRounds(
+    sendRound: () async* {
+      pendingCalls = [];
+      lastRoundCalls = [];
+      lastRoundModelParts = [];
+      retryMalformed = false;
+      final defaultMaxOutputTokens = _defaultGeminiMaxOutputTokens(
+        upstreamModelId,
+      );
+      final omitSamplingParams = _shouldOmitGeminiSamplingParams(
+        upstreamModelId,
+      );
+      final gen = <String, dynamic>{
+        if (!omitSamplingParams && temperature != null)
+          'temperature': temperature,
+        if (!omitSamplingParams && topP != null) 'topP': topP,
+        if (maxTokens ?? defaultMaxOutputTokens case final resolvedMaxTokens?)
+          'maxOutputTokens': resolvedMaxTokens,
+        // Enable IMAGE+TEXT output modalities when model is configured to output images
+        if (wantsImageOutput) 'responseModalities': ['TEXT', 'IMAGE'],
+        if (isReasoning)
+          ...() {
+            final thinkingConfig = _googleThinkingConfig(
+              upstreamModelId,
+              thinkingBudget,
+            );
+            if (thinkingConfig.isEmpty) return const <String, dynamic>{};
+            return {'thinkingConfig': thinkingConfig};
+          }(),
+      };
+      final body = <String, dynamic>{
+        'contents': convo,
+        if (systemPrompt.isNotEmpty)
+          'systemInstruction': {
+            'parts': [
+              {'text': systemPrompt},
+            ],
+          },
+        if (gen.isNotEmpty) 'generationConfig': gen,
+        if (toolsArr.isNotEmpty) 'tools': toolsArr,
+        if (geminiToolConfig != null) 'toolConfig': geminiToolConfig,
+      };
 
-    final request = http.Request('POST', uri);
-    final requestHeaders = <String, String>{
-      'Content-Type': 'application/json',
-      'Accept': 'text/event-stream',
-    };
-    if (config.vertexAI == true) {
-      final token = await _maybeVertexAccessToken(config);
-      if (token != null && token.isNotEmpty) {
-        requestHeaders['Authorization'] = 'Bearer $token';
-      }
-      final proj = (config.projectId ?? '').trim();
-      if (proj.isNotEmpty) requestHeaders['X-Goog-User-Project'] = proj;
-    } else {
-      final apiKey = _effectiveApiKey(config);
-      if (apiKey.isNotEmpty) {
-        requestHeaders['x-goog-api-key'] = apiKey;
-      }
-    }
-    final headers = _customHeaders(
-      config,
-      modelId,
-      baseHeaders: requestHeaders,
-      assistantHeaders: extraHeaders,
-    );
-    request.headers.addAll(headers);
-    final extra = _customBody(config, modelId, assistantBody: extraBody);
-    if (extra.isNotEmpty) {
-      body.addAll(extra);
-    }
-    body['contents'] = _googleApiContents(convo);
-    request.body = jsonEncode(body);
-
-    final resp = await client.send(request);
-    if (resp.statusCode < 200 || resp.statusCode >= 300) {
-      final errorBody = await resp.stream.bytesToString();
-      throw HttpException('HTTP ${resp.statusCode}: $errorBody');
-    }
-
-    final sse = resp.stream.transform(utf8.decoder);
-    final decoder = GoogleStreamDecoder(
-      isGemini3: isGemini3,
-      persistThoughtSigs: persistGeminiThoughtSigs,
-      expectImage: expectImage,
-      receivedImage: receivedImage,
-      initialUsage: usage,
-      citations: builtinCitations,
-      sourceId: 'round-${streamRound++}',
-    );
-    Future<String> sanitizeTextIfNeeded(String input) async {
-      if (input.isEmpty) return input;
-      if (input.contains('data:image') && input.contains('base64,')) {
-        try {
-          return await MarkdownMediaSanitizer.replaceInlineBase64Images(input);
-        } catch (_) {
-          return input;
+      final request = http.Request('POST', uri);
+      final requestHeaders = <String, String>{
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+      };
+      if (config.vertexAI == true) {
+        final token = await _maybeVertexAccessToken(config);
+        if (token != null && token.isNotEmpty) {
+          requestHeaders['Authorization'] = 'Bearer $token';
+        }
+        final proj = (config.projectId ?? '').trim();
+        if (proj.isNotEmpty) requestHeaders['X-Goog-User-Project'] = proj;
+      } else {
+        final apiKey = _effectiveApiKey(config);
+        if (apiKey.isNotEmpty) {
+          requestHeaders['x-goog-api-key'] = apiKey;
         }
       }
-      return input;
-    }
-
-    Future<String> takeBufferedImageMarkdown() async {
-      final pending = decoder.takeBufferedImage();
-      if (pending == null) return '';
-      final path = await AppDirectories.saveBase64Image(
-        pending.mimeType,
-        pending.data,
+      final headers = _customHeaders(
+        config,
+        modelId,
+        baseHeaders: requestHeaders,
+        assistantHeaders: extraHeaders,
       );
-      if (path == null || path.isEmpty) return '';
-      final uri = SandboxPathResolver.canonicalize(path);
-      final sb = StringBuffer()
-        ..write('\n\n![image](')
-        ..write(uri)
-        ..write(')');
-      if (pending.trailingText.isNotEmpty) {
-        sb.write(pending.trailingText);
+      request.headers.addAll(headers);
+      final extra = _customBody(config, modelId, assistantBody: extraBody);
+      if (extra.isNotEmpty) {
+        body.addAll(extra);
       }
-      return sb.toString();
-    }
+      body['contents'] = _googleApiContents(convo);
+      request.body = jsonEncode(body);
 
-    await for (final event in parseSseEventStrings(sse)) {
-      final data = event.data;
-      if (data.isEmpty) continue;
-      // Gemini can deliver {"error":{code,message,status}}, a prompt-level
-      // block, or a candidate-level content-filter finish in-band on a 2xx
-      // stream; raise before the malformed-chunk guard below can swallow it.
-      _throwIfInBandStreamError(data);
-      _throwIfGeminiPromptBlocked(data);
-      _throwIfGeminiCandidateBlocked(data);
-      final decoded = decoder.accept(event);
-      for (final remote in decoder.takePendingRemoteImages()) {
-        try {
-          final b64 = await _downloadRemoteAsBase64(client, config, remote.uri);
-          for (final chunk in decoder.ingestImageData(
-            remote.mimeType,
-            b64,
-            thoughtSigKey: remote.thoughtSigKey,
-            thoughtSigVal: remote.thoughtSigVal,
-          )) {
-            yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
-          }
-        } catch (_) {}
+      final resp = await client.send(request);
+      if (resp.statusCode < 200 || resp.statusCode >= 300) {
+        final errorBody = await resp.stream.bytesToString();
+        throw HttpException('HTTP ${resp.statusCode}: $errorBody');
       }
-      for (final chunk in decoder.takeOrphanedTrailingText()) {
-        yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
-      }
-      for (final chunk in decoded.chunks) {
-        yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
-        if (chunk is ToolCallEnd &&
-            decoder.isClientFunctionCall(chunk.id) &&
-            onToolCall != null) {
-          final call = decoder.functionCallById(chunk.id)!;
-          if (call.result.isEmpty) {
-            final resText = await onToolCall(
-              call.name,
-              call.args,
-              toolCallId: call.id,
+
+      final sse = resp.stream.transform(utf8.decoder);
+      final decoder = GoogleStreamDecoder(
+        isGemini3: isGemini3,
+        persistThoughtSigs: persistGeminiThoughtSigs,
+        expectImage: expectImage,
+        receivedImage: receivedImage,
+        initialUsage: usage,
+        citations: builtinCitations,
+        sourceId: 'round-${streamRound++}',
+      );
+      Future<String> sanitizeTextIfNeeded(String input) async {
+        if (input.isEmpty) return input;
+        if (input.contains('data:image') && input.contains('base64,')) {
+          try {
+            return await MarkdownMediaSanitizer.replaceInlineBase64Images(
+              input,
             );
-            call.result = resText;
-            yield* emitToolResults(
-              [
-                emitToolResult(
-                  id: call.id,
-                  name: call.name,
-                  arguments: call.args,
-                  content: resText,
-                  metadata: {
-                    'google': {
-                      'part': call.part,
-                      if (call.thoughtSigKey != null &&
-                          call.thoughtSigVal != null)
-                        'thoughtSigKey': call.thoughtSigKey,
-                      if (call.thoughtSigKey != null &&
-                          call.thoughtSigVal != null)
-                        'thoughtSigVal': call.thoughtSigVal,
-                    },
+          } catch (_) {
+            return input;
+          }
+        }
+        return input;
+      }
+
+      Future<String> takeBufferedImageMarkdown() async {
+        final pending = decoder.takeBufferedImage();
+        if (pending == null) return '';
+        final path = await AppDirectories.saveBase64Image(
+          pending.mimeType,
+          pending.data,
+        );
+        if (path == null || path.isEmpty) return '';
+        final uri = SandboxPathResolver.canonicalize(path);
+        final sb = StringBuffer()
+          ..write('\n\n![image](')
+          ..write(uri)
+          ..write(')');
+        if (pending.trailingText.isNotEmpty) {
+          sb.write(pending.trailingText);
+        }
+        return sb.toString();
+      }
+
+      await for (final event in parseSseEventStrings(sse)) {
+        final data = event.data;
+        if (data.isEmpty) continue;
+        // Gemini can deliver {"error":{code,message,status}}, a prompt-level
+        // block, or a candidate-level content-filter finish in-band on a 2xx
+        // stream; raise before the malformed-chunk guard below can swallow it.
+        _throwIfInBandStreamError(data);
+        _throwIfGeminiPromptBlocked(data);
+        _throwIfGeminiCandidateBlocked(data);
+        final decoded = decoder.accept(event);
+        for (final remote in decoder.takePendingRemoteImages()) {
+          try {
+            final b64 = await _downloadRemoteAsBase64(
+              client,
+              config,
+              remote.uri,
+            );
+            for (final chunk in decoder.ingestImageData(
+              remote.mimeType,
+              b64,
+              thoughtSigKey: remote.thoughtSigKey,
+              thoughtSigVal: remote.thoughtSigVal,
+            )) {
+              yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
+            }
+          } catch (_) {}
+        }
+        for (final chunk in decoder.takeOrphanedTrailingText()) {
+          yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
+        }
+        for (final chunk in decoded.chunks) {
+          yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
+          if (chunk is ToolCallEnd &&
+              decoder.isClientFunctionCall(chunk.id) &&
+              onToolCall != null) {
+            final call = decoder.functionCallById(chunk.id)!;
+            if (call.result.isEmpty) {
+              final emitCall = emitToolCall(
+                id: call.id,
+                name: call.name,
+                arguments: call.args,
+                metadata: {
+                  'google': {
+                    'part': call.part,
+                    if (call.thoughtSigKey != null &&
+                        call.thoughtSigVal != null)
+                      'thoughtSigKey': call.thoughtSigKey,
+                    if (call.thoughtSigKey != null &&
+                        call.thoughtSigVal != null)
+                      'thoughtSigVal': call.thoughtSigVal,
                   },
-                ),
-              ],
-              usage: decoder.usage,
-              totalTokens: decoder.usage?.totalTokens ?? 0,
-            );
+                },
+              );
+              await for (final resultChunk in executeClientTools(
+                calls: [emitCall],
+                onToolCall: onToolCall,
+                usage: decoder.usage,
+                totalTokens: decoder.usage?.totalTokens ?? 0,
+              )) {
+                if (resultChunk is ToolCallResult) {
+                  call.result = (resultChunk.output ?? '').toString();
+                }
+                yield resultChunk;
+              }
+            }
           }
         }
+        if (decoded.completed || decoder.canFinishNow) break;
       }
-      if (decoded.completed || decoder.canFinishNow) break;
-    }
-    for (final chunk in decoder.onClosed()) {
-      yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
-    }
-
-    receivedImage = decoder.receivedImage;
-    usage = decoder.usage ?? usage;
-    totalTokens = usage?.totalTokens ?? totalTokens;
-    final calls = [
-      for (final call in decoder.functionCalls)
-        <String, dynamic>{
-          'id': call.id,
-          'apiId': call.apiId,
-          'name': call.name,
-          'args': call.args,
-          'result': call.result,
-          'thoughtSigKey': call.thoughtSigKey,
-          'thoughtSigVal': call.thoughtSigVal,
-          'part': call.part,
-        },
-    ];
-    final roundModelParts = decoder.roundModelParts;
-    final retryMalformedResponse = decoder.retryMalformedResponse;
-    final responseTextThoughtSigKey = decoder.textThoughtSigKey;
-    final responseTextThoughtSigVal = decoder.textThoughtSigVal;
-    final responseImageThoughtSigs = decoder.imageThoughtSigs;
-
-    if (retryMalformedResponse) {
-      // This is a transient model-generation failure, so retry the unchanged
-      // round once without adding the malformed candidate to conversation.
-      if (malformedResponseRetryCount == 0) {
-        malformedResponseRetryCount++;
-        continue;
+      for (final chunk in decoder.onClosed()) {
+        yield await _sanitizeStreamChunk(chunk, sanitizeTextIfNeeded);
       }
-      throw const HttpException(
-        'Gemini response generation failed (MALFORMED_RESPONSE)',
-      );
-    }
 
-    // Flush any buffered inline image that never became Image* events.
-    if (!decoder.emittedImageEvents) {
-      final pendingImage = await takeBufferedImageMarkdown();
-      if (pendingImage.isNotEmpty) {
-        _logImageFallback(
-          provider: config.id,
-          model: modelId,
-          reason: 'google_decoder_missed_image',
-        );
-        final sanitized = await sanitizeTextIfNeeded(pendingImage);
-        yield* emitDelta(
-          content: sanitized,
-          usage: usage,
-          totalTokens: totalTokens,
+      receivedImage = decoder.receivedImage;
+      usage = decoder.usage ?? usage;
+      totalTokens = usage?.totalTokens ?? totalTokens;
+      final calls = [
+        for (final call in decoder.functionCalls)
+          <String, dynamic>{
+            'id': call.id,
+            'apiId': call.apiId,
+            'name': call.name,
+            'args': call.args,
+            'result': call.result,
+            'thoughtSigKey': call.thoughtSigKey,
+            'thoughtSigVal': call.thoughtSigVal,
+            'part': call.part,
+          },
+      ];
+      final roundModelParts = decoder.roundModelParts;
+      final retryMalformedResponse = decoder.retryMalformedResponse;
+      final responseTextThoughtSigKey = decoder.textThoughtSigKey;
+      final responseTextThoughtSigVal = decoder.textThoughtSigVal;
+      final responseImageThoughtSigs = decoder.imageThoughtSigs;
+
+      if (retryMalformedResponse) {
+        // This is a transient model-generation failure, so retry the unchanged
+        // round once without adding the malformed candidate to conversation.
+        if (malformedResponseRetryCount == 0) {
+          malformedResponseRetryCount++;
+          retryMalformed = true;
+          return;
+        }
+        throw const HttpException(
+          'Gemini response generation failed (MALFORMED_RESPONSE)',
         );
       }
-    }
 
-    if (calls.isEmpty) {
-      // No tool calls; this round finished. Citations already left the decoder.
-      if (persistGeminiThoughtSigs) {
-        final metaComment = _buildGeminiThoughtSigComment(
-          textKey: responseTextThoughtSigKey,
-          textValue: responseTextThoughtSigVal,
-          imageSigs: responseImageThoughtSigs,
-        );
-        if (metaComment.isNotEmpty) {
+      // Flush any buffered inline image that never became Image* events.
+      if (!decoder.emittedImageEvents) {
+        final pendingImage = await takeBufferedImageMarkdown();
+        if (pendingImage.isNotEmpty) {
+          _logImageFallback(
+            provider: config.id,
+            model: modelId,
+            reason: 'google_decoder_missed_image',
+          );
+          final sanitized = await sanitizeTextIfNeeded(pendingImage);
           yield* emitDelta(
-            content: metaComment,
+            content: sanitized,
             usage: usage,
             totalTokens: totalTokens,
           );
         }
       }
-      yield* emitDone(usage: usage, totalTokens: totalTokens);
-      return;
-    }
 
-    // Append model functionCall(s) and user functionResponse(s) to conversation, then loop
-    malformedResponseRetryCount = 0;
-    if (isGemini3) {
-      // Gemini 3: preserve the original model parts order exactly.
-      convo.add({'role': 'model', 'parts': roundModelParts});
-
-      // 4. All functionResponses in one user turn
-      final responseParts = <Map<String, dynamic>>[];
-      for (final c in calls) {
-        final name = (c['name'] ?? '').toString();
-        final resText = (c['result'] ?? '').toString();
-        final apiId = c['apiId'] as String?;
-        Map<String, dynamic> responseObj;
-        try {
-          responseObj = (jsonDecode(resText) as Map).cast<String, dynamic>();
-        } catch (_) {
-          responseObj = {'result': resText};
+      if (calls.isEmpty) {
+        // No tool calls; this round finished. Citations already left the decoder.
+        if (persistGeminiThoughtSigs) {
+          final metaComment = _buildGeminiThoughtSigComment(
+            textKey: responseTextThoughtSigKey,
+            textValue: responseTextThoughtSigVal,
+            imageSigs: responseImageThoughtSigs,
+          );
+          if (metaComment.isNotEmpty) {
+            yield* emitDelta(
+              content: metaComment,
+              usage: usage,
+              totalTokens: totalTokens,
+            );
+          }
         }
-        responseParts.add({
-          'functionResponse': {
-            'name': name,
-            'response': responseObj,
-            if (apiId != null) 'id': apiId,
-          },
-        });
+        return;
       }
-      convo.add({'role': 'user', 'parts': responseParts});
-    } else {
-      // Gemini 2.x: existing per-call reconstruction
-      for (final c in calls) {
+
+      malformedResponseRetryCount = 0;
+      lastRoundCalls = calls;
+      lastRoundModelParts = roundModelParts;
+      pendingCalls = [
+        for (final c in calls)
+          emitToolCall(
+            id: (c['id'] ?? '').toString(),
+            name: (c['name'] ?? '').toString(),
+            arguments:
+                (c['args'] as Map<String, dynamic>?) ??
+                const <String, dynamic>{},
+          ),
+      ];
+    },
+    takeCalls: () => pendingCalls,
+    continueWithoutCalls: () => retryMalformed,
+    executeAfterRound: false,
+    onToolCall: onToolCall,
+    append: (executed) {
+      if (retryMalformed) return;
+      if (isGemini3) {
+        convo.add({'role': 'model', 'parts': lastRoundModelParts});
+        final responseParts = <Map<String, dynamic>>[];
+        for (final c in lastRoundCalls) {
+          final name = (c['name'] ?? '').toString();
+          final resText = (c['result'] ?? '').toString();
+          final apiId = c['apiId'] as String?;
+          Map<String, dynamic> responseObj;
+          try {
+            responseObj = (jsonDecode(resText) as Map).cast<String, dynamic>();
+          } catch (_) {
+            responseObj = {'result': resText};
+          }
+          responseParts.add({
+            'functionResponse': {
+              'name': name,
+              'response': responseObj,
+              if (apiId != null) 'id': apiId,
+            },
+          });
+        }
+        convo.add({'role': 'user', 'parts': responseParts});
+        return;
+      }
+      for (final c in lastRoundCalls) {
         final name = (c['name'] ?? '').toString();
         final args =
             (c['args'] as Map<String, dynamic>? ?? const <String, dynamic>{});
@@ -1428,7 +1445,8 @@ Stream<StreamChunk> _sendGoogleStream(
           ],
         });
       }
-    }
-    // Continue while(true) for next round
-  }
+    },
+    finish: () => emitDone(usage: usage, totalTokens: totalTokens),
+    usageOf: () => usage,
+  );
 }

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -429,244 +429,246 @@ Stream<StreamChunk> _sendGoogleVertexClaudeStream({
   );
   TokenUsage? totalUsage;
   var streamRound = 0;
+  var pendingCalls = <EmitToolCall>[];
+  var lastAssistantBlocks = <Map<String, dynamic>>[];
+  var lastStreamResults = <Map<String, dynamic>>[];
+  var lastText = '';
+  var pauseTurn = false;
 
-  while (true) {
-    final omitSamplingParams = _claudeShouldOmitSamplingParams(
-      upstreamId,
-      effectiveThinkingBudget,
-    );
-    final compatibleTopP = _claudeCompatibleTopP(
-      upstreamId,
-      effectiveThinkingBudget,
-      topP,
-    );
-    final thinking = isReasoning
-        ? _claudeThinkingConfig(upstreamId, effectiveThinkingBudget)
-        : null;
-    final outputConfig = isReasoning
-        ? _claudeOutputConfig(upstreamId, effectiveThinkingBudget)
-        : null;
-    final body = <String, dynamic>{
-      'anthropic_version': 'vertex-2023-10-16',
-      'messages': convo,
-      'stream': stream,
-      'max_tokens': effectiveMaxTokens,
-      if (systemPrompt.isNotEmpty) 'system': systemPrompt,
-      if (!omitSamplingParams &&
-          !_isClaudeReasoningEnabled(effectiveThinkingBudget) &&
-          temperature != null)
-        'temperature': temperature,
-      if (compatibleTopP != null) 'top_p': compatibleTopP,
-      if (allTools.isNotEmpty) 'tools': allTools,
-      if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
-      if (thinking != null) 'thinking': thinking,
-      if (outputConfig != null) 'output_config': outputConfig,
-    };
-    body.addAll(_customBody(config, modelId, assistantBody: extraBody));
-
-    final request = http.Request('POST', url);
-    request.headers.addAll(headers);
-    request.body = jsonEncode(body);
-
-    final response = await client.send(request);
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final errorBody = await response.stream.bytesToString();
-      throw HttpException('HTTP ${response.statusCode}: $errorBody');
-    }
-
-    if (!stream) {
-      // Vertex rawPredict response is same as Anthropic non-stream response
-      final txt = await response.stream.bytesToString();
-      final obj = jsonDecode(txt) as Map;
-      // Usage
-      try {
-        final u = (obj['usage'] as Map?)?.cast<String, dynamic>();
-        if (u != null) {
-          totalUsage = (totalUsage ?? const TokenUsage()).merge(
-            _claudeUsageFromMap(u),
-          );
-        }
-      } catch (_) {}
-      final content = (obj['content'] as List?) ?? const <dynamic>[];
-      final List<Map<String, dynamic>> assistantBlocks =
-          <Map<String, dynamic>>[];
-      final Map<String, Map<String, dynamic>> toolUses =
-          <String, Map<String, dynamic>>{}; // id -> {name,args}
-      final buf = StringBuffer();
-      for (final it in content) {
-        if (it is! Map) continue;
-        final type = (it['type'] ?? '').toString();
-        if (type == 'text') {
-          final t = (it['text'] ?? '').toString();
-          if (t.isNotEmpty) {
-            assistantBlocks.add({'type': 'text', 'text': t});
-            buf.write(t);
-          }
-        } else if (type == 'thinking' || type == 'redacted_thinking') {
-          try {
-            assistantBlocks.add(
-              Map<String, dynamic>.from(it.cast<String, dynamic>()),
-            );
-          } catch (_) {}
-        } else if (type == 'tool_use') {
-          final id = (it['id'] ?? '').toString();
-          final name = (it['name'] ?? '').toString();
-          final args =
-              (it['input'] as Map?)?.cast<String, dynamic>() ??
-              const <String, dynamic>{};
-          if (id.isNotEmpty) {
-            toolUses[id] = {'name': name, 'args': args};
-            assistantBlocks.add({
-              'type': 'tool_use',
-              'id': id,
-              'name': name,
-              'input': args,
-            });
-          }
-        }
-      }
-      if (toolUses.isNotEmpty && onToolCall != null) {
-        final callInfos = <EmitToolCall>[];
-        for (final e in toolUses.entries) {
-          callInfos.add(
-            emitToolCall(
-              id: e.key,
-              name: (e.value['name'] ?? '').toString(),
-              arguments: (e.value['args'] as Map<String, dynamic>),
-            ),
-          );
-        }
-        yield* emitToolCalls(
-          callInfos,
-          usage: totalUsage,
-          totalTokens: (totalUsage?.totalTokens ?? 0),
-        );
-        final results = <Map<String, dynamic>>[];
-        final resultsInfo = <EmitToolResult>[];
-        for (final e in toolUses.entries) {
-          final name = (e.value['name'] ?? '').toString();
-          final args = (e.value['args'] as Map<String, dynamic>);
-          final res = await onToolCall(name, args, toolCallId: e.key);
-          results.add({
-            'type': 'tool_result',
-            'tool_use_id': e.key,
-            'content': res,
-          });
-          resultsInfo.add(
-            emitToolResult(
-              id: e.key,
-              name: name,
-              arguments: args,
-              content: res,
-            ),
-          );
-        }
-        if (resultsInfo.isNotEmpty) {
-          yield* emitToolResults(
-            resultsInfo,
-            usage: totalUsage,
-            totalTokens: (totalUsage?.totalTokens ?? 0),
-          );
-        }
-        // Extend convo: assistant + user tool_result, loop
-        final assistantMsg = {'role': 'assistant', 'content': assistantBlocks};
-        final userToolMsg = {'role': 'user', 'content': results};
-        convo = [...convo, assistantMsg, userToolMsg];
-        continue; // next round
-      }
-      // No tool use -> return final text
-      yield* emitDone(
-        content: buf.toString(),
-        usage: totalUsage,
-        totalTokens: (totalUsage?.totalTokens ?? 0),
+  yield* runProviderToolRounds(
+    sendRound: () async* {
+      pendingCalls = [];
+      lastStreamResults = [];
+      lastText = '';
+      lastAssistantBlocks = [];
+      pauseTurn = false;
+      final omitSamplingParams = _claudeShouldOmitSamplingParams(
+        upstreamId,
+        effectiveThinkingBudget,
       );
-      return;
-    }
+      final compatibleTopP = _claudeCompatibleTopP(
+        upstreamId,
+        effectiveThinkingBudget,
+        topP,
+      );
+      final thinking = isReasoning
+          ? _claudeThinkingConfig(upstreamId, effectiveThinkingBudget)
+          : null;
+      final outputConfig = isReasoning
+          ? _claudeOutputConfig(upstreamId, effectiveThinkingBudget)
+          : null;
+      final body = <String, dynamic>{
+        'anthropic_version': 'vertex-2023-10-16',
+        'messages': convo,
+        'stream': stream,
+        'max_tokens': effectiveMaxTokens,
+        if (systemPrompt.isNotEmpty) 'system': systemPrompt,
+        if (!omitSamplingParams &&
+            !_isClaudeReasoningEnabled(effectiveThinkingBudget) &&
+            temperature != null)
+          'temperature': temperature,
+        if (compatibleTopP != null) 'top_p': compatibleTopP,
+        if (allTools.isNotEmpty) 'tools': allTools,
+        if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
+        if (thinking != null) 'thinking': thinking,
+        if (outputConfig != null) 'output_config': outputConfig,
+      };
+      body.addAll(_customBody(config, modelId, assistantBody: extraBody));
 
-    final sse = response.stream.transform(utf8.decoder);
-    final decoder = ClaudeStreamDecoder(sourceId: 'round-${streamRound++}');
-    final executedToolIds = <String>{};
+      final request = http.Request('POST', url);
+      request.headers.addAll(headers);
+      request.body = jsonEncode(body);
 
-    await for (final event in parseSseEventStrings(sse)) {
-      // Anthropic-on-Vertex reports failures in-band as `event: error` with
-      // {type:"error", error:{type,message}}; raise before the
-      // malformed-chunk guard below can swallow it.
-      _throwIfInBandStreamError(event.data);
-      final decoded = decoder.accept(event);
-      for (final chunk in decoded.chunks) {
-        yield chunk;
-        if (chunk is ToolCallEnd &&
-            decoder.isClientTool(chunk.id) &&
-            onToolCall != null &&
-            executedToolIds.add(chunk.id)) {
-          final tool = decoder.clientTools[chunk.id]!;
-          final args = tool.decodedArguments;
-          final res = await onToolCall(tool.name, args, toolCallId: tool.id);
-          decoder.recordToolResult(tool.id, res);
-          yield* emitToolResults(
-            [
-              emitToolResult(
-                id: tool.id,
-                name: tool.name,
-                arguments: args,
-                content: res,
+      final response = await client.send(request);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        final errorBody = await response.stream.bytesToString();
+        throw HttpException('HTTP ${response.statusCode}: $errorBody');
+      }
+
+      if (!stream) {
+        // Vertex rawPredict response is same as Anthropic non-stream response
+        final txt = await response.stream.bytesToString();
+        final obj = jsonDecode(txt) as Map;
+        // Usage
+        try {
+          final u = (obj['usage'] as Map?)?.cast<String, dynamic>();
+          if (u != null) {
+            totalUsage = (totalUsage ?? const TokenUsage()).merge(
+              _claudeUsageFromMap(u),
+            );
+          }
+        } catch (_) {}
+        final content = (obj['content'] as List?) ?? const <dynamic>[];
+        final List<Map<String, dynamic>> assistantBlocks =
+            <Map<String, dynamic>>[];
+        final Map<String, Map<String, dynamic>> toolUses =
+            <String, Map<String, dynamic>>{}; // id -> {name,args}
+        final buf = StringBuffer();
+        for (final it in content) {
+          if (it is! Map) continue;
+          final type = (it['type'] ?? '').toString();
+          if (type == 'text') {
+            final t = (it['text'] ?? '').toString();
+            if (t.isNotEmpty) {
+              assistantBlocks.add({'type': 'text', 'text': t});
+              buf.write(t);
+            }
+          } else if (type == 'thinking' || type == 'redacted_thinking') {
+            try {
+              assistantBlocks.add(
+                Map<String, dynamic>.from(it.cast<String, dynamic>()),
+              );
+            } catch (_) {}
+          } else if (type == 'tool_use') {
+            final id = (it['id'] ?? '').toString();
+            final name = (it['name'] ?? '').toString();
+            final args =
+                (it['input'] as Map?)?.cast<String, dynamic>() ??
+                const <String, dynamic>{};
+            if (id.isNotEmpty) {
+              toolUses[id] = {'name': name, 'args': args};
+              assistantBlocks.add({
+                'type': 'tool_use',
+                'id': id,
+                'name': name,
+                'input': args,
+              });
+            }
+          }
+        }
+        lastAssistantBlocks = assistantBlocks;
+        lastText = buf.toString();
+        if (toolUses.isNotEmpty && onToolCall != null) {
+          pendingCalls = [
+            for (final e in toolUses.entries)
+              emitToolCall(
+                id: e.key,
+                name: (e.value['name'] ?? '').toString(),
+                arguments: (e.value['args'] as Map<String, dynamic>),
               ),
-            ],
-            usage: decoder.usage,
-            totalTokens: decoder.usage?.totalTokens ?? 0,
+          ];
+        }
+        return;
+      }
+
+      final sse = response.stream.transform(utf8.decoder);
+      final decoder = ClaudeStreamDecoder(sourceId: 'round-${streamRound++}');
+      final executedToolIds = <String>{};
+
+      await for (final event in parseSseEventStrings(sse)) {
+        // Anthropic-on-Vertex reports failures in-band as `event: error` with
+        // {type:"error", error:{type,message}}; raise before the
+        // malformed-chunk guard below can swallow it.
+        _throwIfInBandStreamError(event.data);
+        final decoded = decoder.accept(event);
+        for (final chunk in decoded.chunks) {
+          yield chunk;
+          if (chunk is ToolCallEnd &&
+              decoder.isClientTool(chunk.id) &&
+              onToolCall != null &&
+              executedToolIds.add(chunk.id)) {
+            final tool = decoder.clientTools[chunk.id]!;
+            final args = tool.decodedArguments;
+            final call = emitToolCall(
+              id: tool.id,
+              name: tool.name,
+              arguments: args,
+            );
+            await for (final resultChunk in executeClientTools(
+              calls: [call],
+              onToolCall: onToolCall,
+              usage: decoder.usage,
+              totalTokens: decoder.usage?.totalTokens ?? 0,
+            )) {
+              if (resultChunk is ToolCallResult) {
+                decoder.recordToolResult(
+                  tool.id,
+                  (resultChunk.output ?? '').toString(),
+                );
+              }
+              yield resultChunk;
+            }
+          }
+        }
+        if (decoded.completed) break;
+      }
+      for (final chunk in decoder.onClosed()) {
+        yield chunk;
+      }
+
+      final usage = decoder.usage;
+      final assistantBlocks = decoder.assistantBlocks;
+      final lastStopReason = decoder.lastStopReason;
+      final toolResultsContent = decoder.toolResults;
+
+      if (usage != null) {
+        totalUsage = (totalUsage ?? const TokenUsage()).merge(usage);
+      }
+
+      lastAssistantBlocks = assistantBlocks;
+      if (decoder.clientTools.isEmpty) {
+        pauseTurn = (lastStopReason ?? '') == 'pause_turn';
+        return;
+      }
+
+      pendingCalls = [
+        for (final tool in decoder.clientTools.values)
+          emitToolCall(
+            id: tool.id,
+            name: tool.name,
+            arguments: tool.decodedArguments,
+          ),
+      ];
+      for (final tool in decoder.clientTools.values) {
+        var res = toolResultsContent[tool.id] ?? '';
+        if (res.isEmpty && onToolCall != null) {
+          res = await onToolCall(
+            tool.name,
+            tool.decodedArguments,
+            toolCallId: tool.id,
           );
         }
+        lastStreamResults.add({
+          'type': 'tool_result',
+          'tool_use_id': tool.id,
+          if (res.isNotEmpty) 'content': res,
+        });
       }
-      if (decoded.completed) break;
-    }
-    for (final chunk in decoder.onClosed()) {
-      yield chunk;
-    }
-
-    final usage = decoder.usage;
-    final roundTokens = usage?.totalTokens ?? 0;
-    final assistantBlocks = decoder.assistantBlocks;
-    final lastStopReason = decoder.lastStopReason;
-    final toolResultsContent = decoder.toolResults;
-
-    if (usage != null) {
-      totalUsage = (totalUsage ?? const TokenUsage()).merge(usage);
-    }
-
-    if (decoder.clientTools.isEmpty) {
-      final sr = lastStopReason ?? '';
-      if (sr == 'pause_turn') {
+    },
+    takeCalls: () => pendingCalls,
+    continueWithoutCalls: () => pauseTurn,
+    executeAfterRound: !stream,
+    emitCalls: !stream,
+    onToolCall: onToolCall,
+    append: (executed) {
+      if (pauseTurn) {
         convo = [
           ...convo,
-          {'role': 'assistant', 'content': assistantBlocks},
+          {'role': 'assistant', 'content': lastAssistantBlocks},
         ];
-        continue;
+        return;
       }
-      yield* emitDone(
-        usage: totalUsage ?? usage,
-        totalTokens: (totalUsage?.totalTokens ?? roundTokens),
-      );
-      return;
-    }
-
-    final toolResultsBlocks = <Map<String, dynamic>>[];
-    for (final tool in decoder.clientTools.values) {
-      final args = tool.decodedArguments;
-      var res = toolResultsContent[tool.id] ?? '';
-      if (res.isEmpty && onToolCall != null) {
-        res = await onToolCall(tool.name, args, toolCallId: tool.id);
-      }
-      toolResultsBlocks.add({
-        'type': 'tool_result',
-        'tool_use_id': tool.id,
-        if (res.isNotEmpty) 'content': res,
-      });
-    }
-
-    convo = [
-      ...convo,
-      {'role': 'assistant', 'content': assistantBlocks},
-      {'role': 'user', 'content': toolResultsBlocks},
-    ];
-  }
+      final results = stream
+          ? lastStreamResults
+          : [
+              for (final item in executed)
+                <String, dynamic>{
+                  'type': 'tool_result',
+                  'tool_use_id': item.call.id,
+                  'content': item.content,
+                },
+            ];
+      convo = [
+        ...convo,
+        {'role': 'assistant', 'content': lastAssistantBlocks},
+        {'role': 'user', 'content': results},
+      ];
+    },
+    finish: () => emitDone(
+      content: lastText,
+      usage: totalUsage,
+      totalTokens: totalUsage?.totalTokens ?? 0,
+    ),
+    usageOf: () => totalUsage,
+  );
 }

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -414,6 +414,126 @@ Map<String, dynamic> _buildAssistantToolCallMessage({
   return msg;
 }
 
+Map<String, dynamic>? _openaiFirstChoice(Map<String, dynamic> obj) {
+  try {
+    final choices = obj['choices'] as List?;
+    if (choices != null && choices.isNotEmpty) {
+      return (choices.first as Map).cast<String, dynamic>();
+    }
+  } catch (_) {}
+  return null;
+}
+
+Map<String, dynamic>? _openaiFirstChoiceMessage(Map<String, dynamic> obj) {
+  return (_openaiFirstChoice(obj)?['message'] as Map?)?.cast<String, dynamic>();
+}
+
+List<EmitToolCall> _openaiCallsFromCompletionMessage(
+  Map<String, dynamic>? msg,
+) {
+  final tcs = (msg?['tool_calls'] as List?) ?? const <dynamic>[];
+  final calls = <EmitToolCall>[];
+  for (var i = 0; i < tcs.length; i++) {
+    final raw = tcs[i];
+    if (raw is! Map) continue;
+    final t = raw.cast<String, dynamic>();
+    final id = _effectiveToolCallId(t['id'], 'call', i);
+    final f =
+        (t['function'] as Map?)?.cast<String, dynamic>() ??
+        const <String, dynamic>{};
+    final name = (f['name'] ?? '').toString();
+    Map<String, dynamic> args;
+    try {
+      args = (jsonDecode((f['arguments'] ?? '{}').toString()) as Map)
+          .cast<String, dynamic>();
+    } catch (_) {
+      args = <String, dynamic>{};
+    }
+    calls.add(emitToolCall(id: id, name: name, arguments: args));
+  }
+  return calls;
+}
+
+TokenUsage? _openaiUsageFromObj(Map<String, dynamic> obj) {
+  try {
+    final u = obj['usage'];
+    if (u is! Map) return null;
+    final prompt = (u['prompt_tokens'] ?? 0) as int? ?? 0;
+    final completion = (u['completion_tokens'] ?? 0) as int? ?? 0;
+    final cached =
+        (u['prompt_tokens_details']?['cached_tokens'] ?? 0) as int? ?? 0;
+    return TokenUsage(
+      promptTokens: prompt,
+      completionTokens: completion,
+      cachedTokens: cached,
+      totalTokens: prompt + completion,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+({String content, List<({String uri, String mimeType})> images})
+_openaiVisibleOutputFromMessage(Map<String, dynamic>? cmsg) {
+  var content = '';
+  final images = <({String uri, String mimeType})>[];
+  if (cmsg == null) return (content: content, images: images);
+  final cc = cmsg['content'];
+  if (cc is String) {
+    content = cc;
+  } else if (cc is List) {
+    final buf = StringBuffer();
+    for (final it in cc) {
+      if (it is Map && (it['type'] == 'text')) {
+        final t = (it['text'] ?? '').toString();
+        if (t.isNotEmpty) buf.write(t);
+      } else if (it is Map &&
+          (it['type'] == 'image_url' || it['type'] == 'image')) {
+        dynamic iu = it['image_url'];
+        String? url;
+        if (iu is String) {
+          url = iu;
+        } else if (iu is Map) {
+          final u2 = iu['url'];
+          if (u2 is String) url = u2;
+        }
+        if (url != null && url.isNotEmpty) {
+          images.add((
+            uri: url,
+            mimeType: mimeTypeFromImageUri(url) ?? 'image/png',
+          ));
+        }
+      }
+    }
+    content = buf.toString();
+  }
+  return (content: content, images: images);
+}
+
+List<EmitToolCall> _responsesCallsFromIndexMap(
+  Map<int, Map<String, String>> byIndex,
+) {
+  final calls = <EmitToolCall>[];
+  final sorted = byIndex.keys.toList()..sort();
+  for (final idx in sorted) {
+    final m = byIndex[idx]!;
+    Map<String, dynamic> args;
+    try {
+      args = (jsonDecode(m['args'] ?? '{}') as Map).cast<String, dynamic>();
+    } catch (_) {
+      args = <String, dynamic>{};
+    }
+    calls.add(
+      emitToolCall(
+        id: _effectiveToolCallId(m['call_id'], 'call', idx),
+        name: (m['name'] ?? '').toString(),
+        arguments: args,
+      ),
+    );
+  }
+  return calls;
+}
+
 String _openAIEffortForBudget(int? budget, String upstreamModelId) {
   final baseEffort = _effortForBudget(budget);
   var requestedEffort = baseEffort;
@@ -1053,6 +1173,495 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
 /// per-event catch, which tolerates malformed JSON. Convert their transport
 /// failures into [HttpException] up front so that catch cannot swallow them
 /// and let the no-[DONE] fallback persist truncated output as a completion.
+Stream<StreamChunk> _runOpenAIChatCompletionsToolFollowUps({
+  required http.Client client,
+  required ProviderConfig config,
+  required String modelId,
+  required String upstreamModelId,
+  required Uri url,
+  required _OpenAIProviderInfo info,
+  required List<Map<String, dynamic>> messages,
+  required Map<dynamic, dynamic> firstToolAcc,
+  required String firstAssistantContent,
+  required String firstReasoning,
+  required dynamic firstReasoningDetails,
+  required ToolCallHandler onToolCall,
+  required List<String>? userImagePaths,
+  required bool canImageInput,
+  required bool allowRemoteImages,
+  required bool isClaudeUpstream,
+  required bool isReasoning,
+  required String effort,
+  required int? thinkingBudget,
+  required double? temperature,
+  required double? topP,
+  required List<Map<String, dynamic>>? tools,
+  required Map<String, dynamic> extraBodyCfg,
+  required Map<String, String>? extraHeaders,
+  required bool wantsImageOutput,
+  required bool needsReasoningEcho,
+  required bool reasoningDetailsAllowSnapshots,
+  required void Function(Map<String, dynamic> body) applyMaxTokens,
+  required TokenUsage? initialUsage,
+  required int streamRound,
+  required int approxPromptTokens,
+  required int approxCompletionChars,
+  required bool includeReasoningDetailsOnDone,
+}) async* {
+  var usage = initialUsage;
+  var chars = approxCompletionChars;
+  var round = streamRound;
+  ChatCompletionsStreamDecoder? lastRound;
+  var currentMessages = [
+    for (final message in messages) _copyChatCompletionMessage(message),
+  ];
+
+  String assistantContent() =>
+      lastRound?.assistantContent ?? firstAssistantContent;
+  String reasoning() => lastRound?.reasoningEcho ?? firstReasoning;
+  dynamic reasoningDetails() =>
+      lastRound?.reasoningDetails ?? firstReasoningDetails;
+
+  yield* runClientToolFollowUps(
+    initialCalls: clientToolCallsFromChatAcc(firstToolAcc),
+    onToolCall: onToolCall,
+    append: (executed) {
+      currentMessages = [
+        ...currentMessages,
+        _buildAssistantToolCallMessage(
+          calls: openaiToolCallMaps([for (final item in executed) item.call]),
+          content: assistantContent(),
+          reasoningContent: needsReasoningEcho ? reasoning() : null,
+          includeEmptyReasoningContent: needsReasoningEcho,
+          reasoningDetails: reasoningDetails(),
+        ),
+        ...openaiToolResultMessages(executed),
+      ];
+    },
+    sendFollowUp: () async* {
+      final body2 = <String, dynamic>{
+        'model': upstreamModelId,
+        'messages': await _buildOpenAIChatCompletionMessages(
+          currentMessages,
+          userMediaPaths: userImagePaths,
+          canImageInput: canImageInput,
+          allowRemoteImages: allowRemoteImages,
+          reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
+          stripReasoningContent: isClaudeUpstream,
+        ),
+        'stream': true,
+        if (temperature != null) 'temperature': temperature,
+        if (topP != null) 'top_p': topP,
+        if (isReasoning && effort != 'off' && effort != 'auto')
+          'reasoning_effort': effort,
+        if (tools != null && tools.isNotEmpty)
+          'tools': _cleanToolsForCompatibility(tools),
+        if (tools != null && tools.isNotEmpty) 'tool_choice': 'auto',
+      };
+      applyMaxTokens(body2);
+      _applyVendorReasoningKnobs(
+        body2,
+        info: info,
+        isReasoning: isReasoning,
+        thinkingBudget: thinkingBudget,
+      );
+      _applyCompatibleBuiltInSearch(
+        body2,
+        config: config,
+        modelId: modelId,
+        upstreamModelId: upstreamModelId,
+      );
+      _maybeAddStreamingUsageOptions(
+        body2,
+        stream: true,
+        config: config,
+        host: info.host,
+      );
+      if (extraBodyCfg.isNotEmpty) {
+        body2.addAll(extraBodyCfg);
+      }
+      _sanitizeOpenAIGpt5SamplingParams(
+        body2,
+        upstreamModelId,
+        fallbackEffort: effort,
+        isOpenRouter: info.isOpenRouter,
+      );
+      _normalizeMoonshotKimiChatBody(
+        body2,
+        upstreamModelId: upstreamModelId,
+        isReasoning: isReasoning,
+        thinkingBudget: thinkingBudget,
+      );
+      final req2 = http.Request('POST', url);
+      req2.headers.addAll(
+        _customHeaders(
+          config,
+          modelId,
+          baseHeaders: <String, String>{
+            'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+          },
+          assistantHeaders: extraHeaders,
+        ),
+      );
+      req2.body = jsonEncode(body2);
+      final http.StreamedResponse resp2;
+      try {
+        resp2 = await client.send(req2);
+        if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
+          final errorBody = await resp2.stream.bytesToString();
+          throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
+        }
+      } on HttpException {
+        rethrow;
+      } catch (e) {
+        throw HttpException('Follow-up request failed: $e');
+      }
+      final s2 = _rethrowFollowUpStreamErrors(
+        resp2.stream.transform(utf8.decoder),
+      );
+      final roundDecoder = ChatCompletionsStreamDecoder(
+        wantsImageOutput: wantsImageOutput,
+        needsReasoningEcho: needsReasoningEcho,
+        allowReasoningSnapshots: reasoningDetailsAllowSnapshots,
+        initialUsage: usage,
+        sourceId: 'round-${round++}',
+      );
+      await for (final event in parseSseEventStrings(s2)) {
+        final data = event.data;
+        if (data == '[DONE]') continue;
+        _throwIfInBandStreamError(data);
+        try {
+          for (final chunk in roundDecoder.accept(event).chunks) {
+            yield chunk;
+          }
+        } catch (_) {}
+      }
+      usage = roundDecoder.usage ?? usage;
+      chars = roundDecoder.approxCompletionChars;
+      lastRound = roundDecoder;
+    },
+    takeCallsAfterRound: () {
+      final decoder = lastRound;
+      if (decoder == null) return const <EmitToolCall>[];
+      if (decoder.finishReason == 'tool_calls' ||
+          decoder.toolCalls.isNotEmpty) {
+        return clientToolCallsFromChatAcc(decoder.toolCalls);
+      }
+      return const <EmitToolCall>[];
+    },
+    finish: () {
+      final approxTotal = approxPromptTokens + (chars / 4).round();
+      return emitDone(
+        reasoningDetails: includeReasoningDetailsOnDone
+            ? lastRound?.reasoningDetails ?? firstReasoningDetails
+            : null,
+        usage: usage,
+        totalTokens: usage?.totalTokens ?? approxTotal,
+      );
+    },
+    usageOf: () => usage,
+  );
+}
+
+Stream<StreamChunk> _runOpenAIChatCompletionsNonStreamToolFollowUps({
+  required http.Client client,
+  required ProviderConfig config,
+  required String modelId,
+  required String upstreamModelId,
+  required Uri url,
+  required _OpenAIProviderInfo info,
+  required List<Map<String, dynamic>> messages,
+  required Map<String, dynamic> requestBody,
+  required Map<String, dynamic> firstObj,
+  required List<EmitToolCall> initialCalls,
+  required ToolCallHandler onToolCall,
+  required List<String>? userImagePaths,
+  required bool canImageInput,
+  required bool allowRemoteImages,
+  required bool isClaudeUpstream,
+  required bool needsReasoningEcho,
+  required Map<String, String>? extraHeaders,
+  required TokenUsage? initialUsage,
+}) async* {
+  var usage = initialUsage;
+  var lastObj = firstObj;
+  var currentMessages = [
+    for (final message in messages) _copyChatCompletionMessage(message),
+  ];
+
+  yield* runClientToolFollowUps(
+    initialCalls: initialCalls,
+    onToolCall: onToolCall,
+    emitCalls: true,
+    append: (executed) {
+      final msg =
+          _openaiFirstChoiceMessage(lastObj) ?? const <String, dynamic>{};
+      final reasoningForTools =
+          (msg['reasoning_content'] ?? msg['reasoning'])?.toString() ?? '';
+      currentMessages = [
+        ...currentMessages,
+        _buildAssistantToolCallMessage(
+          calls: openaiToolCallMaps([for (final item in executed) item.call]),
+          content: msg['content'],
+          reasoningContent: needsReasoningEcho ? reasoningForTools : null,
+          includeEmptyReasoningContent: needsReasoningEcho,
+          reasoningDetails: msg['reasoning_details'],
+        ),
+        ...openaiToolResultMessages(executed),
+      ];
+    },
+    sendFollowUp: () async* {
+      final req = http.Request('POST', url);
+      req.headers.addAll(
+        _customHeaders(
+          config,
+          modelId,
+          baseHeaders: <String, String>{
+            'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+          },
+          assistantHeaders: extraHeaders,
+        ),
+      );
+      final reqBody = Map<String, dynamic>.from(requestBody);
+      reqBody['messages'] = await _buildOpenAIChatCompletionMessages(
+        currentMessages,
+        userMediaPaths: userImagePaths,
+        canImageInput: canImageInput,
+        allowRemoteImages: allowRemoteImages,
+        reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
+        stripReasoningContent: isClaudeUpstream,
+      );
+      reqBody.remove('stream');
+      req.body = jsonEncode(reqBody);
+      final resp2 = await client.send(req);
+      if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
+        final errorBody = await resp2.stream.bytesToString();
+        throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
+      }
+      lastObj =
+          jsonDecode(await resp2.stream.bytesToString())
+              as Map<String, dynamic>;
+      final roundUsage = _openaiUsageFromObj(lastObj);
+      if (roundUsage != null) {
+        usage = (usage ?? const TokenUsage()).merge(roundUsage);
+      }
+    },
+    takeCallsAfterRound: () =>
+        _openaiCallsFromCompletionMessage(_openaiFirstChoiceMessage(lastObj)),
+    finish: () async* {
+      final choice = _openaiFirstChoice(lastObj);
+      if (choice == null) {
+        yield* emitDone(
+          content: (lastObj['output_text'] ?? '').toString(),
+          usage: usage,
+          totalTokens: usage?.totalTokens ?? 0,
+        );
+        return;
+      }
+      final visible = _openaiVisibleOutputFromMessage(
+        (choice['message'] as Map?)?.cast<String, dynamic>(),
+      );
+      yield* emitImages(visible.images);
+      yield* emitDone(
+        content: visible.content,
+        reasoningDetails: _openaiFirstChoiceMessage(
+          lastObj,
+        )?['reasoning_details'],
+        usage: usage,
+        totalTokens: usage?.totalTokens ?? 0,
+      );
+    },
+    usageOf: () => usage,
+  );
+}
+
+Stream<StreamChunk> _runOpenAIResponsesToolFollowUps({
+  required http.Client client,
+  required ProviderConfig config,
+  required String modelId,
+  required String upstreamModelId,
+  required Uri url,
+  required _OpenAIProviderInfo info,
+  required List<Map<String, dynamic>> initialInput,
+  required List<Map<String, dynamic>> firstOutputItems,
+  required List<EmitToolCall> initialCalls,
+  required List<Map<String, dynamic>> responsesToolsSpec,
+  required String responsesInstructions,
+  required List<dynamic>? responsesIncludeParam,
+  required ToolCallHandler onToolCall,
+  required Map<String, String>? extraHeaders,
+  required Map<String, dynamic>? extraBody,
+  required double? temperature,
+  required double? topP,
+  required int? maxTokens,
+  required bool isReasoning,
+  required String effort,
+  required int? thinkingBudget,
+  required TokenUsage? initialUsage,
+  required int streamRound,
+  required int approxPromptTokens,
+  required int approxCompletionChars,
+}) async* {
+  var usage = initialUsage;
+  var chars = approxCompletionChars;
+  var round = streamRound;
+  var currentInput = <Map<String, dynamic>>[...initialInput];
+  var outputItemsForAppend = firstOutputItems;
+  var lastCalls = const <EmitToolCall>[];
+  String? lastToolSignature;
+  var consecutiveDupeCount = 0;
+
+  yield* runClientToolFollowUps(
+    initialCalls: initialCalls,
+    onToolCall: onToolCall,
+    append: (executed) {
+      currentInput = [
+        ...currentInput,
+        ..._withResponsesFunctionCallItems(outputItemsForAppend, [
+          for (final item in executed) item.call,
+        ]),
+        for (final item in executed)
+          <String, dynamic>{
+            'type': 'function_call_output',
+            'call_id': item.call.id,
+            'output': item.content,
+          },
+      ];
+    },
+    sendFollowUp: () async* {
+      final body2 = <String, dynamic>{
+        'model': upstreamModelId,
+        'input': currentInput,
+        'stream': true,
+        if (responsesToolsSpec.isNotEmpty) 'tools': responsesToolsSpec,
+        if (responsesToolsSpec.isNotEmpty) 'tool_choice': 'auto',
+        if (responsesInstructions.isNotEmpty)
+          'instructions': responsesInstructions,
+        if (temperature != null) 'temperature': temperature,
+        if (topP != null) 'top_p': topP,
+        if (maxTokens != null) 'max_output_tokens': maxTokens,
+        if (isReasoning && effort != 'off')
+          'reasoning': {
+            'summary': 'auto',
+            if (effort != 'auto') 'effort': effort,
+          },
+        if (responsesIncludeParam != null) 'include': responsesIncludeParam,
+      };
+      _applyCompatibleResponsesReasoning(
+        body2,
+        config: config,
+        modelId: modelId,
+        upstreamModelId: upstreamModelId,
+        isReasoning: isReasoning,
+        thinkingBudget: thinkingBudget,
+      );
+      final extraCfg = _customBody(config, modelId, assistantBody: extraBody);
+      if (extraCfg.isNotEmpty) body2.addAll(extraCfg);
+      try {
+        if (body2['tools'] is List) {
+          final raw = (body2['tools'] as List).cast<dynamic>();
+          body2['tools'] = _toResponsesToolsFormat(
+            raw.map((e) => (e as Map).cast<String, dynamic>()).toList(),
+          );
+        }
+      } catch (_) {}
+      _sanitizeOpenAIGpt5SamplingParams(
+        body2,
+        upstreamModelId,
+        fallbackEffort: effort,
+        isOpenRouter: info.isOpenRouter,
+      );
+
+      final req2 = http.Request('POST', url);
+      req2.headers.addAll(
+        _customHeaders(
+          config,
+          modelId,
+          baseHeaders: <String, String>{
+            'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+          },
+          assistantHeaders: extraHeaders,
+        ),
+      );
+      req2.body = jsonEncode(body2);
+      final http.StreamedResponse resp2;
+      try {
+        resp2 = await client.send(req2);
+        if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
+          final errorBody = await resp2.stream.bytesToString();
+          throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
+        }
+      } on HttpException {
+        rethrow;
+      } catch (e) {
+        throw HttpException('Follow-up request failed: $e');
+      }
+      final s2 = _rethrowFollowUpStreamErrors(
+        resp2.stream.transform(utf8.decoder),
+      );
+      final followUpDecoder = ResponsesStreamDecoder(
+        initialUsage: usage,
+        sourceId: 'round-${round++}',
+      );
+      await for (final event in parseSseEventStrings(s2)) {
+        final d = event.data;
+        if (d == '[DONE]') {
+          followUpDecoder.accept(event);
+          break;
+        }
+        _throwIfInBandStreamError(d);
+        final decoded = followUpDecoder.accept(event);
+        for (final chunk in decoded.chunks) {
+          yield chunk;
+        }
+        if (decoded.completed) break;
+      }
+      usage = followUpDecoder.usage ?? usage;
+      chars += followUpDecoder.approxCompletionChars;
+      outputItemsForAppend = followUpDecoder.outputItems;
+      final respCalls2 = <int, Map<String, String>>{
+        for (final call in followUpDecoder.takeFunctionCalls())
+          call.index: <String, String>{
+            'call_id': call.callId,
+            'name': call.name,
+            'args': call.args,
+          },
+      };
+      lastCalls = _responsesCallsFromIndexMap(respCalls2);
+      if (lastCalls.isEmpty) return;
+      final sorted2 = respCalls2.keys.toList()..sort();
+      final currentSig = [
+        for (final idx2 in sorted2)
+          '${respCalls2[idx2]!['name'] ?? ''}:${respCalls2[idx2]!['args'] ?? ''}',
+      ].join('|');
+      if (currentSig == lastToolSignature) {
+        consecutiveDupeCount += 1;
+        if (consecutiveDupeCount >= 3) {
+          lastCalls = const <EmitToolCall>[];
+        }
+      } else {
+        lastToolSignature = currentSig;
+        consecutiveDupeCount = 1;
+      }
+    },
+    takeCallsAfterRound: () => lastCalls,
+    finish: () {
+      final approxTotal = approxPromptTokens + (chars / 4).round();
+      return emitDone(
+        usage: usage,
+        totalTokens: usage?.totalTokens ?? approxTotal,
+      );
+    },
+    usageOf: () => usage,
+  );
+}
+
 Stream<String> _rethrowFollowUpStreamErrors(Stream<String> source) {
   return source.transform(
     StreamTransformer<String, String>.fromHandlers(
@@ -1979,215 +2588,58 @@ Stream<StreamChunk> _sendOpenAIStream(
       }
 
       // Chat Completions non-stream with tool-calls follow-ups
-      TokenUsage? aggUsage;
-      Map<String, dynamic> lastObj = obj is Map
+      final lastObj = obj is Map
           ? Map<String, dynamic>.from(obj)
           : <String, dynamic>{};
-      while (true) {
-        Map<String, dynamic>? c0;
-        try {
-          final choices = lastObj['choices'] as List?;
-          if (choices != null && choices.isNotEmpty) {
-            c0 = (choices.first as Map).cast<String, dynamic>();
-          }
-        } catch (_) {}
-        if (c0 == null) {
-          final s = (lastObj['output_text'] ?? '').toString();
-          yield* emitDone(
-            content: s,
-            usage: aggUsage,
-            totalTokens: aggUsage?.totalTokens ?? 0,
-          );
-          return;
-        }
-        // usage
-        try {
-          final u = lastObj['usage'];
-          if (u is Map) {
-            final prompt = (u['prompt_tokens'] ?? 0) as int? ?? 0;
-            final completion = (u['completion_tokens'] ?? 0) as int? ?? 0;
-            final cached =
-                (u['prompt_tokens_details']?['cached_tokens'] ?? 0) as int? ??
-                0;
-            final round = TokenUsage(
-              promptTokens: prompt,
-              completionTokens: completion,
-              cachedTokens: cached,
-              totalTokens: prompt + completion,
-            );
-            aggUsage = (aggUsage ?? const TokenUsage()).merge(round);
-          }
-        } catch (_) {}
-
-        final msg =
-            (c0['message'] as Map?)?.cast<String, dynamic>() ??
-            const <String, dynamic>{};
-        final reasoningForTools =
-            (msg['reasoning_content'] ?? msg['reasoning'])?.toString() ?? '';
-        final reasoningDetailsForTools = msg['reasoning_details'];
-        final tcs = (msg['tool_calls'] as List?) ?? const <dynamic>[];
-        if (tcs.isNotEmpty && effectiveOnToolCall != null) {
-          final calls = <Map<String, dynamic>>[];
-          final callInfos = <EmitToolCall>[];
-          for (int i = 0; i < tcs.length; i++) {
-            final t = (tcs[i] as Map).cast<String, dynamic>();
-            final id = _effectiveToolCallId(t['id'], 'call', i);
-            final f =
-                (t['function'] as Map?)?.cast<String, dynamic>() ??
-                const <String, dynamic>{};
-            final name = (f['name'] ?? '').toString();
-            Map<String, dynamic> args;
-            try {
-              args = (jsonDecode((f['arguments'] ?? '{}').toString()) as Map)
-                  .cast<String, dynamic>();
-            } catch (_) {
-              args = <String, dynamic>{};
-            }
-            callInfos.add(emitToolCall(id: id, name: name, arguments: args));
-            calls.add({
-              'id': id,
-              'type': 'function',
-              'function': {'name': name, 'arguments': jsonEncode(args)},
-            });
-          }
-          if (callInfos.isNotEmpty) {
-            yield* emitToolCalls(
-              callInfos,
-              usage: aggUsage,
-              totalTokens: aggUsage?.totalTokens ?? 0,
-            );
-          }
-          final results = <Map<String, dynamic>>[];
-          final resultsInfo = <EmitToolResult>[];
-          for (final c in callInfos) {
-            final res = await effectiveOnToolCall(
-              c.name,
-              c.arguments,
-              toolCallId: c.id,
-            );
-            results.add({'tool_call_id': c.id, 'content': res});
-            resultsInfo.add(
-              emitToolResult(
-                id: c.id,
-                name: c.name,
-                arguments: c.arguments,
-                content: res,
-              ),
-            );
-          }
-          if (resultsInfo.isNotEmpty) {
-            yield* emitToolResults(
-              resultsInfo,
-              usage: aggUsage,
-              totalTokens: aggUsage?.totalTokens ?? 0,
-            );
-          }
-          // Follow-up request
-          final req = http.Request('POST', url);
-          final headers2 = _customHeaders(
-            config,
-            modelId,
-            baseHeaders: <String, String>{
-              'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-            },
-            assistantHeaders: extraHeaders,
-          );
-          req.headers.addAll(headers2);
-          final next = <Map<String, dynamic>>[];
-          for (final m in messages) {
-            next.add(_copyChatCompletionMessage(m));
-          }
-          final assistantToolCallMsg = _buildAssistantToolCallMessage(
-            calls: calls,
-            content: msg['content'],
-            reasoningContent: needsReasoningEcho ? reasoningForTools : null,
-            includeEmptyReasoningContent: needsReasoningEcho,
-            reasoningDetails: reasoningDetailsForTools,
-          );
-          next.add(assistantToolCallMsg);
-          for (final r in results) {
-            final id = r['tool_call_id'];
-            final name = calls.firstWhere(
-              (c) => c['id'] == id,
-              orElse: () => const {
-                'function': {'name': ''},
-              },
-            )['function']['name'];
-            next.add({
-              'role': 'tool',
-              'tool_call_id': id,
-              'name': name,
-              'content': r['content'],
-            });
-          }
-          final reqBody = Map<String, dynamic>.from(body);
-          reqBody['messages'] = await _buildOpenAIChatCompletionMessages(
-            next,
-            userMediaPaths: userImagePaths,
-            canImageInput: canImageInput,
-            allowRemoteImages: allowRemoteImages,
-            reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
-            stripReasoningContent: isClaudeUpstream,
-          );
-          reqBody.remove('stream');
-          req.body = jsonEncode(reqBody);
-          final resp2 = await client.send(req);
-          if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
-            final errorBody = await resp2.stream.bytesToString();
-            throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
-          }
-          final txt2 = await resp2.stream.bytesToString();
-          lastObj = jsonDecode(txt2) as Map<String, dynamic>;
-          messages = next; // update transcript for next round
-          continue;
-        }
-
-        // No tool calls -> final content
-        String content = '';
-        final images = <({String uri, String mimeType})>[];
-        final cmsg = (c0['message'] as Map?)?.cast<String, dynamic>();
-        if (cmsg != null) {
-          final cc = cmsg['content'];
-          if (cc is String) {
-            content = cc;
-          } else if (cc is List) {
-            final buf = StringBuffer();
-            for (final it in cc) {
-              if (it is Map && (it['type'] == 'text')) {
-                final t = (it['text'] ?? '').toString();
-                if (t.isNotEmpty) buf.write(t);
-              } else if (it is Map &&
-                  (it['type'] == 'image_url' || it['type'] == 'image')) {
-                dynamic iu = it['image_url'];
-                String? url;
-                if (iu is String) {
-                  url = iu;
-                } else if (iu is Map) {
-                  final u2 = iu['url'];
-                  if (u2 is String) url = u2;
-                }
-                if (url != null && url.isNotEmpty) {
-                  images.add((
-                    uri: url,
-                    mimeType: mimeTypeFromImageUri(url) ?? 'image/png',
-                  ));
-                }
-              }
-            }
-            content = buf.toString();
-          }
-        }
-        yield* emitImages(images);
+      final firstUsage = _openaiUsageFromObj(lastObj);
+      final firstChoice = _openaiFirstChoice(lastObj);
+      if (firstChoice == null) {
         yield* emitDone(
-          content: content,
-          reasoningDetails: cmsg?['reasoning_details'],
-          usage: aggUsage,
-          totalTokens: aggUsage?.totalTokens ?? 0,
+          content: (lastObj['output_text'] ?? '').toString(),
+          usage: firstUsage,
+          totalTokens: firstUsage?.totalTokens ?? 0,
         );
         return;
       }
+      final firstCalls = _openaiCallsFromCompletionMessage(
+        (firstChoice['message'] as Map?)?.cast<String, dynamic>(),
+      );
+      if (firstCalls.isNotEmpty && effectiveOnToolCall != null) {
+        yield* _runOpenAIChatCompletionsNonStreamToolFollowUps(
+          client: client,
+          config: config,
+          modelId: modelId,
+          upstreamModelId: upstreamModelId,
+          url: url,
+          info: info,
+          messages: messages,
+          requestBody: body,
+          firstObj: lastObj,
+          initialCalls: firstCalls,
+          onToolCall: effectiveOnToolCall,
+          userImagePaths: userImagePaths,
+          canImageInput: canImageInput,
+          allowRemoteImages: allowRemoteImages,
+          isClaudeUpstream: isClaudeUpstream,
+          needsReasoningEcho: needsReasoningEcho,
+          extraHeaders: extraHeaders,
+          initialUsage: firstUsage,
+        );
+        return;
+      }
+      final visible = _openaiVisibleOutputFromMessage(
+        (firstChoice['message'] as Map?)?.cast<String, dynamic>(),
+      );
+      yield* emitImages(visible.images);
+      yield* emitDone(
+        content: visible.content,
+        reasoningDetails: _openaiFirstChoiceMessage(
+          lastObj,
+        )?['reasoning_details'],
+        usage: firstUsage,
+        totalTokens: firstUsage?.totalTokens ?? 0,
+      );
+      return;
     } catch (e) {
       throw HttpException('Invalid JSON: $e');
     }
@@ -2246,275 +2698,44 @@ Stream<StreamChunk> _sendOpenAIStream(
       // If model streamed tool_calls but didn't include finish_reason on prior chunks,
       // execute tool flow now and start follow-up request.
       if (effectiveOnToolCall != null && toolAcc.isNotEmpty) {
-        final calls = <Map<String, dynamic>>[];
-        final callInfos = <EmitToolCall>[];
-        final toolMsgs = <Map<String, dynamic>>[];
-        toolAcc.forEach((idx, m) {
-          final id = _effectiveToolCallId(m['id'], 'call', idx);
-          final name = (m['name'] ?? '');
-          Map<String, dynamic> args;
-          try {
-            args = (jsonDecode(m['args'] ?? '{}') as Map)
-                .cast<String, dynamic>();
-          } catch (_) {
-            args = <String, dynamic>{};
-          }
-          callInfos.add(emitToolCall(id: id, name: name, arguments: args));
-          calls.add({
-            'id': id,
-            'type': 'function',
-            'function': {'name': name, 'arguments': jsonEncode(args)},
-          });
-          toolMsgs.add({'__name': name, '__id': id, '__args': args});
-        });
-
-        // Execute tools and emit results. ToolCall* already left the decoder.
-        final results = <Map<String, dynamic>>[];
-        final resultsInfo = <EmitToolResult>[];
-        for (final m in toolMsgs) {
-          final name = m['__name'] as String;
-          final id = m['__id'] as String;
-          final args = (m['__args'] as Map<String, dynamic>);
-          final res = await effectiveOnToolCall(name, args, toolCallId: id);
-          results.add({'tool_call_id': id, 'content': res});
-          resultsInfo.add(
-            emitToolResult(id: id, name: name, arguments: args, content: res),
-          );
-        }
-        if (resultsInfo.isNotEmpty) {
-          yield* emitToolResults(
-            resultsInfo,
-            usage: usage,
-            totalTokens: usage?.totalTokens ?? 0,
-          );
-        }
-
-        // Build follow-up messages
-        final mm2 = <Map<String, dynamic>>[];
-        for (final m in messages) {
-          mm2.add(_copyChatCompletionMessage(m));
-        }
-        final assistantToolCallMsg = _buildAssistantToolCallMessage(
-          calls: calls,
-          content: assistantContentBuffer,
-          reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
-          includeEmptyReasoningContent: needsReasoningEcho,
-          reasoningDetails:
+        yield* _runOpenAIChatCompletionsToolFollowUps(
+          client: client,
+          config: config,
+          modelId: modelId,
+          upstreamModelId: upstreamModelId,
+          url: url,
+          info: info,
+          messages: messages,
+          firstToolAcc: toolAcc,
+          firstAssistantContent: assistantContentBuffer,
+          firstReasoning: reasoningBuffer,
+          firstReasoningDetails:
               chatDecoder?.reasoningDetails ??
               reasoningDetailsBuffer.detailsOrNull,
+          onToolCall: effectiveOnToolCall,
+          userImagePaths: userImagePaths,
+          canImageInput: canImageInput,
+          allowRemoteImages: allowRemoteImages,
+          isClaudeUpstream: isClaudeUpstream,
+          isReasoning: isReasoning,
+          effort: effort,
+          thinkingBudget: thinkingBudget,
+          temperature: temperature,
+          topP: topP,
+          tools: tools,
+          extraBodyCfg: extraBodyCfg,
+          extraHeaders: extraHeaders,
+          wantsImageOutput: wantsImageOutput,
+          needsReasoningEcho: needsReasoningEcho,
+          reasoningDetailsAllowSnapshots: reasoningDetailsAllowSnapshots,
+          applyMaxTokens: setMaxTokens,
+          initialUsage: usage,
+          streamRound: streamRound,
+          approxPromptTokens: approxPromptTokens,
+          approxCompletionChars: approxCompletionChars,
+          includeReasoningDetailsOnDone: true,
         );
-        mm2.add(assistantToolCallMsg);
-        for (final r in results) {
-          final id = r['tool_call_id'];
-          final name = calls.firstWhere(
-            (c) => c['id'] == id,
-            orElse: () => const {
-              'function': {'name': ''},
-            },
-          )['function']['name'];
-          mm2.add({
-            'role': 'tool',
-            'tool_call_id': id,
-            'name': name,
-            'content': r['content'],
-          });
-        }
-
-        // Follow-up request(s) with multi-round tool calls
-        var currentMessages = mm2;
-        while (true) {
-          final Map<String, dynamic> body2 = {
-            'model': upstreamModelId,
-            'messages': await _buildOpenAIChatCompletionMessages(
-              currentMessages,
-              userMediaPaths: userImagePaths,
-              canImageInput: canImageInput,
-              allowRemoteImages: allowRemoteImages,
-              reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
-              stripReasoningContent: isClaudeUpstream,
-            ),
-            'stream': true,
-            if (temperature != null) 'temperature': temperature,
-            if (topP != null) 'top_p': topP,
-            if (isReasoning && effort != 'off' && effort != 'auto')
-              'reasoning_effort': effort,
-            if (tools != null && tools.isNotEmpty)
-              'tools': _cleanToolsForCompatibility(tools),
-            if (tools != null && tools.isNotEmpty) 'tool_choice': 'auto',
-          };
-          setMaxTokens(body2);
-
-          _applyVendorReasoningKnobs(
-            body2,
-            info: info,
-            isReasoning: isReasoning,
-            thinkingBudget: thinkingBudget,
-          );
-
-          // Ask for usage in streaming (when supported)
-          _applyCompatibleBuiltInSearch(
-            body2,
-            config: config,
-            modelId: modelId,
-            upstreamModelId: upstreamModelId,
-          );
-          _maybeAddStreamingUsageOptions(
-            body2,
-            stream: true,
-            config: config,
-            host: info.host,
-          );
-
-          // Apply custom body overrides
-          if (extraBodyCfg.isNotEmpty) {
-            body2.addAll(extraBodyCfg);
-          }
-
-          _sanitizeOpenAIGpt5SamplingParams(
-            body2,
-            upstreamModelId,
-            fallbackEffort: effort,
-            isOpenRouter: info.isOpenRouter,
-          );
-          _normalizeMoonshotKimiChatBody(
-            body2,
-            upstreamModelId: upstreamModelId,
-            isReasoning: isReasoning,
-            thinkingBudget: thinkingBudget,
-          );
-
-          final req2 = http.Request('POST', url);
-          final headers2 = _customHeaders(
-            config,
-            modelId,
-            baseHeaders: <String, String>{
-              'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
-              'Content-Type': 'application/json',
-              'Accept': 'text/event-stream',
-            },
-            assistantHeaders: extraHeaders,
-          );
-          req2.headers.addAll(headers2);
-          req2.body = jsonEncode(body2);
-          final resp2 = await client.send(req2);
-          if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
-            final errorBody = await resp2.stream.bytesToString();
-            throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
-          }
-          final s2 = resp2.stream.transform(utf8.decoder);
-          final roundDecoder = ChatCompletionsStreamDecoder(
-            wantsImageOutput: wantsImageOutput,
-            needsReasoningEcho: needsReasoningEcho,
-            allowReasoningSnapshots: reasoningDetailsAllowSnapshots,
-            initialUsage: usage,
-            sourceId: 'round-${streamRound++}',
-          );
-          await for (final event in parseSseEventStrings(s2)) {
-            final d = event.data;
-            if (d == '[DONE]') {
-              continue;
-            }
-            _throwIfInBandStreamError(d);
-            try {
-              for (final chunk in roundDecoder.accept(event).chunks) {
-                yield chunk;
-              }
-            } catch (_) {}
-          }
-          usage = roundDecoder.usage ?? usage;
-          if (usage != null) totalTokens = usage.totalTokens;
-          final toolAcc2 = roundDecoder.toolCalls;
-          final finishReason2 = roundDecoder.finishReason;
-          final contentAccum = roundDecoder.assistantContent;
-          final reasoningAccum = roundDecoder.reasoningEcho;
-          final reasoningDetailsAccum = roundDecoder.reasoningDetails;
-
-          // After this follow-up round finishes: if tool calls again, execute and loop
-          if (finishReason2 == 'tool_calls' || toolAcc2.isNotEmpty) {
-            final calls2 = <Map<String, dynamic>>[];
-            final callInfos2 = <EmitToolCall>[];
-            final toolMsgs2 = <Map<String, dynamic>>[];
-            toolAcc2.forEach((idx, m) {
-              final id = _effectiveToolCallId(m['id'], 'call', idx);
-              final name = (m['name'] ?? '');
-              Map<String, dynamic> args;
-              try {
-                args = (jsonDecode(m['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args = <String, dynamic>{};
-              }
-              callInfos2.add(emitToolCall(id: id, name: name, arguments: args));
-              calls2.add({
-                'id': id,
-                'type': 'function',
-                'function': {'name': name, 'arguments': jsonEncode(args)},
-              });
-              toolMsgs2.add({'__name': name, '__id': id, '__args': args});
-            });
-            final results2 = <Map<String, dynamic>>[];
-            final resultsInfo2 = <EmitToolResult>[];
-            for (final m in toolMsgs2) {
-              final name = m['__name'] as String;
-              final id = m['__id'] as String;
-              final args = (m['__args'] as Map<String, dynamic>);
-              final res = await effectiveOnToolCall(name, args, toolCallId: id);
-              results2.add({'tool_call_id': id, 'content': res});
-              resultsInfo2.add(
-                emitToolResult(
-                  id: id,
-                  name: name,
-                  arguments: args,
-                  content: res,
-                ),
-              );
-            }
-            if (resultsInfo2.isNotEmpty) {
-              yield* emitToolResults(
-                resultsInfo2,
-                usage: usage,
-                totalTokens: usage?.totalTokens ?? 0,
-              );
-            }
-            // Append for next loop - including any content accumulated in this round
-            final nextAssistantToolCall = _buildAssistantToolCallMessage(
-              calls: calls2,
-              content: contentAccum,
-              reasoningContent: needsReasoningEcho ? reasoningAccum : null,
-              includeEmptyReasoningContent: needsReasoningEcho,
-              reasoningDetails: reasoningDetailsAccum,
-            );
-            currentMessages = [
-              ...currentMessages,
-              nextAssistantToolCall,
-              for (final r in results2)
-                {
-                  'role': 'tool',
-                  'tool_call_id': r['tool_call_id'],
-                  'name': calls2.firstWhere(
-                    (c) => c['id'] == r['tool_call_id'],
-                    orElse: () => const {
-                      'function': {'name': ''},
-                    },
-                  )['function']['name'],
-                  'content': r['content'],
-                },
-            ];
-            // Continue loop
-            continue;
-          } else {
-            // No further tool calls; finish
-            final approxTotal =
-                approxPromptTokens +
-                approxTokensFromChars(approxCompletionChars);
-            yield* emitDone(
-              reasoningDetails: reasoningDetailsAccum,
-              usage: usage,
-              totalTokens: usage?.totalTokens ?? approxTotal,
-            );
-            return;
-          }
-        }
+        return;
       }
 
       final approxTotal =
@@ -2578,324 +2799,65 @@ Stream<StreamChunk> _sendOpenAIStream(
           }
         }
         if (!decoder.emittedCitationEvents && decoder.citations.isNotEmpty) {
-          final payload = jsonEncode({'items': decoder.citations});
-          yield* emitToolResults(
-            [
-              emitToolResult(
-                id: 'builtin_search',
-                name: 'search_web',
-                arguments: const <String, dynamic>{},
-                content: payload,
-              ),
-            ],
-            usage: usage,
-            totalTokens: totalTokens,
+          yield ServerToolStart(id: 'builtin_search', toolName: 'search_web');
+          yield ServerToolEnd(
+            id: 'builtin_search',
+            output: <String, dynamic>{'items': decoder.citations},
           );
         }
         // Responses tool calling follow-up handling
         final bool hasRespCalls =
             respToolCallsByIndex.isNotEmpty || toolAccResp.isNotEmpty;
         if (effectiveOnToolCall != null && hasRespCalls) {
-          // Prefer the indexed calls (with call_id); fallback to toolAccResp
-          final callInfos = <EmitToolCall>[];
-          final msgs = <Map<String, dynamic>>[]; // for executing tools
-          if (respToolCallsByIndex.isNotEmpty) {
-            final sorted = respToolCallsByIndex.keys.toList()..sort();
-            for (final idx in sorted) {
-              final m = respToolCallsByIndex[idx]!;
-              final callId = (m['call_id'] ?? '').toString();
-              final name = (m['name'] ?? '').toString();
-              Map<String, dynamic> args;
-              try {
-                args = (jsonDecode(m['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args = <String, dynamic>{};
-              }
-              final id = _effectiveToolCallId(callId, 'call', idx);
-              callInfos.add(emitToolCall(id: id, name: name, arguments: args));
-              msgs.add({'__id': id, '__name': name, '__args': args});
-            }
-          } else {
-            int idx = 0;
-            toolAccResp.forEach((key, m) {
-              Map<String, dynamic> args;
-              try {
-                args = (jsonDecode(m['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args = <String, dynamic>{};
-              }
-              final id2 = _effectiveToolCallId(key, 'call', idx);
-              callInfos.add(
-                emitToolCall(id: id2, name: (m['name'] ?? ''), arguments: args),
-              );
-              msgs.add({
-                '__id': id2,
-                '__name': (m['name'] ?? ''),
-                '__args': args,
-              });
-              idx += 1;
-            });
-          }
-          final responseOutputItems = _withResponsesFunctionCallItems(
-            lastResponseOutputItems,
-            callInfos,
-          );
-          final resultsInfo = <EmitToolResult>[];
-          final followUpOutputs = <Map<String, dynamic>>[];
-          for (final m in msgs) {
-            final nm = m['__name'] as String;
-            final id2 = m['__id'] as String;
-            final args = (m['__args'] as Map<String, dynamic>);
-            final res = await effectiveOnToolCall(nm, args, toolCallId: id2);
-            resultsInfo.add(
-              emitToolResult(id: id2, name: nm, arguments: args, content: res),
-            );
-            followUpOutputs.add({
-              'type': 'function_call_output',
-              'call_id': id2,
-              'output': res,
-            });
-          }
-          if (resultsInfo.isNotEmpty) {
-            yield* emitToolResults(
-              resultsInfo,
-              usage: usage,
-              totalTokens: usage?.totalTokens ?? 0,
-            );
-          }
-
-          // Build follow-up Responses request input
-          List<Map<String, dynamic>> currentInput = <Map<String, dynamic>>[
-            ...responsesInitialInput,
-          ];
-          if (responseOutputItems.isNotEmpty) {
-            currentInput.addAll(responseOutputItems);
-          }
-          currentInput.addAll(followUpOutputs);
-
-          // Iteratively request until the model stops issuing tool calls,
-          // consistent with how Claude, Gemini and OpenAI Chat Completions
-          // providers handle the tool-call loop (while-true until done).
-          // Guard: break if the exact same tool-call set repeats 3 times
-          // consecutively, which indicates the model is stuck in a loop.
-          const int maxConsecutiveDupes = 3;
-          String? lastToolSignature;
-          int consecutiveDupeCount = 0;
-          while (true) {
-            final body2 = <String, dynamic>{
-              'model': upstreamModelId,
-              'input': currentInput,
-              'stream': true,
-              if (responsesToolsSpec.isNotEmpty) 'tools': responsesToolsSpec,
-              if (responsesToolsSpec.isNotEmpty) 'tool_choice': 'auto',
-              if (responsesInstructions.isNotEmpty)
-                'instructions': responsesInstructions,
-              if (temperature != null) 'temperature': temperature,
-              if (topP != null) 'top_p': topP,
-              if (maxTokens != null) 'max_output_tokens': maxTokens,
-              if (isReasoning && effort != 'off')
-                'reasoning': {
-                  'summary': 'auto',
-                  if (effort != 'auto') 'effort': effort,
-                },
-              if (responsesIncludeParam != null)
-                'include': responsesIncludeParam,
-            };
-            _applyCompatibleResponsesReasoning(
-              body2,
-              config: config,
-              modelId: modelId,
-              upstreamModelId: upstreamModelId,
-              isReasoning: isReasoning,
-              thinkingBudget: thinkingBudget,
-            );
-
-            // Apply overrides
-            final extraCfg = _customBody(
-              config,
-              modelId,
-              assistantBody: extraBody,
-            );
-            if (extraCfg.isNotEmpty) body2.addAll(extraCfg);
-            // Ensure tools are flattened
-            try {
-              if (body2['tools'] is List) {
-                final raw = (body2['tools'] as List).cast<dynamic>();
-                body2['tools'] = _toResponsesToolsFormat(
-                  raw.map((e) => (e as Map).cast<String, dynamic>()).toList(),
-                );
-              }
-            } catch (_) {}
-
-            _sanitizeOpenAIGpt5SamplingParams(
-              body2,
-              upstreamModelId,
-              fallbackEffort: effort,
-              isOpenRouter: info.isOpenRouter,
-            );
-
-            final req2 = http.Request('POST', url);
-            final headers2 = _customHeaders(
-              config,
-              modelId,
-              baseHeaders: <String, String>{
-                'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
-                'Content-Type': 'application/json',
-                'Accept': 'text/event-stream',
-              },
-              assistantHeaders: extraHeaders,
-            );
-            req2.headers.addAll(headers2);
-            req2.body = jsonEncode(body2);
-            final http.StreamedResponse resp2;
-            try {
-              resp2 = await client.send(req2);
-              if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
-                final errorBody = await resp2.stream.bytesToString();
-                throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
-              }
-            } on HttpException {
-              rethrow;
-            } catch (e) {
-              // Keep as HttpException so the per-event catch below (which
-              // tolerates malformed JSON) cannot swallow this failure.
-              throw HttpException('Follow-up request failed: $e');
-            }
-            final s2 = _rethrowFollowUpStreamErrors(
-              resp2.stream.transform(utf8.decoder),
-            );
-            final followUpDecoder = ResponsesStreamDecoder(
-              initialUsage: usage,
-              sourceId: 'round-${streamRound++}',
-            );
-            await for (final event in parseSseEventStrings(s2)) {
-              final d = event.data;
-              if (d == '[DONE]') {
-                followUpDecoder.accept(event);
-                break;
-              }
-              _throwIfInBandStreamError(d);
-              final decoded = followUpDecoder.accept(event);
-              for (final chunk in decoded.chunks) {
-                yield chunk;
-              }
-              if (decoded.completed) break;
-            }
-            usage = followUpDecoder.usage ?? usage;
-            totalTokens = usage?.totalTokens ?? totalTokens;
-            approxCompletionChars += followUpDecoder.approxCompletionChars;
-            final respCalls2 = <int, Map<String, String>>{
-              for (final call in followUpDecoder.takeFunctionCalls())
-                call.index: <String, String>{
-                  'call_id': call.callId,
-                  'name': call.name,
-                  'args': call.args,
-                },
-            };
-            final outItems2 = followUpDecoder.outputItems;
-
-            if (respCalls2.isEmpty) {
-              // No further tool calls; finalize
-              final approxTotal2 =
-                  approxPromptTokens +
-                  approxTokensFromChars(approxCompletionChars);
-              yield* emitDone(
-                usage: usage,
-                totalTokens: usage?.totalTokens ?? approxTotal2,
-              );
-              return;
-            }
-
-            // Detect consecutive duplicate tool-call patterns
-            final sorted2 = respCalls2.keys.toList()..sort();
-            final sigParts = <String>[];
-            for (final idx2 in sorted2) {
-              final m2 = respCalls2[idx2]!;
-              sigParts.add('${m2['name'] ?? ''}:${m2['args'] ?? ''}');
-            }
-            final currentSig = sigParts.join('|');
-            if (currentSig == lastToolSignature) {
-              consecutiveDupeCount += 1;
-              if (consecutiveDupeCount >= maxConsecutiveDupes) {
-                // Break out of loop – model is stuck repeating the same calls
-                break;
-              }
-            } else {
-              lastToolSignature = currentSig;
-              consecutiveDupeCount = 1;
-            }
-
-            // Execute next round of tool calls
-            final callInfos2 = <EmitToolCall>[];
-            final msgs2 = <Map<String, dynamic>>[];
-            for (final idx2 in sorted2) {
-              final m2 = respCalls2[idx2]!;
-              final callId2 = (m2['call_id'] ?? '').toString();
-              final name2 = (m2['name'] ?? '').toString();
-              Map<String, dynamic> args2;
-              try {
-                args2 = (jsonDecode(m2['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args2 = <String, dynamic>{};
-              }
-              final id2 = _effectiveToolCallId(callId2, 'call', idx2);
-              callInfos2.add(
-                emitToolCall(id: id2, name: name2, arguments: args2),
-              );
-              msgs2.add({'__id': id2, '__name': name2, '__args': args2});
-            }
-            final responseOutputItems2 = _withResponsesFunctionCallItems(
-              outItems2,
-              callInfos2,
-            );
-            final resultsInfo2 = <EmitToolResult>[];
-            final followUpOutputs2 = <Map<String, dynamic>>[];
-            for (final m in msgs2) {
-              final nm = m['__name'] as String;
-              final id2 = m['__id'] as String;
-              final args2 = (m['__args'] as Map<String, dynamic>);
-              final res2 = await effectiveOnToolCall(
-                nm,
-                args2,
-                toolCallId: id2,
-              );
-              resultsInfo2.add(
-                emitToolResult(
-                  id: id2,
-                  name: nm,
-                  arguments: args2,
-                  content: res2,
-                ),
-              );
-              followUpOutputs2.add({
-                'type': 'function_call_output',
-                'call_id': id2,
-                'output': res2,
-              });
-            }
-            if (resultsInfo2.isNotEmpty) {
-              yield* emitToolResults(
-                resultsInfo2,
-                usage: usage,
-                totalTokens: usage?.totalTokens ?? 0,
-              );
-            }
-            // Extend current input with this round's model output and our outputs
-            if (responseOutputItems2.isNotEmpty) {
-              currentInput.addAll(responseOutputItems2);
-            }
-            currentInput.addAll(followUpOutputs2);
-          }
-
-          // Safety
-          final approxTotal =
-              approxPromptTokens + approxTokensFromChars(approxCompletionChars);
-          yield* emitDone(
-            usage: usage,
-            totalTokens: usage?.totalTokens ?? approxTotal,
+          final callInfos = respToolCallsByIndex.isNotEmpty
+              ? _responsesCallsFromIndexMap(respToolCallsByIndex)
+              : [
+                  for (final entry
+                      in toolAccResp.entries.toList().asMap().entries)
+                    emitToolCall(
+                      id: _effectiveToolCallId(
+                        entry.value.key,
+                        'call',
+                        entry.key,
+                      ),
+                      name: (entry.value.value['name'] ?? '').toString(),
+                      arguments: () {
+                        try {
+                          return (jsonDecode(entry.value.value['args'] ?? '{}')
+                                  as Map)
+                              .cast<String, dynamic>();
+                        } catch (_) {
+                          return <String, dynamic>{};
+                        }
+                      }(),
+                    ),
+                ];
+          yield* _runOpenAIResponsesToolFollowUps(
+            client: client,
+            config: config,
+            modelId: modelId,
+            upstreamModelId: upstreamModelId,
+            url: url,
+            info: info,
+            initialInput: responsesInitialInput,
+            firstOutputItems: lastResponseOutputItems,
+            initialCalls: callInfos,
+            responsesToolsSpec: responsesToolsSpec,
+            responsesInstructions: responsesInstructions,
+            responsesIncludeParam: responsesIncludeParam,
+            onToolCall: effectiveOnToolCall,
+            extraHeaders: extraHeaders,
+            extraBody: extraBody,
+            temperature: temperature,
+            topP: topP,
+            maxTokens: maxTokens,
+            isReasoning: isReasoning,
+            effort: effort,
+            thinkingBudget: thinkingBudget,
+            initialUsage: usage,
+            streamRound: streamRound,
+            approxPromptTokens: approxPromptTokens,
+            approxCompletionChars: approxCompletionChars,
           );
           return;
         }
@@ -2933,274 +2895,44 @@ Stream<StreamChunk> _sendOpenAIStream(
           finishReason == 'tool_calls' &&
           toolAcc.isNotEmpty &&
           effectiveOnToolCall != null) {
-        // print('[ChatApi/XinLiu] Executing tools immediately (finishReason=tool_calls, toolAcc.size=${toolAcc.length})');
-        // Some providers (like XinLiu) return tool_calls with finish_reason='tool_calls' but no [DONE]
-        // Execute tools immediately in this case
-        final calls = <Map<String, dynamic>>[];
-        final callInfos = <EmitToolCall>[];
-        final toolMsgs = <Map<String, dynamic>>[];
-        toolAcc.forEach((idx, m) {
-          final id = _effectiveToolCallId(m['id'], 'call', idx);
-          final name = (m['name'] ?? '');
-          Map<String, dynamic> args;
-          try {
-            args = (jsonDecode(m['args'] ?? '{}') as Map)
-                .cast<String, dynamic>();
-          } catch (_) {
-            args = <String, dynamic>{};
-          }
-          callInfos.add(emitToolCall(id: id, name: name, arguments: args));
-          calls.add({
-            'id': id,
-            'type': 'function',
-            'function': {'name': name, 'arguments': jsonEncode(args)},
-          });
-          toolMsgs.add({'__name': name, '__id': id, '__args': args});
-        });
-        // Execute tools and emit results. ToolCall* already left the decoder.
-        final results = <Map<String, dynamic>>[];
-        final resultsInfo = <EmitToolResult>[];
-        for (final m in toolMsgs) {
-          final name = m['__name'] as String;
-          final id = m['__id'] as String;
-          final args = (m['__args'] as Map<String, dynamic>);
-          final res = await effectiveOnToolCall(name, args, toolCallId: id);
-          results.add({'tool_call_id': id, 'content': res});
-          resultsInfo.add(
-            emitToolResult(id: id, name: name, arguments: args, content: res),
-          );
-        }
-        if (resultsInfo.isNotEmpty) {
-          yield* emitToolResults(
-            resultsInfo,
-            usage: usage,
-            totalTokens: usage?.totalTokens ?? 0,
-          );
-        }
-        // Build follow-up messages
-        final mm2 = <Map<String, dynamic>>[];
-        for (final m in messages) {
-          mm2.add(_copyChatCompletionMessage(m));
-        }
-        final assistantToolCallMsg = _buildAssistantToolCallMessage(
-          calls: calls,
-          content: assistantContentBuffer,
-          reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
-          includeEmptyReasoningContent: needsReasoningEcho,
-          reasoningDetails:
+        yield* _runOpenAIChatCompletionsToolFollowUps(
+          client: client,
+          config: config,
+          modelId: modelId,
+          upstreamModelId: upstreamModelId,
+          url: url,
+          info: info,
+          messages: messages,
+          firstToolAcc: toolAcc,
+          firstAssistantContent: assistantContentBuffer,
+          firstReasoning: reasoningBuffer,
+          firstReasoningDetails:
               chatDecoder.reasoningDetails ??
               reasoningDetailsBuffer.detailsOrNull,
+          onToolCall: effectiveOnToolCall,
+          userImagePaths: userImagePaths,
+          canImageInput: canImageInput,
+          allowRemoteImages: allowRemoteImages,
+          isClaudeUpstream: isClaudeUpstream,
+          isReasoning: isReasoning,
+          effort: effort,
+          thinkingBudget: thinkingBudget,
+          temperature: temperature,
+          topP: topP,
+          tools: tools,
+          extraBodyCfg: extraBodyCfg,
+          extraHeaders: extraHeaders,
+          wantsImageOutput: wantsImageOutput,
+          needsReasoningEcho: needsReasoningEcho,
+          reasoningDetailsAllowSnapshots: reasoningDetailsAllowSnapshots,
+          applyMaxTokens: setMaxTokens,
+          initialUsage: usage,
+          streamRound: streamRound,
+          approxPromptTokens: approxPromptTokens,
+          approxCompletionChars: approxCompletionChars,
+          includeReasoningDetailsOnDone: true,
         );
-        mm2.add(assistantToolCallMsg);
-        for (final r in results) {
-          final id = r['tool_call_id'];
-          final name = calls.firstWhere(
-            (c) => c['id'] == id,
-            orElse: () => const {
-              'function': {'name': ''},
-            },
-          )['function']['name'];
-          mm2.add({
-            'role': 'tool',
-            'tool_call_id': id,
-            'name': name,
-            'content': r['content'],
-          });
-        }
-        // Continue streaming with follow-up request
-        var currentMessages = mm2;
-        while (true) {
-          final Map<String, dynamic> body2 = {
-            'model': upstreamModelId,
-            'messages': await _buildOpenAIChatCompletionMessages(
-              currentMessages,
-              userMediaPaths: userImagePaths,
-              canImageInput: canImageInput,
-              allowRemoteImages: allowRemoteImages,
-              reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
-              stripReasoningContent: isClaudeUpstream,
-            ),
-            'stream': true,
-            if (temperature != null) 'temperature': temperature,
-            if (topP != null) 'top_p': topP,
-            if (isReasoning && effort != 'off' && effort != 'auto')
-              'reasoning_effort': effort,
-            if (tools != null && tools.isNotEmpty)
-              'tools': _cleanToolsForCompatibility(tools),
-            if (tools != null && tools.isNotEmpty) 'tool_choice': 'auto',
-          };
-          setMaxTokens(body2);
-          _applyVendorReasoningKnobs(
-            body2,
-            info: info,
-            isReasoning: isReasoning,
-            thinkingBudget: thinkingBudget,
-          );
-          _applyCompatibleBuiltInSearch(
-            body2,
-            config: config,
-            modelId: modelId,
-            upstreamModelId: upstreamModelId,
-          );
-          _maybeAddStreamingUsageOptions(
-            body2,
-            stream: true,
-            config: config,
-            host: info.host,
-          );
-          if (extraBodyCfg.isNotEmpty) {
-            body2.addAll(extraBodyCfg);
-          }
-          _sanitizeOpenAIGpt5SamplingParams(
-            body2,
-            upstreamModelId,
-            fallbackEffort: effort,
-            isOpenRouter: info.isOpenRouter,
-          );
-          _normalizeMoonshotKimiChatBody(
-            body2,
-            upstreamModelId: upstreamModelId,
-            isReasoning: isReasoning,
-            thinkingBudget: thinkingBudget,
-          );
-          final req2 = http.Request('POST', url);
-          final headers2 = _customHeaders(
-            config,
-            modelId,
-            baseHeaders: <String, String>{
-              'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
-              'Content-Type': 'application/json',
-              'Accept': 'text/event-stream',
-            },
-            assistantHeaders: extraHeaders,
-          );
-          req2.headers.addAll(headers2);
-          req2.body = jsonEncode(body2);
-          final http.StreamedResponse resp2;
-          try {
-            resp2 = await client.send(req2);
-            if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
-              final errorBody = await resp2.stream.bytesToString();
-              throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
-            }
-          } on HttpException {
-            rethrow;
-          } catch (e) {
-            // Keep as HttpException so the per-event catch below (which
-            // tolerates malformed JSON) cannot swallow this failure.
-            throw HttpException('Follow-up request failed: $e');
-          }
-          final s2 = _rethrowFollowUpStreamErrors(
-            resp2.stream.transform(utf8.decoder),
-          );
-          final roundDecoder = ChatCompletionsStreamDecoder(
-            wantsImageOutput: wantsImageOutput,
-            needsReasoningEcho: needsReasoningEcho,
-            allowReasoningSnapshots: reasoningDetailsAllowSnapshots,
-            initialUsage: usage,
-            sourceId: 'round-${streamRound++}',
-          );
-          await for (final event in parseSseEventStrings(s2)) {
-            final d = event.data;
-            if (d == '[DONE]') {
-              continue;
-            }
-            _throwIfInBandStreamError(d);
-            try {
-              for (final chunk in roundDecoder.accept(event).chunks) {
-                yield chunk;
-              }
-            } catch (_) {}
-          }
-          usage = roundDecoder.usage ?? usage;
-          if (usage != null) totalTokens = usage.totalTokens;
-          final toolAcc2 = roundDecoder.toolCalls;
-          final finishReason2 = roundDecoder.finishReason;
-          final contentAccum = roundDecoder.assistantContent;
-          final reasoningAccum = roundDecoder.reasoningEcho;
-          final reasoningDetailsAccum = roundDecoder.reasoningDetails;
-          if (finishReason2 == 'tool_calls' || toolAcc2.isNotEmpty) {
-            final calls2 = <Map<String, dynamic>>[];
-            final callInfos2 = <EmitToolCall>[];
-            final toolMsgs2 = <Map<String, dynamic>>[];
-            toolAcc2.forEach((idx, m) {
-              final id = _effectiveToolCallId(m['id'], 'call', idx);
-              final name = (m['name'] ?? '');
-              Map<String, dynamic> args;
-              try {
-                args = (jsonDecode(m['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args = <String, dynamic>{};
-              }
-              callInfos2.add(emitToolCall(id: id, name: name, arguments: args));
-              calls2.add({
-                'id': id,
-                'type': 'function',
-                'function': {'name': name, 'arguments': jsonEncode(args)},
-              });
-              toolMsgs2.add({'__name': name, '__id': id, '__args': args});
-            });
-            final results2 = <Map<String, dynamic>>[];
-            final resultsInfo2 = <EmitToolResult>[];
-            for (final m in toolMsgs2) {
-              final name = m['__name'] as String;
-              final id = m['__id'] as String;
-              final args = (m['__args'] as Map<String, dynamic>);
-              final res = await effectiveOnToolCall(name, args, toolCallId: id);
-              results2.add({'tool_call_id': id, 'content': res});
-              resultsInfo2.add(
-                emitToolResult(
-                  id: id,
-                  name: name,
-                  arguments: args,
-                  content: res,
-                ),
-              );
-            }
-            if (resultsInfo2.isNotEmpty) {
-              yield* emitToolResults(
-                resultsInfo2,
-                usage: usage,
-                totalTokens: usage?.totalTokens ?? 0,
-              );
-            }
-            final nextAssistantToolCall = _buildAssistantToolCallMessage(
-              calls: calls2,
-              content: contentAccum,
-              reasoningContent: needsReasoningEcho ? reasoningAccum : null,
-              includeEmptyReasoningContent: needsReasoningEcho,
-              reasoningDetails: reasoningDetailsAccum,
-            );
-            currentMessages = [
-              ...currentMessages,
-              nextAssistantToolCall,
-              for (final r in results2)
-                {
-                  'role': 'tool',
-                  'tool_call_id': r['tool_call_id'],
-                  'name': calls2.firstWhere(
-                    (c) => c['id'] == r['tool_call_id'],
-                    orElse: () => const {
-                      'function': {'name': ''},
-                    },
-                  )['function']['name'],
-                  'content': r['content'],
-                },
-            ];
-            continue;
-          } else {
-            final approxTotal =
-                approxPromptTokens +
-                approxTokensFromChars(approxCompletionChars);
-            yield* emitDone(
-              reasoningDetails: reasoningDetailsAccum,
-              usage: usage,
-              totalTokens: usage?.totalTokens ?? approxTotal,
-            );
-            return;
-          }
-        }
+        return;
       }
       // XinLiu compatibility: Don't end early if we have accumulated tool calls
       if (config.useResponseApi != true &&
@@ -3208,288 +2940,48 @@ Stream<StreamChunk> _sendOpenAIStream(
           finishReason != 'tool_calls') {
         final bool hasPendingToolCalls =
             toolAcc.isNotEmpty || toolAccResp.isNotEmpty;
-        if (hasPendingToolCalls) {
+        final pendingHandler = effectiveOnToolCall;
+        if (hasPendingToolCalls && pendingHandler != null) {
           // Some providers (like XinLiu/iflow.cn) may return tool_calls with finish_reason='stop'
           // and may not send a [DONE] marker. Execute tools immediately in this case.
-          if (effectiveOnToolCall != null && toolAcc.isNotEmpty) {
-            final calls = <Map<String, dynamic>>[];
-            final callInfos = <EmitToolCall>[];
-            final toolMsgs = <Map<String, dynamic>>[];
-            toolAcc.forEach((idx, m) {
-              final id = _effectiveToolCallId(m['id'], 'call', idx);
-              final name = (m['name'] ?? '');
-              Map<String, dynamic> args;
-              try {
-                args = (jsonDecode(m['args'] ?? '{}') as Map)
-                    .cast<String, dynamic>();
-              } catch (_) {
-                args = <String, dynamic>{};
-              }
-              callInfos.add(emitToolCall(id: id, name: name, arguments: args));
-              calls.add({
-                'id': id,
-                'type': 'function',
-                'function': {'name': name, 'arguments': jsonEncode(args)},
-              });
-              toolMsgs.add({'__name': name, '__id': id, '__args': args});
-            });
-            // Execute tools and emit results. ToolCall* already left the decoder.
-            final results = <Map<String, dynamic>>[];
-            final resultsInfo = <EmitToolResult>[];
-            for (final m in toolMsgs) {
-              final name = m['__name'] as String;
-              final id = m['__id'] as String;
-              final args = (m['__args'] as Map<String, dynamic>);
-              final res = await effectiveOnToolCall(name, args, toolCallId: id);
-              results.add({'tool_call_id': id, 'content': res});
-              resultsInfo.add(
-                emitToolResult(
-                  id: id,
-                  name: name,
-                  arguments: args,
-                  content: res,
-                ),
-              );
-            }
-            if (resultsInfo.isNotEmpty) {
-              yield* emitToolResults(
-                resultsInfo,
-                usage: usage,
-                totalTokens: usage?.totalTokens ?? 0,
-              );
-            }
-            // Build follow-up messages
-            final mm2 = <Map<String, dynamic>>[];
-            for (final m in messages) {
-              mm2.add(_copyChatCompletionMessage(m));
-            }
-            final assistantToolCallMsg = _buildAssistantToolCallMessage(
-              calls: calls,
-              content: assistantContentBuffer,
-              reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
-              includeEmptyReasoningContent: needsReasoningEcho,
-              reasoningDetails:
-                  chatDecoder.reasoningDetails ??
-                  reasoningDetailsBuffer.detailsOrNull,
-            );
-            mm2.add(assistantToolCallMsg);
-            for (final r in results) {
-              final id = r['tool_call_id'];
-              final name = calls.firstWhere(
-                (c) => c['id'] == id,
-                orElse: () => const {
-                  'function': {'name': ''},
-                },
-              )['function']['name'];
-              mm2.add({
-                'role': 'tool',
-                'tool_call_id': id,
-                'name': name,
-                'content': r['content'],
-              });
-            }
-            // Continue streaming with follow-up request - reuse existing multi-round logic from [DONE] handler
-            var currentMessages = mm2;
-            while (true) {
-              final Map<String, dynamic> body2 = {
-                'model': upstreamModelId,
-                'messages': await _buildOpenAIChatCompletionMessages(
-                  currentMessages,
-                  userMediaPaths: userImagePaths,
-                  canImageInput: canImageInput,
-                  allowRemoteImages: allowRemoteImages,
-                  reasoningContentReplayPolicy:
-                      info.reasoningContentReplayPolicy,
-                  stripReasoningContent: isClaudeUpstream,
-                ),
-                'stream': true,
-                if (temperature != null) 'temperature': temperature,
-                if (topP != null) 'top_p': topP,
-                if (isReasoning && effort != 'off' && effort != 'auto')
-                  'reasoning_effort': effort,
-                if (tools != null && tools.isNotEmpty)
-                  'tools': _cleanToolsForCompatibility(tools),
-                if (tools != null && tools.isNotEmpty) 'tool_choice': 'auto',
-              };
-              setMaxTokens(body2);
-              _applyVendorReasoningKnobs(
-                body2,
-                info: info,
-                isReasoning: isReasoning,
-                thinkingBudget: thinkingBudget,
-              );
-              _applyCompatibleBuiltInSearch(
-                body2,
-                config: config,
-                modelId: modelId,
-                upstreamModelId: upstreamModelId,
-              );
-              _maybeAddStreamingUsageOptions(
-                body2,
-                stream: true,
-                config: config,
-                host: info.host,
-              );
-              if (extraBodyCfg.isNotEmpty) {
-                body2.addAll(extraBodyCfg);
-              }
-              _sanitizeOpenAIGpt5SamplingParams(
-                body2,
-                upstreamModelId,
-                fallbackEffort: effort,
-                isOpenRouter: info.isOpenRouter,
-              );
-              _normalizeMoonshotKimiChatBody(
-                body2,
-                upstreamModelId: upstreamModelId,
-                isReasoning: isReasoning,
-                thinkingBudget: thinkingBudget,
-              );
-              final req2 = http.Request('POST', url);
-              final headers2 = _customHeaders(
-                config,
-                modelId,
-                baseHeaders: <String, String>{
-                  'Authorization':
-                      'Bearer ${_apiKeyForRequest(config, modelId)}',
-                  'Content-Type': 'application/json',
-                  'Accept': 'text/event-stream',
-                },
-                assistantHeaders: extraHeaders,
-              );
-              req2.headers.addAll(headers2);
-              req2.body = jsonEncode(body2);
-              final http.StreamedResponse resp2;
-              try {
-                resp2 = await client.send(req2);
-                if (resp2.statusCode < 200 || resp2.statusCode >= 300) {
-                  final errorBody = await resp2.stream.bytesToString();
-                  throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
-                }
-              } on HttpException {
-                rethrow;
-              } catch (e) {
-                // Keep as HttpException so the per-event catch below (which
-                // tolerates malformed JSON) cannot swallow this failure.
-                throw HttpException('Follow-up request failed: $e');
-              }
-              final s2 = _rethrowFollowUpStreamErrors(
-                resp2.stream.transform(utf8.decoder),
-              );
-              final roundDecoder = ChatCompletionsStreamDecoder(
-                wantsImageOutput: wantsImageOutput,
-                needsReasoningEcho: needsReasoningEcho,
-                allowReasoningSnapshots: reasoningDetailsAllowSnapshots,
-                initialUsage: usage,
-                sourceId: 'round-${streamRound++}',
-              );
-              await for (final event in parseSseEventStrings(s2)) {
-                final d = event.data;
-                if (d == '[DONE]') {
-                  continue;
-                }
-                _throwIfInBandStreamError(d);
-                try {
-                  for (final chunk in roundDecoder.accept(event).chunks) {
-                    yield chunk;
-                  }
-                } catch (_) {}
-              }
-              usage = roundDecoder.usage ?? usage;
-              if (usage != null) totalTokens = usage.totalTokens;
-              final toolAcc2 = roundDecoder.toolCalls;
-              final finishReason2 = roundDecoder.finishReason;
-              final contentAccum = roundDecoder.assistantContent;
-              final reasoningAccum = roundDecoder.reasoningEcho;
-              final reasoningDetailsAccum = roundDecoder.reasoningDetails;
-              if (finishReason2 == 'tool_calls' || toolAcc2.isNotEmpty) {
-                final calls2 = <Map<String, dynamic>>[];
-                final callInfos2 = <EmitToolCall>[];
-                final toolMsgs2 = <Map<String, dynamic>>[];
-                toolAcc2.forEach((idx, m) {
-                  final id = _effectiveToolCallId(m['id'], 'call', idx);
-                  final name = (m['name'] ?? '');
-                  Map<String, dynamic> args;
-                  try {
-                    args = (jsonDecode(m['args'] ?? '{}') as Map)
-                        .cast<String, dynamic>();
-                  } catch (_) {
-                    args = <String, dynamic>{};
-                  }
-                  callInfos2.add(
-                    emitToolCall(id: id, name: name, arguments: args),
-                  );
-                  calls2.add({
-                    'id': id,
-                    'type': 'function',
-                    'function': {'name': name, 'arguments': jsonEncode(args)},
-                  });
-                  toolMsgs2.add({'__name': name, '__id': id, '__args': args});
-                });
-                final results2 = <Map<String, dynamic>>[];
-                final resultsInfo2 = <EmitToolResult>[];
-                for (final m in toolMsgs2) {
-                  final name = m['__name'] as String;
-                  final id = m['__id'] as String;
-                  final args = (m['__args'] as Map<String, dynamic>);
-                  final res = await effectiveOnToolCall(
-                    name,
-                    args,
-                    toolCallId: id,
-                  );
-                  results2.add({'tool_call_id': id, 'content': res});
-                  resultsInfo2.add(
-                    emitToolResult(
-                      id: id,
-                      name: name,
-                      arguments: args,
-                      content: res,
-                    ),
-                  );
-                }
-                if (resultsInfo2.isNotEmpty) {
-                  yield* emitToolResults(
-                    resultsInfo2,
-                    usage: usage,
-                    totalTokens: usage?.totalTokens ?? 0,
-                  );
-                }
-                final nextAssistantToolCall = _buildAssistantToolCallMessage(
-                  calls: calls2,
-                  content: contentAccum,
-                  reasoningContent: needsReasoningEcho ? reasoningAccum : null,
-                  includeEmptyReasoningContent: needsReasoningEcho,
-                  reasoningDetails: reasoningDetailsAccum,
-                );
-                currentMessages = [
-                  ...currentMessages,
-                  nextAssistantToolCall,
-                  for (final r in results2)
-                    {
-                      'role': 'tool',
-                      'tool_call_id': r['tool_call_id'],
-                      'name': calls2.firstWhere(
-                        (c) => c['id'] == r['tool_call_id'],
-                        orElse: () => const {
-                          'function': {'name': ''},
-                        },
-                      )['function']['name'],
-                      'content': r['content'],
-                    },
-                ];
-                continue;
-              } else {
-                final approxTotal =
-                    approxPromptTokens +
-                    approxTokensFromChars(approxCompletionChars);
-                yield* emitDone(
-                  usage: usage,
-                  totalTokens: usage?.totalTokens ?? approxTotal,
-                );
-                return;
-              }
-            }
-          }
+          yield* _runOpenAIChatCompletionsToolFollowUps(
+            client: client,
+            config: config,
+            modelId: modelId,
+            upstreamModelId: upstreamModelId,
+            url: url,
+            info: info,
+            messages: messages,
+            firstToolAcc: toolAcc,
+            firstAssistantContent: assistantContentBuffer,
+            firstReasoning: reasoningBuffer,
+            firstReasoningDetails:
+                chatDecoder.reasoningDetails ??
+                reasoningDetailsBuffer.detailsOrNull,
+            onToolCall: pendingHandler,
+            userImagePaths: userImagePaths,
+            canImageInput: canImageInput,
+            allowRemoteImages: allowRemoteImages,
+            isClaudeUpstream: isClaudeUpstream,
+            isReasoning: isReasoning,
+            effort: effort,
+            thinkingBudget: thinkingBudget,
+            temperature: temperature,
+            topP: topP,
+            tools: tools,
+            extraBodyCfg: extraBodyCfg,
+            extraHeaders: extraHeaders,
+            wantsImageOutput: wantsImageOutput,
+            needsReasoningEcho: needsReasoningEcho,
+            reasoningDetailsAllowSnapshots: reasoningDetailsAllowSnapshots,
+            applyMaxTokens: setMaxTokens,
+            initialUsage: usage,
+            streamRound: streamRound,
+            approxPromptTokens: approxPromptTokens,
+            approxCompletionChars: approxCompletionChars,
+            includeReasoningDetailsOnDone: false,
+          );
+          return;
         }
       }
     } on HttpException {

--- a/lib/core/services/api/stream/stream_chunk.dart
+++ b/lib/core/services/api/stream/stream_chunk.dart
@@ -114,6 +114,19 @@ final class ToolCallEnd extends StreamChunk {
   final String id;
 }
 
+/// Local (Kelivo-executed) tool result.
+///
+/// Fills the matching [ToolCallPart] `content` without marking the part as a
+/// provider-hosted server tool. Provider-hosted search / code execution keep
+/// using [ServerToolEnd].
+final class ToolCallResult extends StreamChunk {
+  const ToolCallResult({required this.id, this.output, this.metadata});
+
+  final String id;
+  final Object? output;
+  final Map<String, dynamic>? metadata;
+}
+
 final class ServerToolStart extends StreamChunk {
   const ServerToolStart({
     required this.id,

--- a/lib/core/services/api/stream/stream_chunk_emit.dart
+++ b/lib/core/services/api/stream/stream_chunk_emit.dart
@@ -143,8 +143,6 @@ Stream<StreamChunk> emitToolCalls(
   }
 }
 
-// Local Kelivo-executed results reuse ServerTool until P5 lifts the tool
-// loop. Handler payload `server` is therefore true for these too.
 Stream<StreamChunk> emitToolResults(
   List<EmitToolResult> results, {
   TokenUsage? usage,
@@ -152,14 +150,8 @@ Stream<StreamChunk> emitToolResults(
 }) async* {
   yield* emitUsage(_usageOrApprox(usage, totalTokens));
   for (final result in results) {
-    yield ServerToolStart(
+    yield ToolCallResult(
       id: result.id,
-      toolName: result.name,
-      metadata: result.metadata,
-    );
-    yield ServerToolEnd(
-      id: result.id,
-      input: result.arguments,
       output: result.content,
       metadata: result.metadata,
     );

--- a/lib/core/services/api/stream/stream_chunk_handler.dart
+++ b/lib/core/services/api/stream/stream_chunk_handler.dart
@@ -63,6 +63,8 @@ class StreamChunkHandler {
         );
       case ToolCallEnd(:final id):
         _upsertTool(id);
+      case ToolCallResult(:final id, :final output, :final metadata):
+        _upsertTool(id, content: output ?? '', metadata: metadata);
       case ServerToolStart(
         :final id,
         :final toolName,

--- a/lib/core/services/api/stream/stream_trace.dart
+++ b/lib/core/services/api/stream/stream_trace.dart
@@ -155,6 +155,11 @@ Map<String, dynamic> _chunkSnapshot(StreamChunk chunk) {
       'type': 'tool_call_end',
       'id': id,
     },
+    ToolCallResult(:final id, :final output) => <String, dynamic>{
+      'type': 'tool_call_result',
+      'id': id,
+      if (output != null) 'output': _stableJson(output),
+    },
     ServerToolStart(:final id, :final toolName) => <String, dynamic>{
       'type': 'server_tool_start',
       'id': id,

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import '../../../core/database/generation_run.dart';
@@ -1878,70 +1877,22 @@ class ChatActions {
           await _handleReasoningChunk(text, state);
         }
         _scheduleStreamingCheckpoint(state);
-      case ToolCallStart(:final id, :final toolName, :final metadata):
+      case ToolCallStart(:final id, :final toolName):
         if (toolName.isNotEmpty) state.pendingToolNames[id] = toolName;
-        await _handleToolCallsChunk([
-          emitToolCall(
-            id: id,
-            name: state.pendingToolNames[id] ?? toolName,
-            arguments: const <String, dynamic>{},
-            metadata: metadata,
-          ),
-        ], state);
+        await _handleToolCallsChunk(chunk, state);
         _scheduleStreamingCheckpoint(state);
       case ToolCallDelta(:final id, :final toolNameDelta):
         if (toolNameDelta.isNotEmpty) {
           state.pendingToolNames[id] =
               '${state.pendingToolNames[id] ?? ''}$toolNameDelta';
         }
-      case ToolCallEnd(:final id):
-        await _handleToolCallsChunk([
-          _emitToolCallFromHandler(state, id),
-        ], state);
+      case ToolCallEnd():
+        await _handleToolCallsChunk(chunk, state);
         _scheduleStreamingCheckpoint(state);
       case ServerToolStart(:final id, :final toolName):
         if (toolName.isNotEmpty) state.pendingToolNames[id] = toolName;
-      case ServerToolEnd(
-        :final id,
-        :final input,
-        :final output,
-        :final metadata,
-      ):
-        await _handleToolResultsChunk([
-          emitToolResult(
-            id: id,
-            name: state.pendingToolNames.remove(id) ?? '',
-            arguments: input is Map
-                ? input.cast<String, dynamic>()
-                : const <String, dynamic>{},
-            content: output == null
-                ? ''
-                : output is String
-                ? output
-                : jsonEncode(output),
-            metadata: metadata,
-          ),
-        ], state);
-        _scheduleStreamingCheckpoint(state);
-      case Annotations(:final annotations):
-        if (annotations.isEmpty) return;
-        await _handleToolResultsChunk([
-          emitToolResult(
-            id: 'builtin_search',
-            name: 'search_web',
-            arguments: const <String, dynamic>{},
-            content: jsonEncode(<String, dynamic>{
-              'items': [
-                for (final citation
-                    in annotations.whereType<UrlCitationAnnotation>())
-                  <String, dynamic>{
-                    'url': citation.url,
-                    if (citation.title.isNotEmpty) 'title': citation.title,
-                  },
-              ],
-            }),
-          ),
-        ], state);
+      case ServerToolEnd() || ToolCallResult() || Annotations():
+        await _handleToolResultsChunk(chunk, state);
         _scheduleStreamingCheckpoint(state);
       case Usage(:final usage):
         _applyUsage(state, usage);
@@ -1963,37 +1914,6 @@ class ChatActions {
   void _applyUsage(stream_ctrl.StreamingState state, TokenUsage usage) {
     state.usage = (state.usage ?? const TokenUsage()).merge(usage);
     state.totalTokens = state.usage!.totalTokens;
-  }
-
-  EmitToolCall _emitToolCallFromHandler(
-    stream_ctrl.StreamingState state,
-    String id,
-  ) {
-    for (final part in state.shadowHandler.parts.reversed) {
-      if (part is! ToolCallPart) continue;
-      try {
-        final decoded = jsonDecode(part.payloadJson);
-        if (decoded is! Map) continue;
-        if ((decoded['id'] ?? '').toString() != id) continue;
-        final args = decoded['arguments'];
-        return emitToolCall(
-          id: id,
-          name: (decoded['name'] ?? state.pendingToolNames[id] ?? '')
-              .toString(),
-          arguments: args is Map
-              ? args.cast<String, dynamic>()
-              : const <String, dynamic>{},
-          metadata: decoded['metadata'] is Map
-              ? (decoded['metadata'] as Map).cast<String, dynamic>()
-              : null,
-        );
-      } catch (_) {}
-    }
-    return emitToolCall(
-      id: id,
-      name: state.pendingToolNames[id] ?? '',
-      arguments: const <String, dynamic>{},
-    );
   }
 
   Future<void> _markGenerationStreaming(
@@ -2034,11 +1954,11 @@ class ChatActions {
 
   /// Handle tool calls chunk from stream.
   Future<void> _handleToolCallsChunk(
-    List<EmitToolCall> toolCalls,
+    StreamChunk chunk,
     stream_ctrl.StreamingState state,
   ) async {
     await streamController.handleToolCallsChunk(
-      toolCalls,
+      chunk,
       state,
       updateReasoningSegmentsInDb: (String messageId, String json) async {
         // The complete reasoning snapshot is coalesced after this chunk.
@@ -2056,11 +1976,11 @@ class ChatActions {
 
   /// Handle tool results chunk from stream.
   Future<void> _handleToolResultsChunk(
-    List<EmitToolResult> toolResults,
+    StreamChunk chunk,
     stream_ctrl.StreamingState state,
   ) async {
     await streamController.handleToolResultsChunk(
-      toolResults,
+      chunk,
       state,
       upsertToolEventInDb:
           (

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import '../../../core/models/chat_message.dart';
@@ -6,6 +7,7 @@ import '../../../core/models/message_part.dart';
 import '../../../core/models/token_usage.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../core/services/api/stream/stream_chunk.dart';
 import '../../../core/services/api/stream/stream_chunk_handler.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../chat/widgets/chat_message_widget.dart';
@@ -895,9 +897,9 @@ class StreamController {
     }
   }
 
-  /// Process tool calls chunk from stream.
+  /// Process a tool-call [StreamChunk] (Start placeholder or End with args).
   Future<void> handleToolCallsChunk(
-    List<EmitToolCall> toolCalls,
+    StreamChunk chunk,
     StreamingState state, {
     required Future<void> Function(String messageId, String json)
     updateReasoningSegmentsInDb,
@@ -909,7 +911,8 @@ class StreamController {
     required List<Map<String, dynamic>> Function(String messageId)
     getToolEventsFromDb,
   }) async {
-    if (toolCalls.isEmpty) return;
+    final call = _toolCallUiFromChunk(chunk, state);
+    if (call == null) return;
 
     final messageId = state.messageId;
     final conversationId = state.conversationId;
@@ -932,21 +935,17 @@ class StreamController {
       );
     }
 
-    // Add tool call placeholders
     final existing = List<ToolUIPart>.of(_toolParts[messageId] ?? const []);
-    for (final c in toolCalls) {
-      existing.add(
-        ToolUIPart(
-          id: c.id,
-          toolName: c.name,
-          arguments: c.arguments,
-          loading: true,
-        ),
-      );
-    }
+    existing.add(
+      ToolUIPart(
+        id: call.id,
+        toolName: call.name,
+        arguments: call.arguments,
+        loading: true,
+      ),
+    );
     if (getCurrentConversationId() == conversationId) {
       _toolParts[messageId] = dedupeToolPartsList(existing);
-      // Notify via StreamingContentNotifier for real-time UI updates
       streamingContentNotifier.notifyToolPartsUpdated(
         messageId,
         contentSplitOffsets: state.contentSplitOffsets,
@@ -955,28 +954,26 @@ class StreamController {
       );
     }
 
-    // Persist tool events
     try {
       final prev = getToolEventsFromDb(messageId);
       final newEvents = <Map<String, dynamic>>[
         ...prev,
-        for (final c in toolCalls)
-          {
-            'id': c.id,
-            'name': c.name,
-            'arguments': c.arguments,
-            'content': null,
-            if (c.metadata != null && c.metadata!.isNotEmpty)
-              'metadata': c.metadata,
-          },
+        {
+          'id': call.id,
+          'name': call.name,
+          'arguments': call.arguments,
+          'content': null,
+          if (call.metadata != null && call.metadata!.isNotEmpty)
+            'metadata': call.metadata,
+        },
       ];
       await setToolEventsInDb(messageId, dedupeToolEvents(newEvents));
     } catch (_) {}
   }
 
-  /// Process tool results chunk from stream.
+  /// Process a tool-result [StreamChunk] (local result, server tool, or citations).
   Future<void> handleToolResultsChunk(
-    List<EmitToolResult> toolResults,
+    StreamChunk chunk,
     StreamingState state, {
     required Future<void> Function(
       String messageId, {
@@ -988,64 +985,69 @@ class StreamController {
     })
     upsertToolEventInDb,
   }) async {
-    if (toolResults.isEmpty) return;
+    final result = _toolResultUiFromChunk(chunk, state);
+    if (result == null) return;
 
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     state.hadThinkingBlock = true;
 
     final parts = List<ToolUIPart>.of(_toolParts[messageId] ?? const []);
-    for (final r in toolResults) {
-      int idx = -1;
+    int idx = -1;
+    for (int i = 0; i < parts.length; i++) {
+      if (parts[i].loading &&
+          (parts[i].id == result.id ||
+              (parts[i].id.isEmpty && parts[i].toolName == result.name))) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0 && result.id.isNotEmpty) {
       for (int i = 0; i < parts.length; i++) {
-        if (parts[i].loading &&
-            (parts[i].id == r.id ||
-                (parts[i].id.isEmpty && parts[i].toolName == r.name))) {
+        if (parts[i].id == result.id) {
           idx = i;
           break;
         }
       }
-      if (idx >= 0) {
-        parts[idx] = ToolUIPart(
-          id: parts[idx].id,
-          toolName: parts[idx].toolName,
-          arguments: r.arguments.isNotEmpty
-              ? Map<String, dynamic>.from(r.arguments)
-              : parts[idx].arguments,
-          content: r.content,
-          loading: false,
-        );
-      } else if (r.id == 'builtin_search' &&
-          parts.any((part) => part.id != r.id && part.toolName == r.name)) {
-        // Annotations map to a synthetic search result. The
-        // server tool already carries those citations.
-        continue;
-      } else {
-        parts.add(
-          ToolUIPart(
-            id: r.id,
-            toolName: r.name,
-            arguments: r.arguments,
-            content: r.content,
-            loading: false,
-          ),
-        );
-      }
-      try {
-        final args = Map<String, dynamic>.from(r.arguments);
-        await upsertToolEventInDb(
-          messageId,
-          id: r.id,
-          name: r.name,
-          arguments: args,
-          content: r.content,
-          metadata: r.metadata,
-        );
-      } catch (_) {}
     }
+    if (idx >= 0) {
+      parts[idx] = ToolUIPart(
+        id: parts[idx].id,
+        toolName: parts[idx].toolName,
+        arguments: result.arguments.isNotEmpty
+            ? Map<String, dynamic>.from(result.arguments)
+            : parts[idx].arguments,
+        content: result.content,
+        loading: false,
+      );
+    } else if (result.id == 'builtin_search' &&
+        parts.any(
+          (part) => part.id != result.id && part.toolName == result.name,
+        )) {
+      return;
+    } else {
+      parts.add(
+        ToolUIPart(
+          id: result.id,
+          toolName: result.name,
+          arguments: result.arguments,
+          content: result.content,
+          loading: false,
+        ),
+      );
+    }
+    try {
+      await upsertToolEventInDb(
+        messageId,
+        id: result.id,
+        name: result.name,
+        arguments: Map<String, dynamic>.from(result.arguments),
+        content: result.content,
+        metadata: result.metadata,
+      );
+    } catch (_) {}
     if (getCurrentConversationId() == conversationId) {
       _toolParts[messageId] = dedupeToolPartsList(parts);
-      // Notify via StreamingContentNotifier for real-time UI updates
       final splits = _contentSplits[messageId];
       streamingContentNotifier.notifyToolPartsUpdated(
         messageId,
@@ -1054,6 +1056,149 @@ class StreamController {
         toolCountAtSplit: splits?.toolCounts,
       );
     }
+  }
+
+  ({
+    String id,
+    String name,
+    Map<String, dynamic> arguments,
+    Map<String, dynamic>? metadata,
+  })?
+  _toolCallUiFromChunk(StreamChunk chunk, StreamingState state) {
+    switch (chunk) {
+      case ToolCallStart(:final id, :final toolName, :final metadata):
+        return (
+          id: id,
+          name: toolName.isNotEmpty
+              ? toolName
+              : (state.pendingToolNames[id] ?? ''),
+          arguments: const <String, dynamic>{},
+          metadata: metadata,
+        );
+      case ToolCallEnd(:final id):
+        final fromHandler = _toolPayloadFromHandler(state, id);
+        return (
+          id: id,
+          name: (fromHandler?['name'] ?? state.pendingToolNames[id] ?? '')
+              .toString(),
+          arguments: _mapOrEmpty(fromHandler?['arguments']),
+          metadata: _mapOrNull(fromHandler?['metadata']),
+        );
+      default:
+        return null;
+    }
+  }
+
+  ({
+    String id,
+    String name,
+    Map<String, dynamic> arguments,
+    String content,
+    Map<String, dynamic>? metadata,
+  })?
+  _toolResultUiFromChunk(StreamChunk chunk, StreamingState state) {
+    switch (chunk) {
+      case ServerToolEnd(
+        :final id,
+        :final input,
+        :final output,
+        :final metadata,
+      ):
+        return (
+          id: id,
+          name: _toolResultName(state, id),
+          arguments: _mapOrEmpty(input),
+          content: _toolOutputText(output),
+          metadata: metadata,
+        );
+      case ToolCallResult(:final id, :final output, :final metadata):
+        final fromHandler = _toolPayloadFromHandler(state, id);
+        return (
+          id: id,
+          name: _toolResultName(
+            state,
+            id,
+            fromHandler: (fromHandler?['name'] ?? '').toString(),
+          ),
+          arguments: _mapOrEmpty(fromHandler?['arguments']),
+          content: _toolOutputText(output),
+          metadata: metadata,
+        );
+      case Annotations(:final annotations):
+        if (annotations.isEmpty) return null;
+        return (
+          id: 'builtin_search',
+          name: 'search_web',
+          arguments: const <String, dynamic>{},
+          content: jsonEncode(<String, dynamic>{
+            'items': [
+              for (final citation
+                  in annotations.whereType<UrlCitationAnnotation>())
+                <String, dynamic>{
+                  'url': citation.url,
+                  if (citation.title.isNotEmpty) 'title': citation.title,
+                },
+            ],
+          }),
+          metadata: null,
+        );
+      default:
+        return null;
+    }
+  }
+
+  Map<String, dynamic>? _toolPayloadFromHandler(
+    StreamingState state,
+    String id,
+  ) {
+    for (final part in state.shadowHandler.parts.reversed) {
+      if (part is! ToolCallPart) continue;
+      try {
+        final decoded = jsonDecode(part.payloadJson);
+        if (decoded is Map && (decoded['id'] ?? '').toString() == id) {
+          return decoded.cast<String, dynamic>();
+        }
+      } catch (_) {}
+    }
+    return null;
+  }
+
+  String _toolResultName(
+    StreamingState state,
+    String id, {
+    String? fromHandler,
+  }) {
+    final name =
+        state.pendingToolNames.remove(id) ??
+        (fromHandler != null && fromHandler.isNotEmpty ? fromHandler : null) ??
+        _existingToolName(state, id) ??
+        '';
+    if (name.isNotEmpty) return name;
+    if (id == 'builtin_search') return 'builtin_search';
+    return '';
+  }
+
+  String? _existingToolName(StreamingState state, String id) {
+    for (final part in _toolParts[state.messageId] ?? const <ToolUIPart>[]) {
+      if (part.id == id && part.toolName.isNotEmpty) return part.toolName;
+    }
+    return null;
+  }
+
+  static Map<String, dynamic> _mapOrEmpty(Object? value) {
+    if (value is Map) return value.cast<String, dynamic>();
+    return const <String, dynamic>{};
+  }
+
+  static Map<String, dynamic>? _mapOrNull(Object? value) {
+    if (value is Map) return value.cast<String, dynamic>();
+    return null;
+  }
+
+  static String _toolOutputText(Object? output) {
+    if (output == null) return '';
+    if (output is String) return output;
+    return jsonEncode(output);
   }
 
   /// Finish reasoning segment when content starts arriving.

--- a/test/core/services/api/generation/tool_loop_runner_test.dart
+++ b/test/core/services/api/generation/tool_loop_runner_test.dart
@@ -1,0 +1,111 @@
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('executeClientTools emits ToolCall* then ToolCallResult', () async {
+    final chunks = await executeClientTools(
+      calls: [
+        emitToolCall(
+          id: 'call_1',
+          name: 'lookup',
+          arguments: const <String, dynamic>{'q': 'kelivo'},
+        ),
+      ],
+      onToolCall: (name, args, {toolCallId}) async => '{"ok":true}',
+      emitCalls: true,
+    ).toList();
+
+    expect(chunks.whereType<ToolCallStart>().single.id, 'call_1');
+    expect(chunks.whereType<ToolCallEnd>().single.id, 'call_1');
+    expect(chunks.whereType<ToolCallResult>().single.output, '{"ok":true}');
+    expect(chunks.whereType<ServerToolEnd>(), isEmpty);
+  });
+
+  test(
+    'runClientToolFollowUps executes, appends, and stops when no more calls',
+    () async {
+      final appended = <String>[];
+      var rounds = 0;
+      final chunks = await runClientToolFollowUps(
+        initialCalls: [
+          emitToolCall(
+            id: 'call_1',
+            name: 'lookup',
+            arguments: const <String, dynamic>{'q': '1'},
+          ),
+        ],
+        onToolCall: (name, args, {toolCallId}) async => 'res-$toolCallId',
+        append: (executed) {
+          appended.addAll(executed.map((item) => item.content));
+        },
+        sendFollowUp: () async* {
+          rounds += 1;
+          yield const TextDelta(id: 't', text: 'done');
+        },
+        takeCallsAfterRound: () => const <EmitToolCall>[],
+        finish: () => emitFinish(),
+      ).toList();
+
+      expect(appended, ['res-call_1']);
+      expect(rounds, 1);
+      expect(chunks.whereType<ToolCallResult>().single.output, 'res-call_1');
+      expect(chunks.whereType<TextDelta>().single.text, 'done');
+      expect(chunks.whereType<Finish>(), hasLength(1));
+    },
+  );
+
+  test(
+    'runProviderToolRounds sends, executes after the round, then finishes',
+    () async {
+      var sends = 0;
+      final appended = <int>[];
+      final chunks = await runProviderToolRounds(
+        sendRound: () async* {
+          sends += 1;
+          yield TextDelta(id: 't', text: 'round-$sends');
+        },
+        takeCalls: () => sends == 1
+            ? [
+                emitToolCall(
+                  id: 'call_1',
+                  name: 'lookup',
+                  arguments: const <String, dynamic>{'q': '1'},
+                ),
+              ]
+            : const <EmitToolCall>[],
+        continueWithoutCalls: () => false,
+        executeAfterRound: true,
+        emitCalls: true,
+        onToolCall: (name, args, {toolCallId}) async => 'res-$toolCallId',
+        append: (executed) => appended.add(executed.length),
+        finish: () => emitFinish(),
+      ).toList();
+
+      expect(sends, 2);
+      expect(appended, [1]);
+      expect(chunks.whereType<ToolCallStart>(), hasLength(1));
+      expect(chunks.whereType<ToolCallResult>().single.output, 'res-call_1');
+      expect(chunks.whereType<Finish>(), hasLength(1));
+    },
+  );
+
+  test('runProviderToolRounds continues without calls when asked', () async {
+    var sends = 0;
+    final chunks = await runProviderToolRounds(
+      sendRound: () async* {
+        sends += 1;
+        yield TextDelta(id: 't', text: 'pause-$sends');
+      },
+      takeCalls: () => const <EmitToolCall>[],
+      continueWithoutCalls: () => sends < 2,
+      executeAfterRound: false,
+      append: (_) {},
+      finish: () => emitFinish(),
+    ).toList();
+
+    expect(sends, 2);
+    expect(chunks.whereType<TextDelta>(), hasLength(2));
+    expect(chunks.whereType<Finish>(), hasLength(1));
+  });
+}

--- a/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
+++ b/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
@@ -201,31 +201,28 @@ void main() {
     expect(decoder.finishReason, isNull);
   });
 
-  test(
-    'emits grok citations as search_web ServerTool events',
-    () {
-      final decoder = ChatCompletionsStreamDecoder();
-      final result = decoder.accept(
-        _event(<String, dynamic>{
-          ..._choice(delta: <String, dynamic>{'content': 'see'}),
-          'citations': <String>['https://example.com'],
-        }),
-      );
+  test('emits grok citations as search_web ServerTool events', () {
+    final decoder = ChatCompletionsStreamDecoder();
+    final result = decoder.accept(
+      _event(<String, dynamic>{
+        ..._choice(delta: <String, dynamic>{'content': 'see'}),
+        'citations': <String>['https://example.com'],
+      }),
+    );
 
-      expect(
-        result.chunks.whereType<ServerToolStart>().single.toolName,
-        'search_web',
-      );
-      final end = result.chunks.whereType<ServerToolEnd>().single;
-      expect(end.id, 'stream:search-1');
-      final items = (end.output as Map)['items'] as List;
-      expect(items.single, <String, dynamic>{
-        'index': 1,
-        'url': 'https://example.com',
-        'title': 'https://example.com',
-      });
-    },
-  );
+    expect(
+      result.chunks.whereType<ServerToolStart>().single.toolName,
+      'search_web',
+    );
+    final end = result.chunks.whereType<ServerToolEnd>().single;
+    expect(end.id, 'stream:search-1');
+    final items = (end.output as Map)['items'] as List;
+    expect(items.single, <String, dynamic>{
+      'index': 1,
+      'url': 'https://example.com',
+      'title': 'https://example.com',
+    });
+  });
 
   test('emits Image events only when image output is requested', () {
     final off = ChatCompletionsStreamDecoder();

--- a/test/core/services/api/stream/stream_chunk_handler_test.dart
+++ b/test/core/services/api/stream/stream_chunk_handler_test.dart
@@ -146,6 +146,25 @@ void main() {
     },
   );
 
+  test('fills a local ToolCallResult without marking the part server-side', () {
+    final handler = StreamChunkHandler();
+    handler.handle(const ToolCallStart(id: 'call_1', toolName: 'lookup'));
+    handler.handle(
+      const ToolCallDelta(id: 'call_1', inputDelta: '{"q":"kelivo"}'),
+    );
+    handler.handle(const ToolCallEnd('call_1'));
+    handler.handle(const ToolCallResult(id: 'call_1', output: '{"ok":true}'));
+
+    final payload = jsonDecode(
+      (handler.parts.single as ToolCallPart).payloadJson,
+    );
+    expect(payload['id'], 'call_1');
+    expect(payload['name'], 'lookup');
+    expect(payload['arguments'], <String, dynamic>{'q': 'kelivo'});
+    expect(payload['content'], '{"ok":true}');
+    expect(payload['server'], isFalse);
+  });
+
   test('maps a server tool result onto a tool_call part', () {
     final handler = StreamChunkHandler();
     handler.handle(

--- a/test/features/chat/widgets/chat_message_widget_background_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_background_test.dart
@@ -9,7 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:Kelivo/core/models/chat_message.dart';
 import 'package:Kelivo/core/providers/settings_provider.dart';
 import 'package:Kelivo/core/providers/tts_provider.dart';
-import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
 import 'package:Kelivo/core/services/chat/chat_service.dart';
 import 'package:Kelivo/features/chat/widgets/chat_message_widget.dart';
 import 'package:Kelivo/features/home/controllers/stream_controller.dart'
@@ -282,28 +282,20 @@ void main() {
         }) async {}
 
         await controller.handleToolResultsChunk(
-          [
-            emitToolResult(
-              id: 'builtin_search',
-              name: 'builtin_search',
-              arguments: const <String, dynamic>{},
-              content:
-                  '{"items":[{"title":"First source","url":"https://one.example.com/a","text":"A"}]}',
-            ),
-          ],
+          const ToolCallResult(
+            id: 'builtin_search',
+            output:
+                '{"items":[{"title":"First source","url":"https://one.example.com/a","text":"A"}]}',
+          ),
           state,
           upsertToolEventInDb: upsertToolEventInDb,
         );
         await controller.handleToolResultsChunk(
-          [
-            emitToolResult(
-              id: 'builtin_search',
-              name: 'builtin_search',
-              arguments: const <String, dynamic>{},
-              content:
-                  '{"items":[{"title":"First source","url":"https://one.example.com/a","text":"A"},{"title":"Second source","url":"https://two.example.com/b","text":"B"}]}',
-            ),
-          ],
+          const ToolCallResult(
+            id: 'builtin_search',
+            output:
+                '{"items":[{"title":"First source","url":"https://one.example.com/a","text":"A"},{"title":"Second source","url":"https://two.example.com/b","text":"B"}]}',
+          ),
           state,
           upsertToolEventInDb: upsertToolEventInDb,
         );

--- a/test/features/home/controllers/stream_controller_content_split_test.dart
+++ b/test/features/home/controllers/stream_controller_content_split_test.dart
@@ -2,7 +2,7 @@ import "../../../support/business_test_harness.dart";
 import 'package:flutter_test/flutter_test.dart';
 import 'package:Kelivo/core/models/chat_message.dart';
 import 'package:Kelivo/core/providers/settings_provider.dart';
-import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
 import 'package:Kelivo/core/services/chat/chat_service.dart';
 import 'package:Kelivo/features/chat/widgets/chat_message_widget.dart'
     show ToolUIPart;
@@ -376,27 +376,19 @@ void main() {
       }) async {}
 
       await controller.handleToolResultsChunk(
-        [
-          emitToolResult(
-            id: 'builtin_search',
-            name: 'builtin_search',
-            arguments: const <String, dynamic>{},
-            content: '{"items":[{"title":"First"}]}',
-          ),
-        ],
+        const ToolCallResult(
+          id: 'builtin_search',
+          output: '{"items":[{"title":"First"}]}',
+        ),
         state,
         upsertToolEventInDb: upsertToolEventInDb,
       );
 
       await controller.handleToolResultsChunk(
-        [
-          emitToolResult(
-            id: 'builtin_search',
-            name: 'builtin_search',
-            arguments: const <String, dynamic>{},
-            content: '{"items":[{"title":"First"},{"title":"Second"}]}',
-          ),
-        ],
+        const ToolCallResult(
+          id: 'builtin_search',
+          output: '{"items":[{"title":"First"},{"title":"Second"}]}',
+        ),
         state,
         upsertToolEventInDb: upsertToolEventInDb,
       );
@@ -429,27 +421,14 @@ void main() {
         Map<String, dynamic>? metadata,
       }) async {}
 
+      state.pendingToolNames['st_1'] = 'search_web';
       await controller.handleToolResultsChunk(
-        [
-          emitToolResult(
-            id: 'st_1',
-            name: 'search_web',
-            arguments: const <String, dynamic>{},
-            content: '{"query":"kotlin"}',
-          ),
-        ],
+        const ServerToolEnd(id: 'st_1', output: '{"query":"kotlin"}'),
         state,
         upsertToolEventInDb: upsertToolEventInDb,
       );
       await controller.handleToolResultsChunk(
-        [
-          emitToolResult(
-            id: 'builtin_search',
-            name: 'search_web',
-            arguments: const <String, dynamic>{},
-            content: '{"items":[{"url":"https://example.com"}]}',
-          ),
-        ],
+        const Annotations([UrlCitationAnnotation(url: 'https://example.com')]),
         state,
         upsertToolEventInDb: upsertToolEventInDb,
       );


### PR DESCRIPTION
## Summary
- Extract OpenAI / Claude / Gemini / Vertex client-tool follow-ups into `tool_loop_runner.dart`. Providers send one round; the runner executes tools, appends the transcript, and requests the next round.
- Local tool output is now `ToolCallResult` (fills `ToolCallPart`, `server: false`). Hosted search / code execution stay on `ServerTool*`.
- `handleToolCallsChunk` / `handleToolResultsChunk` take `StreamChunk` directly. `EmitToolCall` / `EmitToolResult` stay inside the API layer; `_emitToolCallFromHandler` is gone.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed lib test`
- [x] `dart analyze --fatal-infos lib test`
- [x] `flutter test` (2514 passed)
- [ ] Smoke a Chat Completions tool round (stream + non-stream)
- [ ] Smoke a Responses API function-call follow-up
- [ ] Smoke Claude / Gemini / Vertex Claude tool loops