### PR TITLE
refactor(api): fold non-stream generation through StreamChunkHandler

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -27,17 +27,22 @@ import '../model_override_payload_parser.dart';
 import '../custom_request_merger.dart';
 import 'provider_request_headers.dart';
 import '../../utils/multimodal_input_utils.dart';
+import 'generation/text_generation_result.dart';
 import 'stream/sse_framing.dart';
 import 'stream/stream_chunk.dart';
+import 'stream/stream_chunk_handler.dart';
 import 'stream/stream_chunk_ids.dart';
 import 'providers/claude/claude_decoder.dart';
 import 'providers/google/google_decoder.dart';
 import 'providers/openai/chat_completions_decoder.dart';
 import 'providers/openai/responses_decoder.dart';
 
+export 'generation/text_generation_result.dart';
+
 part 'chat_api_service_shims.dart';
 part 'stream/stream_chunk_emit.dart';
 part 'generation/tool_loop_runner.dart';
+part 'providers/openai/openai_tool_transcript.dart';
 part 'providers/openai_common.dart';
 part 'providers/openai_chat_completions.dart';
 part 'providers/openai_images.dart';
@@ -62,6 +67,13 @@ String _effectiveToolCallId(
   final id = rawId?.toString().trim() ?? '';
   if (id.isNotEmpty) return id;
   return '${fallbackPrefix}_${DateTime.now().microsecondsSinceEpoch}_$index';
+}
+
+Future<String> _decodeUtf8Stream(
+  http.ByteStream stream, {
+  bool allowMalformed = true,
+}) async {
+  return utf8.decode(await stream.toBytes(), allowMalformed: allowMalformed);
 }
 
 class ChatApiService {
@@ -556,13 +568,6 @@ class ChatApiService {
     return DioHttpClient(cancelToken: cancelToken);
   }
 
-  static String _decodeUtf8Body(
-    http.Response response, {
-    bool allowMalformed = false,
-  }) {
-    return utf8.decode(response.bodyBytes, allowMalformed: allowMalformed);
-  }
-
   static Stream<StreamChunk> sendMessageStream({
     required ProviderConfig config,
     required String modelId,
@@ -743,6 +748,48 @@ class ChatApiService {
     }
   }
 
+  /// Non-stream generation folded through [StreamChunkHandler].
+  static Future<TextGenerationResult> generateMessage({
+    required ProviderConfig config,
+    required String modelId,
+    required List<Map<String, dynamic>> messages,
+    List<String>? userImagePaths,
+    int? thinkingBudget,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    List<Map<String, dynamic>>? tools,
+    ToolCallHandler? onToolCall,
+    Map<String, String>? extraHeaders,
+    Map<String, dynamic>? extraBody,
+    String? requestId,
+    bool allowImagesApiRouting = true,
+    bool ocrActive = false,
+  }) async {
+    final handler = StreamChunkHandler();
+    await for (final chunk in sendMessageStream(
+      config: config,
+      modelId: modelId,
+      messages: messages,
+      userImagePaths: userImagePaths,
+      thinkingBudget: thinkingBudget,
+      temperature: temperature,
+      topP: topP,
+      maxTokens: maxTokens,
+      tools: tools,
+      onToolCall: onToolCall,
+      extraHeaders: extraHeaders,
+      extraBody: extraBody,
+      stream: false,
+      requestId: requestId,
+      allowImagesApiRouting: allowImagesApiRouting,
+      ocrActive: ocrActive,
+    )) {
+      handler.handle(chunk);
+    }
+    return handler.toResult();
+  }
+
   // Non-streaming text generation for utilities like title summarization
   static Future<String> generateText({
     required ProviderConfig config,
@@ -752,406 +799,17 @@ class ChatApiService {
     Map<String, dynamic>? extraBody,
     int? thinkingBudget,
   }) async {
-    final kind = ProviderConfig.classify(
-      config.id,
-      explicitType: config.providerType,
+    final result = await generateMessage(
+      config: config,
+      modelId: modelId,
+      messages: [
+        {'role': 'user', 'content': prompt},
+      ],
+      extraHeaders: extraHeaders,
+      extraBody: extraBody,
+      thinkingBudget: thinkingBudget,
     );
-    final client = _clientFor(config, CancelToken());
-    final upstreamModelId = _apiModelId(config, modelId);
-    final safePrompt = UnicodeSanitizer.sanitize(prompt);
-    try {
-      if (kind == ProviderKind.openai) {
-        final url = _openAICompatibleUrl(config);
-        Map<String, dynamic> body;
-        final effectiveInfo = _effectiveModelInfo(config, modelId);
-        final isReasoning = effectiveInfo.abilities.contains(
-          ModelAbility.reasoning,
-        );
-        final effort = _openAIEffortForBudget(thinkingBudget, upstreamModelId);
-        final info = _OpenAIProviderInfo(
-          host: Uri.tryParse(config.baseUrl)?.host.toLowerCase() ?? '',
-          providerId: config.id.toLowerCase(),
-          upstreamModelId: upstreamModelId,
-        );
-        if (config.useResponseApi == true) {
-          // Inject built-in web_search tool when enabled and supported
-          final toolsList = <Map<String, dynamic>>[];
-          bool isResponsesWebSearchSupported(String id) {
-            if (BuiltInToolsHelper.isOpenAIResponsesBuiltInSearchSupportedModel(
-              id,
-            )) {
-              return true;
-            }
-            if (BuiltInToolsHelper.isDashScopeProvider(config)) {
-              return BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
-                id,
-              );
-            }
-            if (BuiltInToolsHelper.isArkProvider(config)) {
-              return BuiltInToolsHelper.isDoubaoResponsesBuiltInSearchSupportedModel(
-                id,
-              );
-            }
-            return false;
-          }
-
-          if (isResponsesWebSearchSupported(upstreamModelId)) {
-            final builtIns = _builtInTools(config, modelId);
-            if (builtIns.contains(BuiltInToolNames.search)) {
-              if (BuiltInToolsHelper.isDashScopeProvider(config) ||
-                  BuiltInToolsHelper.isArkProvider(config)) {
-                toolsList.add({'type': 'web_search'});
-              } else {
-                Map<String, dynamic> ws = const <String, dynamic>{};
-                try {
-                  final ov = config.modelOverrides[modelId];
-                  if (ov is Map && ov['webSearch'] is Map) {
-                    ws = (ov['webSearch'] as Map).cast<String, dynamic>();
-                  }
-                } catch (_) {}
-                final usePreview =
-                    (ws['preview'] == true) ||
-                    ((ws['tool'] ?? '').toString() == 'preview');
-                final entry = <String, dynamic>{
-                  'type': usePreview ? 'web_search_preview' : 'web_search',
-                };
-                if (ws['allowed_domains'] is List &&
-                    (ws['allowed_domains'] as List).isNotEmpty) {
-                  entry['filters'] = {
-                    'allowed_domains': List<String>.from(
-                      (ws['allowed_domains'] as List).map((e) => e.toString()),
-                    ),
-                  };
-                }
-                if (ws['user_location'] is Map) {
-                  entry['user_location'] = (ws['user_location'] as Map)
-                      .cast<String, dynamic>();
-                }
-                if (usePreview && ws['search_context_size'] is String) {
-                  entry['search_context_size'] = ws['search_context_size'];
-                }
-                toolsList.add(entry);
-              }
-            }
-          }
-          body = {
-            'model': upstreamModelId,
-            'stream': false,
-            'input': [
-              {'role': 'user', 'content': safePrompt},
-            ],
-            if (toolsList.isNotEmpty)
-              'tools': _toResponsesToolsFormat(toolsList),
-            if (toolsList.isNotEmpty) 'tool_choice': 'auto',
-            if (isReasoning && effort != 'off')
-              'reasoning': {
-                'summary': 'auto',
-                if (effort != 'auto') 'effort': effort,
-              },
-          };
-        } else {
-          body = {
-            'model': upstreamModelId,
-            'stream': false,
-            'messages': [
-              {'role': 'user', 'content': safePrompt},
-            ],
-            if (isReasoning && effort != 'off' && effort != 'auto')
-              'reasoning_effort': effort,
-          };
-        }
-        _applyCompatibleBuiltInSearch(
-          body,
-          config: config,
-          modelId: modelId,
-          upstreamModelId: upstreamModelId,
-        );
-        _applyOpenRouterClaudePromptCaching(
-          body,
-          config: config,
-          upstreamModelId: upstreamModelId,
-        );
-        _applyCompatibleResponsesReasoning(
-          body,
-          config: config,
-          modelId: modelId,
-          upstreamModelId: upstreamModelId,
-          isReasoning: isReasoning,
-          thinkingBudget: thinkingBudget,
-        );
-        final headers = _customHeaders(
-          config,
-          modelId,
-          baseHeaders: <String, String>{
-            'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
-            'Content-Type': 'application/json',
-          },
-          assistantHeaders: extraHeaders,
-        );
-        final extra = _customBody(config, modelId, assistantBody: extraBody);
-        if (extra.isNotEmpty) body.addAll(extra);
-        // Vendor-specific reasoning knobs for chat-completions compatible hosts (non-streaming)
-        if (config.useResponseApi != true) {
-          _applyVendorReasoningKnobs(
-            body,
-            info: info,
-            isReasoning: isReasoning,
-            thinkingBudget: thinkingBudget,
-          );
-          if (info.isKimiThinkingModel) {
-            _normalizeMoonshotKimiChatBody(
-              body,
-              upstreamModelId: upstreamModelId,
-              isReasoning: isReasoning,
-              thinkingBudget: thinkingBudget,
-            );
-          }
-        }
-        // Ensure Responses tools use the flattened schema even if supplied via overrides
-        try {
-          if (config.useResponseApi == true && body['tools'] is List) {
-            final raw = (body['tools'] as List).cast<dynamic>();
-            body['tools'] = _toResponsesToolsFormat(
-              raw.map((e) => (e as Map).cast<String, dynamic>()).toList(),
-            );
-          }
-        } catch (_) {}
-        _sanitizeOpenAIGpt5SamplingParams(
-          body,
-          upstreamModelId,
-          fallbackEffort: effort,
-          isOpenRouter: info.isOpenRouter,
-        );
-        final resp = await client.post(
-          url,
-          headers: headers,
-          body: jsonEncode(body),
-        );
-        if (resp.statusCode < 200 || resp.statusCode >= 300) {
-          final responseText = _decodeUtf8Body(resp, allowMalformed: true);
-          throw HttpException('HTTP ${resp.statusCode}: $responseText');
-        }
-        final responseText = _decodeUtf8Body(resp);
-        final data = jsonDecode(responseText);
-        if (config.useResponseApi == true) {
-          // Prefer SDK-style convenience when present
-          final ot = data['output_text'];
-          if (ot is String && ot.isNotEmpty) return ot;
-          // Aggregate text from `output` list of message blocks
-          final out = data['output'];
-          if (out is List) {
-            final buf = StringBuffer();
-            for (final item in out) {
-              if (item is! Map) continue;
-              final content = item['content'];
-              if (content is List) {
-                for (final c in content) {
-                  if (c is Map &&
-                      (c['type'] == 'output_text') &&
-                      (c['text'] is String)) {
-                    buf.write(c['text']);
-                  }
-                }
-              }
-            }
-            final s = buf.toString();
-            if (s.isNotEmpty) return s;
-          }
-          return '';
-        } else {
-          final choices = data['choices'] as List?;
-          if (choices != null && choices.isNotEmpty) {
-            final msg = choices.first['message'];
-            return (msg?['content'] ?? '').toString();
-          }
-          return '';
-        }
-      } else if (kind == ProviderKind.claude) {
-        final base = config.baseUrl.endsWith('/')
-            ? config.baseUrl.substring(0, config.baseUrl.length - 1)
-            : config.baseUrl;
-        final url = Uri.parse('$base/messages');
-        final effectiveInfo = _effectiveModelInfo(config, modelId);
-        final isReasoning = effectiveInfo.abilities.contains(
-          ModelAbility.reasoning,
-        );
-        final thinking = isReasoning
-            ? _claudeThinkingConfig(
-                upstreamModelId,
-                thinkingBudget,
-                config: config,
-              )
-            : null;
-        final outputConfig = isReasoning
-            ? _claudeOutputConfig(
-                upstreamModelId,
-                thinkingBudget,
-                config: config,
-              )
-            : null;
-        final body = <String, dynamic>{
-          'model': upstreamModelId,
-          'stream': false,
-          'max_tokens': 512,
-          'messages': [
-            {'role': 'user', 'content': safePrompt},
-          ],
-          if (thinking != null) 'thinking': thinking,
-          if (outputConfig != null) 'output_config': outputConfig,
-        };
-        final headers = _customHeaders(
-          config,
-          modelId,
-          baseHeaders: <String, String>{
-            'x-api-key': _apiKeyForRequest(config, modelId),
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json',
-          },
-          assistantHeaders: extraHeaders,
-        );
-        final extra = _customBody(config, modelId, assistantBody: extraBody);
-        if (extra.isNotEmpty) body.addAll(extra);
-        final resp = await client.post(
-          url,
-          headers: headers,
-          body: jsonEncode(body),
-        );
-        if (resp.statusCode < 200 || resp.statusCode >= 300) {
-          final responseText = _decodeUtf8Body(resp, allowMalformed: true);
-          throw HttpException('HTTP ${resp.statusCode}: $responseText');
-        }
-        final responseText = _decodeUtf8Body(resp);
-        final data = jsonDecode(responseText);
-        final content = data['content'] as List?;
-        if (content != null && content.isNotEmpty) {
-          final buf = StringBuffer();
-          for (final item in content) {
-            if (item is! Map) continue;
-            if ((item['type'] ?? '').toString() != 'text') continue;
-            final text = item['text'];
-            if (text is String && text.isNotEmpty) {
-              buf.write(text);
-            }
-          }
-          return buf.toString();
-        }
-        return '';
-      } else {
-        // Google
-        // Check for Vertex AI Claude models (prefix "claude-")
-        if ((config.vertexAI == true) &&
-            modelId.toLowerCase().startsWith('claude-')) {
-          // Reuse existing streaming method but buffer the output for non-streaming
-          final stream = _sendGoogleVertexClaudeStream(
-            client: client,
-            config: config,
-            modelId: modelId,
-            messages: [
-              {'role': 'user', 'content': prompt},
-            ],
-            extraHeaders: extraHeaders,
-            extraBody: extraBody,
-            thinkingBudget: thinkingBudget,
-            stream: false,
-          );
-          final text = StringBuffer();
-          await for (final chunk in stream) {
-            if (chunk is TextDelta) text.write(chunk.text);
-          }
-          return text.toString();
-        }
-
-        String url;
-        if (config.vertexAI == true &&
-            (config.location?.isNotEmpty == true) &&
-            (config.projectId?.isNotEmpty == true)) {
-          final loc = config.location!;
-          final proj = config.projectId!;
-          url =
-              'https://aiplatform.googleapis.com/v1/projects/$proj/locations/$loc/publishers/google/models/$upstreamModelId:generateContent';
-        } else {
-          final base = config.baseUrl.endsWith('/')
-              ? config.baseUrl.substring(0, config.baseUrl.length - 1)
-              : config.baseUrl;
-          url = '$base/models/$upstreamModelId:generateContent';
-        }
-        final body = <String, dynamic>{
-          'contents': [
-            {
-              'role': 'user',
-              'parts': [
-                {'text': safePrompt},
-              ],
-            },
-          ],
-        };
-
-        // Inject Gemini built-in tools with version-aware mutual exclusion.
-        // Gemini 2.x: code_execution is exclusive (cannot coexist with others).
-        // Gemini 3: all built-in tools can coexist.
-        final builtIns = _builtInTools(config, modelId);
-        if (builtIns.isNotEmpty) {
-          final bool isGemini3 = upstreamModelId.toLowerCase().contains(
-            'gemini-3',
-          );
-          final toolsArr = _buildGeminiToolsArray(
-            builtIns: builtIns,
-            allowCoexistence: isGemini3,
-          );
-          if (toolsArr.isNotEmpty) {
-            body['tools'] = toolsArr;
-          }
-        }
-        final baseHeaders = <String, String>{
-          'Content-Type': 'application/json',
-        };
-        // Add API Key header for non-Vertex
-        if (!(config.vertexAI == true)) {
-          final apiKey = _apiKeyForRequest(config, modelId);
-          if (apiKey.isNotEmpty) {
-            baseHeaders['x-goog-api-key'] = apiKey;
-          }
-        }
-        // Add Bearer for Vertex via service account JSON
-        if (config.vertexAI == true) {
-          final token = await _maybeVertexAccessToken(config);
-          if (token != null && token.isNotEmpty) {
-            baseHeaders['Authorization'] = 'Bearer $token';
-          }
-          final proj = (config.projectId ?? '').trim();
-          if (proj.isNotEmpty) baseHeaders['X-Goog-User-Project'] = proj;
-        }
-        final headers = _customHeaders(
-          config,
-          modelId,
-          baseHeaders: baseHeaders,
-          assistantHeaders: extraHeaders,
-        );
-        final extra = _customBody(config, modelId, assistantBody: extraBody);
-        if (extra.isNotEmpty) body.addAll(extra);
-        final resp = await client.post(
-          Uri.parse(url),
-          headers: headers,
-          body: jsonEncode(body),
-        );
-        if (resp.statusCode < 200 || resp.statusCode >= 300) {
-          final responseText = _decodeUtf8Body(resp, allowMalformed: true);
-          throw HttpException('HTTP ${resp.statusCode}: $responseText');
-        }
-        final responseText = _decodeUtf8Body(resp);
-        final data = jsonDecode(responseText);
-        final candidates = data['candidates'] as List?;
-        if (candidates != null && candidates.isNotEmpty) {
-          final parts = candidates.first['content']?['parts'] as List?;
-          if (parts != null && parts.isNotEmpty) {
-            return (parts.first['text'] ?? '').toString();
-          }
-        }
-        return '';
-      }
-    } finally {
-      client.close();
-    }
+    return result.text;
   }
 
   static List<Map<String, dynamic>> _sanitizeMessages(

--- a/lib/core/services/api/generation/text_generation_result.dart
+++ b/lib/core/services/api/generation/text_generation_result.dart
@@ -1,0 +1,26 @@
+import '../../../models/message_part.dart';
+import '../../../models/token_usage.dart';
+
+/// One-shot (non-stream) generation result.
+///
+/// [parts] are already complete and renderable — image URIs must be full
+/// `data:` / `http(s):` / `file:` / `kelivo-file:` URLs at the parse source,
+/// never raw base64 that a later merge step would prefix.
+final class TextGenerationResult {
+  const TextGenerationResult({
+    required this.parts,
+    this.usage,
+    this.finishReason,
+    this.reasoningDetails,
+  });
+
+  final List<MessagePart> parts;
+  final TokenUsage? usage;
+  final String? finishReason;
+  final dynamic reasoningDetails;
+
+  String get text => [
+    for (final part in parts)
+      if (part is TextPart && part.text.isNotEmpty) part.text,
+  ].join();
+}

--- a/lib/core/services/api/generation/tool_loop_runner.dart
+++ b/lib/core/services/api/generation/tool_loop_runner.dart
@@ -7,59 +7,6 @@ final class ExecutedClientTool {
   final String content;
 }
 
-List<EmitToolCall> clientToolCallsFromChatAcc(Map<dynamic, dynamic> toolAcc) {
-  final calls = <EmitToolCall>[];
-  final keys = toolAcc.keys.toList()
-    ..sort((a, b) {
-      final ai = a is int ? a : int.tryParse(a.toString()) ?? 0;
-      final bi = b is int ? b : int.tryParse(b.toString()) ?? 0;
-      return ai.compareTo(bi);
-    });
-  for (final key in keys) {
-    final raw = toolAcc[key];
-    if (raw is! Map) continue;
-    final id = _effectiveToolCallId(raw['id'], 'call', key);
-    final name = (raw['name'] ?? '').toString();
-    Map<String, dynamic> arguments;
-    try {
-      arguments = (jsonDecode((raw['args'] ?? '{}').toString()) as Map)
-          .cast<String, dynamic>();
-    } catch (_) {
-      arguments = <String, dynamic>{};
-    }
-    calls.add(emitToolCall(id: id, name: name, arguments: arguments));
-  }
-  return calls;
-}
-
-List<Map<String, dynamic>> openaiToolCallMaps(List<EmitToolCall> calls) {
-  return [
-    for (final call in calls)
-      <String, dynamic>{
-        'id': call.id,
-        'type': 'function',
-        'function': <String, dynamic>{
-          'name': call.name,
-          'arguments': jsonEncode(call.arguments),
-        },
-      },
-  ];
-}
-
-List<Map<String, dynamic>> openaiToolResultMessages(
-  List<ExecutedClientTool> executed,
-) {
-  return [
-    for (final item in executed)
-      <String, dynamic>{
-        'role': 'tool',
-        'tool_call_id': item.call.id,
-        'name': item.call.name,
-        'content': item.content,
-      },
-  ];
-}
-
 /// Execute [calls] and yield [ToolCallResult]s (and optionally [ToolCall*]).
 Stream<StreamChunk> executeClientTools({
   required List<EmitToolCall> calls,
@@ -96,6 +43,12 @@ Stream<StreamChunk> executeClientTools({
 ///
 /// The host owns protocol-specific HTTP and transcript shape. This runner
 /// owns execute + [ToolCallResult] emit + the loop.
+///
+/// Two entries stay on purpose. [runProviderToolRounds] owns the first HTTP
+/// round via [sendRound] (Claude / Gemini). OpenAI's first round is consumed
+/// by the caller (`await for` SSE or one-shot JSON); only later rounds enter
+/// [runClientToolFollowUps]. Unifying stream/non-stream return types does not
+/// change who drives the first request, so these cannot merge.
 Stream<StreamChunk> runClientToolFollowUps({
   required List<EmitToolCall> initialCalls,
   required ToolCallHandler onToolCall,

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -517,7 +517,7 @@ Stream<StreamChunk> _sendClaudeStream(
 
       // Non-streaming path: parse full JSON, handle tool_use, then continue loop if needed.
       if (!stream) {
-        final txt = await response.stream.bytesToString();
+        final txt = await _decodeUtf8Stream(response.stream);
         final obj = jsonDecode(txt) as Map;
         // Usage
         try {

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -688,7 +688,7 @@ Stream<StreamChunk> _sendGoogleStream(
           final errorBody = await resp.stream.bytesToString();
           throw HttpException('HTTP ${resp.statusCode}: $errorBody');
         }
-        final txt = await resp.stream.bytesToString();
+        final txt = await _decodeUtf8Stream(resp.stream);
         final obj = jsonDecode(txt) as Map<String, dynamic>;
         try {
           final u = (obj['usageMetadata'] as Map?)?.cast<String, dynamic>();

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -487,7 +487,7 @@ Stream<StreamChunk> _sendGoogleVertexClaudeStream({
 
       if (!stream) {
         // Vertex rawPredict response is same as Anthropic non-stream response
-        final txt = await response.stream.bytesToString();
+        final txt = await _decodeUtf8Stream(response.stream);
         final obj = jsonDecode(txt) as Map;
         // Usage
         try {

--- a/lib/core/services/api/providers/openai/chat_completions_decoder.dart
+++ b/lib/core/services/api/providers/openai/chat_completions_decoder.dart
@@ -131,6 +131,9 @@ class ChatCompletionsStreamDecoder implements StreamChunkDecoder {
               ]);
             }
           }
+          if (delta is! Map || delta['tool_calls'] == null) {
+            _ingestCompleteToolCalls(message['tool_calls'], chunks);
+          }
         }
       }
     }
@@ -239,6 +242,32 @@ class ChatCompletionsStreamDecoder implements StreamChunkDecoder {
     }
   }
 
+  void _ingestCompleteToolCalls(dynamic raw, List<StreamChunk> chunks) {
+    if (raw is! List) return;
+    for (final t in raw) {
+      if (t is! Map) continue;
+      final idx = (t['index'] as int?) ?? toolCalls.length;
+      final id = (t['id'] ?? '').toString();
+      final func = t['function'];
+      if (func is! Map) continue;
+      final name = (func['name'] ?? '').toString();
+      final argsStr = (func['arguments'] ?? '').toString();
+      if (name.isEmpty) continue;
+      final eventId = _toolSeriesId(idx, vendorId: id);
+      final entry = toolCalls.putIfAbsent(
+        idx,
+        () => <String, String>{'id': '', 'name': '', 'args': ''},
+      );
+      entry['id'] = id.isNotEmpty ? id : eventId;
+      entry['name'] = name;
+      entry['args'] = argsStr;
+      chunks.addAll(_emitCompleteToolCall(eventId, name: name, args: argsStr));
+    }
+    if (raw.isNotEmpty) {
+      finishReason ??= 'tool_calls';
+    }
+  }
+
   String _toolSeriesId(int index, {String vendorId = ''}) {
     final existing = _toolIdsByIndex[index];
     if (existing != null) return existing;
@@ -283,11 +312,11 @@ class ChatCompletionsStreamDecoder implements StreamChunkDecoder {
         if (u2 is String) url = u2;
       }
       if (url == null || url.isEmpty) continue;
+      final mime = mimeTypeFromImageUri(url) ?? 'image/png';
+      final uri = completeRenderableImageUri(url, mimeType: mime);
       final id = _ids.next('image');
-      chunks.add(
-        ImageStart(id: id, mimeType: mimeTypeFromImageUri(url) ?? 'image/png'),
-      );
-      chunks.add(ImageSnapshot(id: id, data: url));
+      chunks.add(ImageStart(id: id, mimeType: mime));
+      chunks.add(ImageSnapshot(id: id, data: uri));
       chunks.add(ImageEnd(id));
     }
     return chunks;

--- a/lib/core/services/api/providers/openai/openai_tool_transcript.dart
+++ b/lib/core/services/api/providers/openai/openai_tool_transcript.dart
@@ -1,0 +1,54 @@
+part of '../../chat_api_service.dart';
+
+List<EmitToolCall> clientToolCallsFromChatAcc(Map<dynamic, dynamic> toolAcc) {
+  final calls = <EmitToolCall>[];
+  final keys = toolAcc.keys.toList()
+    ..sort((a, b) {
+      final ai = a is int ? a : int.tryParse(a.toString()) ?? 0;
+      final bi = b is int ? b : int.tryParse(b.toString()) ?? 0;
+      return ai.compareTo(bi);
+    });
+  for (final key in keys) {
+    final raw = toolAcc[key];
+    if (raw is! Map) continue;
+    final id = _effectiveToolCallId(raw['id'], 'call', key);
+    final name = (raw['name'] ?? '').toString();
+    Map<String, dynamic> arguments;
+    try {
+      arguments = (jsonDecode((raw['args'] ?? '{}').toString()) as Map)
+          .cast<String, dynamic>();
+    } catch (_) {
+      arguments = <String, dynamic>{};
+    }
+    calls.add(emitToolCall(id: id, name: name, arguments: arguments));
+  }
+  return calls;
+}
+
+List<Map<String, dynamic>> openaiToolCallMaps(List<EmitToolCall> calls) {
+  return [
+    for (final call in calls)
+      <String, dynamic>{
+        'id': call.id,
+        'type': 'function',
+        'function': <String, dynamic>{
+          'name': call.name,
+          'arguments': jsonEncode(call.arguments),
+        },
+      },
+  ];
+}
+
+List<Map<String, dynamic>> openaiToolResultMessages(
+  List<ExecutedClientTool> executed,
+) {
+  return [
+    for (final item in executed)
+      <String, dynamic>{
+        'role': 'tool',
+        'tool_call_id': item.call.id,
+        'name': item.call.name,
+        'content': item.content,
+      },
+  ];
+}

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -473,6 +473,13 @@ TokenUsage? _openaiUsageFromObj(Map<String, dynamic> obj) {
   }
 }
 
+String? _openaiReasoningText(Map<String, dynamic>? message) {
+  final raw = (message?['reasoning_content'] ?? message?['reasoning'])
+      ?.toString();
+  if (raw == null || raw.isEmpty) return null;
+  return raw;
+}
+
 ({String content, List<({String uri, String mimeType})> images})
 _openaiVisibleOutputFromMessage(Map<String, dynamic>? cmsg) {
   var content = '';
@@ -498,9 +505,10 @@ _openaiVisibleOutputFromMessage(Map<String, dynamic>? cmsg) {
           if (u2 is String) url = u2;
         }
         if (url != null && url.isNotEmpty) {
+          final mime = mimeTypeFromImageUri(url) ?? 'image/png';
           images.add((
-            uri: url,
-            mimeType: mimeTypeFromImageUri(url) ?? 'image/png',
+            uri: completeRenderableImageUri(url, mimeType: mime),
+            mimeType: mime,
           ));
         }
       }
@@ -1443,7 +1451,7 @@ Stream<StreamChunk> _runOpenAIChatCompletionsNonStreamToolFollowUps({
         throw HttpException('HTTP ${resp2.statusCode}: $errorBody');
       }
       lastObj =
-          jsonDecode(await resp2.stream.bytesToString())
+          jsonDecode(await _decodeUtf8Stream(resp2.stream))
               as Map<String, dynamic>;
       final roundUsage = _openaiUsageFromObj(lastObj);
       if (roundUsage != null) {
@@ -1465,14 +1473,17 @@ Stream<StreamChunk> _runOpenAIChatCompletionsNonStreamToolFollowUps({
       final visible = _openaiVisibleOutputFromMessage(
         (choice['message'] as Map?)?.cast<String, dynamic>(),
       );
+      final lastMessage = _openaiFirstChoiceMessage(lastObj);
       yield* emitImages(visible.images);
       yield* emitDone(
         content: visible.content,
-        reasoningDetails: _openaiFirstChoiceMessage(
-          lastObj,
-        )?['reasoning_details'],
+        reasoning: _openaiReasoningText(lastMessage),
+        reasoningDetails: lastMessage?['reasoning_details'],
         usage: usage,
         totalTokens: usage?.totalTokens ?? 0,
+        finishReason: (choice['finish_reason'] ?? '').toString().isEmpty
+            ? null
+            : choice['finish_reason'].toString(),
       );
     },
     usageOf: () => usage,
@@ -2516,7 +2527,7 @@ Stream<StreamChunk> _sendOpenAIStream(
 
   // Non-streaming path: parse one-shot JSON and optionally follow tool calls.
   if (!stream) {
-    final txt = await response.stream.bytesToString();
+    final txt = await _decodeUtf8Stream(response.stream);
     try {
       final obj = jsonDecode(txt);
       // Responses API non-stream
@@ -2598,6 +2609,9 @@ Stream<StreamChunk> _sendOpenAIStream(
           content: (lastObj['output_text'] ?? '').toString(),
           usage: firstUsage,
           totalTokens: firstUsage?.totalTokens ?? 0,
+          finishReason: (lastObj['finish_reason'] ?? '').toString().isEmpty
+              ? null
+              : lastObj['finish_reason'].toString(),
         );
         return;
       }
@@ -2630,14 +2644,17 @@ Stream<StreamChunk> _sendOpenAIStream(
       final visible = _openaiVisibleOutputFromMessage(
         (firstChoice['message'] as Map?)?.cast<String, dynamic>(),
       );
+      final firstMessage = _openaiFirstChoiceMessage(lastObj);
       yield* emitImages(visible.images);
       yield* emitDone(
         content: visible.content,
-        reasoningDetails: _openaiFirstChoiceMessage(
-          lastObj,
-        )?['reasoning_details'],
+        reasoning: _openaiReasoningText(firstMessage),
+        reasoningDetails: firstMessage?['reasoning_details'],
         usage: firstUsage,
         totalTokens: firstUsage?.totalTokens ?? 0,
+        finishReason: (firstChoice['finish_reason'] ?? '').toString().isEmpty
+            ? null
+            : firstChoice['finish_reason'].toString(),
       );
       return;
     } catch (e) {

--- a/lib/core/services/api/stream/stream_chunk.dart
+++ b/lib/core/services/api/stream/stream_chunk.dart
@@ -243,6 +243,19 @@ bool isCompleteImageUri(String data) {
       trimmed.contains('://');
 }
 
+/// Make [data] a renderable URI at the parse source.
+///
+/// Do not call this from [StreamChunkHandler] merge — rikkahub `806f7dd6`
+/// dropped a `data:` prefix by rewriting images during fold.
+String completeRenderableImageUri(
+  String data, {
+  String mimeType = 'image/png',
+}) {
+  final trimmed = data.trim();
+  if (trimmed.isEmpty || isCompleteImageUri(trimmed)) return trimmed;
+  return 'data:$mimeType;base64,$trimmed';
+}
+
 String? mimeTypeFromImageUri(String uri) {
   final trimmed = uri.trim();
   if (trimmed.startsWith('data:')) {

--- a/lib/core/services/api/stream/stream_chunk_emit.dart
+++ b/lib/core/services/api/stream/stream_chunk_emit.dart
@@ -45,10 +45,11 @@ Stream<StreamChunk> emitFinish({
   TokenUsage? usage,
   int totalTokens = 0,
   dynamic reasoningDetails,
+  String? finishReason,
 }) async* {
   yield* emitReasoning(null, details: reasoningDetails);
   yield* emitUsage(_usageOrApprox(usage, totalTokens));
-  yield const Finish();
+  yield Finish(finishReason: finishReason);
 }
 
 Stream<StreamChunk> emitDelta({
@@ -69,10 +70,15 @@ Stream<StreamChunk> emitDone({
   dynamic reasoningDetails,
   TokenUsage? usage,
   int totalTokens = 0,
+  String? finishReason,
 }) async* {
   yield* emitReasoning(reasoning, details: reasoningDetails);
   yield* emitText(content);
-  yield* emitFinish(usage: usage, totalTokens: totalTokens);
+  yield* emitFinish(
+    usage: usage,
+    totalTokens: totalTokens,
+    finishReason: finishReason,
+  );
 }
 
 Stream<StreamChunk> emitImages(
@@ -83,7 +89,10 @@ Stream<StreamChunk> emitImages(
     if (image.uri.isEmpty) continue;
     final id = ids.next('image');
     yield ImageStart(id: id, mimeType: image.mimeType);
-    yield ImageSnapshot(id: id, data: image.uri);
+    yield ImageSnapshot(
+      id: id,
+      data: completeRenderableImageUri(image.uri, mimeType: image.mimeType),
+    );
     yield ImageEnd(id);
   }
 }

--- a/lib/core/services/api/stream/stream_chunk_handler.dart
+++ b/lib/core/services/api/stream/stream_chunk_handler.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import '../../../models/message_part.dart';
 import '../../../models/token_usage.dart';
+import '../generation/text_generation_result.dart';
 import 'stream_chunk.dart';
 
 /// Folds [StreamChunk] events into an ordered [MessagePart] list.
@@ -24,6 +25,51 @@ class StreamChunkHandler {
   String? finishReason;
 
   List<MessagePart> get parts => List<MessagePart>.unmodifiable(_parts);
+
+  TextGenerationResult toResult() {
+    return TextGenerationResult(
+      parts: [
+        for (final part in _parts)
+          if (!_isBlankPart(part)) part,
+      ],
+      usage: usage,
+      finishReason: finishReason,
+      reasoningDetails: reasoningDetails,
+    );
+  }
+
+  static TextGenerationResult collect(Iterable<StreamChunk> chunks) {
+    final handler = StreamChunkHandler();
+    for (final chunk in chunks) {
+      handler.handle(chunk);
+    }
+    return handler.toResult();
+  }
+
+  /// Merge a complete non-stream result. Image URIs are kept as-is.
+  void handleResult(TextGenerationResult result) {
+    if (finished) return;
+    for (final part in result.parts) {
+      switch (part) {
+        case TextPart(:final text) when text.isEmpty:
+          continue;
+        case ReasoningPart(:final text) when text.isEmpty:
+          continue;
+        case ImagePart(:final uri) when uri.isEmpty:
+          continue;
+        default:
+          _parts.add(part);
+      }
+    }
+    if (result.usage != null) {
+      usage = (usage ?? const TokenUsage()).merge(result.usage!);
+    }
+    if (result.reasoningDetails != null) {
+      reasoningDetails = result.reasoningDetails;
+    }
+    finishReason = result.finishReason ?? finishReason;
+    finished = true;
+  }
 
   void handle(StreamChunk chunk) {
     if (finished) return;
@@ -227,6 +273,15 @@ class StreamChunkHandler {
     } else {
       _parts[index] = part;
     }
+  }
+
+  static bool _isBlankPart(MessagePart part) {
+    return switch (part) {
+      TextPart(:final text) => text.isEmpty,
+      ReasoningPart(:final text) => text.isEmpty,
+      ImagePart(:final uri) => uri.isEmpty,
+      _ => false,
+    };
   }
 
   String? _toolId(ToolCallPart part) {

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -1807,6 +1807,54 @@ class ChatActions {
           ..stateRevision = run.stateRevision
           ..nextSeq = run.checkpointSeq + 1;
       }
+      final previousSub = _conversationStreams.remove(conversationId);
+      if (previousSub != null) {
+        ChatApiService.cancelRequest(conversationId);
+        await _cancelSubscriptionWithTimeout(previousSub);
+      }
+
+      if (!ctx.streamOutput) {
+        try {
+          final result = await ChatApiService.generateMessage(
+            config: ctx.config,
+            modelId: ctx.modelId,
+            messages: ctx.apiMessages,
+            userImagePaths: ctx.userImagePaths,
+            thinkingBudget:
+                assistant?.thinkingBudget ?? ctx.settings.thinkingBudget,
+            temperature: assistant?.temperature,
+            topP: assistant?.topP,
+            maxTokens: assistant?.maxTokens,
+            tools: ctx.toolDefs.isEmpty ? null : ctx.toolDefs,
+            onToolCall: ctx.onToolCall,
+            extraHeaders: ctx.extraHeaders,
+            extraBody: ctx.extraBody,
+            requestId: conversationId,
+            allowImagesApiRouting: ctx.allowImagesApiRouting,
+            ocrActive: ctx.ocrActive,
+          );
+          state.streamStartedAt ??= DateTime.now();
+          await _markGenerationStreaming(state);
+          state.shadowHandler.handleResult(result);
+          state.fullContentRaw = result.text;
+          state.bufferedReasoning = [
+            for (final part in result.parts)
+              if (part is ReasoningPart && part.text.isNotEmpty) part.text,
+          ].join();
+          if (result.usage != null) _applyUsage(state, result.usage!);
+          if (result.reasoningDetails != null) {
+            streamController.setReasoningDetails(
+              state.messageId,
+              result.reasoningDetails,
+            );
+          }
+          await _handleStreamFinish(state);
+        } catch (e) {
+          await _handleStreamError(e, state);
+        }
+        return;
+      }
+
       final stream = ChatApiService.sendMessageStream(
         config: ctx.config,
         modelId: ctx.modelId,
@@ -1821,21 +1869,11 @@ class ChatActions {
         onToolCall: ctx.onToolCall,
         extraHeaders: ctx.extraHeaders,
         extraBody: ctx.extraBody,
-        stream: ctx.streamOutput,
         requestId: conversationId,
         allowImagesApiRouting: ctx.allowImagesApiRouting,
         ocrActive: ctx.ocrActive,
       );
 
-      // Replacing a previous stream: the new request has not registered its
-      // cancel token yet (that happens on listen), so cancelRequest still
-      // targets the old one. Break its network wait first so the barrier
-      // cancel below cannot stall on a dead connection.
-      final previousSub = _conversationStreams.remove(conversationId);
-      if (previousSub != null) {
-        ChatApiService.cancelRequest(conversationId);
-        await _cancelSubscriptionWithTimeout(previousSub);
-      }
       final sub = listenSequentiallyToStream<StreamChunk>(
         stream: stream,
         onData: (chunk) => _handleStreamChunk(chunk, state),

--- a/lib/features/home/services/ocr_service.dart
+++ b/lib/features/home/services/ocr_service.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
-import '../../../core/services/api/stream/stream_chunk.dart';
 
 /// OCR 缓存条目
 class OcrCacheEntry {
@@ -119,29 +118,17 @@ class OcrService {
       },
     ];
 
-    final stream = ChatApiService.sendMessageStream(
-      config: cfg,
-      modelId: model,
-      messages: messages,
-      userImagePaths: imagePaths,
-      thinkingBudget: settings.ocrGenerationThinkingBudgetFor(null),
-      topP: null,
-      maxTokens: null,
-      tools: null,
-      onToolCall: null,
-      extraHeaders: null,
-      extraBody: null,
-      stream: false,
-      ocrActive: true,
-    );
-
     String out = '';
     try {
-      await for (final chunk in stream) {
-        if (chunk is TextDelta && chunk.text.isNotEmpty) {
-          out += chunk.text;
-        }
-      }
+      final result = await ChatApiService.generateMessage(
+        config: cfg,
+        modelId: model,
+        messages: messages,
+        userImagePaths: imagePaths,
+        thinkingBudget: settings.ocrGenerationThinkingBudgetFor(null),
+        ocrActive: true,
+      );
+      out = result.text;
     } catch (e) {
       onError?.call(e);
       return null;

--- a/test/chat_api_generate_message_test.dart
+++ b/test/chat_api_generate_message_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ProviderConfig _openAIConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GenerateMessageTest',
+    enabled: true,
+    name: 'GenerateMessageTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+  );
+}
+
+void main() {
+  test(
+    'generateMessage folds non-stream JSON into complete renderable parts',
+    () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody =
+            (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+                .cast<String, dynamic>();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'choices': [
+              {
+                'finish_reason': 'stop',
+                'message': {
+                  'content': [
+                    {'type': 'text', 'text': 'hello'},
+                    {
+                      'type': 'image_url',
+                      'image_url': {'url': 'AQIDBA=='},
+                    },
+                  ],
+                },
+              },
+            ],
+            'usage': {
+              'prompt_tokens': 3,
+              'completion_tokens': 2,
+              'total_tokens': 5,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final result = await ChatApiService.generateMessage(
+        config: _openAIConfig(baseUrl),
+        modelId: 'title-model',
+        messages: [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      );
+
+      expect(requestBody['stream'], isFalse);
+      expect(result.text, 'hello');
+      expect(result.finishReason, 'stop');
+      expect(result.usage?.totalTokens, 5);
+      expect(
+        result.parts.whereType<ImagePart>().single.uri,
+        'data:image/png;base64,AQIDBA==',
+      );
+    },
+  );
+}

--- a/test/chat_api_generate_text_encoding_test.dart
+++ b/test/chat_api_generate_text_encoding_test.dart
@@ -248,7 +248,8 @@ void main() {
       );
 
       expect(title, '标题');
-      expect(requestBody.containsKey('generationConfig'), isFalse);
+      expect(requestBody.containsKey('temperature'), isFalse);
+      expect(requestBody['generationConfig'], isA<Map>());
     });
 
     test(

--- a/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
+++ b/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
@@ -287,6 +287,60 @@ void main() {
     );
   });
 
+  test('ingests complete message.tool_calls from one-shot JSON', () {
+    final decoder = ChatCompletionsStreamDecoder();
+    final result = decoder.accept(
+      _event(
+        _choice(
+          message: <String, dynamic>{
+            'content': '',
+            'tool_calls': [
+              <String, dynamic>{
+                'id': 'call_ns',
+                'type': 'function',
+                'function': <String, dynamic>{
+                  'name': 'lookup',
+                  'arguments': '{"q":"kelivo"}',
+                },
+              },
+            ],
+          },
+          finishReason: 'tool_calls',
+        ),
+      ),
+    );
+
+    expect(decoder.finishReason, 'tool_calls');
+    expect(decoder.toolCalls[0]!['id'], 'call_ns');
+    expect(decoder.toolCalls[0]!['name'], 'lookup');
+    expect(decoder.toolCalls[0]!['args'], '{"q":"kelivo"}');
+    expect(result.chunks.whereType<ToolCallStart>().single.id, 'call_ns');
+    expect(result.chunks.whereType<ToolCallEnd>().single.id, 'call_ns');
+  });
+
+  test('completes raw base64 Chat Completions images at the parse source', () {
+    final decoder = ChatCompletionsStreamDecoder(wantsImageOutput: true);
+    final result = decoder.accept(
+      _event(
+        _choice(
+          message: <String, dynamic>{
+            'content': [
+              <String, dynamic>{
+                'type': 'image_url',
+                'image_url': <String, dynamic>{'url': 'AQIDBA=='},
+              },
+            ],
+          },
+        ),
+      ),
+    );
+
+    expect(
+      result.chunks.whereType<ImageSnapshot>().single.data,
+      'data:image/png;base64,AQIDBA==',
+    );
+  });
+
   test('keeps the data: prefix on Chat Completions image URLs', () {
     const dataUri = 'data:image/png;base64,AQIDBA==';
     final decoder = ChatCompletionsStreamDecoder(wantsImageOutput: true);

--- a/test/core/services/api/stream/stream_chunk_handler_test.dart
+++ b/test/core/services/api/stream/stream_chunk_handler_test.dart
@@ -4,6 +4,7 @@ import 'package:Kelivo/core/models/message_part.dart';
 import 'package:Kelivo/core/models/token_usage.dart';
 import 'package:Kelivo/core/services/api/providers/openai/chat_completions_decoder.dart';
 import 'package:Kelivo/core/services/api/stream/sse_event.dart';
+import 'package:Kelivo/core/services/api/generation/text_generation_result.dart';
 import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
 import 'package:Kelivo/core/services/api/stream/stream_chunk_handler.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -339,5 +340,42 @@ void main() {
 
     expect(handler.parts.map((p) => p.kind).toList(), ['text', 'tool_call']);
     expect((handler.parts[0] as TextPart).text, 'beforeafter');
+  });
+
+  test('collect folds chunks into a TextGenerationResult', () {
+    final result = StreamChunkHandler.collect([
+      const TextDelta(id: 't', text: 'Hello'),
+      const Usage(TokenUsage(totalTokens: 4)),
+      const Finish(finishReason: 'stop'),
+    ]);
+
+    expect(result.text, 'Hello');
+    expect(result.finishReason, 'stop');
+    expect(result.usage?.totalTokens, 4);
+    expect(result.parts, hasLength(1));
+  });
+
+  test('handleResult keeps image URIs as-is and does not add data:', () {
+    final handler = StreamChunkHandler();
+    handler.handleResult(
+      const TextGenerationResult(
+        parts: [
+          TextPart('done'),
+          ImagePart(uri: 'https://img.example/a.png', mime: 'image/png'),
+          ImagePart(uri: 'data:image/png;base64,AQID', mime: 'image/png'),
+          ImagePart(uri: 'kelivo-file:///images/a.png', mime: 'image/png'),
+        ],
+        finishReason: 'stop',
+      ),
+    );
+
+    expect(handler.finished, isTrue);
+    expect(handler.finishReason, 'stop');
+    expect(handler.parts.whereType<ImagePart>().map((part) => part.uri), [
+      'https://img.example/a.png',
+      'data:image/png;base64,AQID',
+      'kelivo-file:///images/a.png',
+    ]);
+    expect(handler.parts.whereType<TextPart>().single.text, 'done');
   });
 }

--- a/test/core/services/api/stream/stream_chunk_test.dart
+++ b/test/core/services/api/stream/stream_chunk_test.dart
@@ -20,6 +20,25 @@ void main() {
     expect(chunk.reasoningType, ReasoningType.summaryText);
   });
 
+  test('completeRenderableImageUri wraps raw base64 only', () {
+    expect(
+      completeRenderableImageUri('iVBORw0K', mimeType: 'image/png'),
+      'data:image/png;base64,iVBORw0K',
+    );
+    expect(
+      completeRenderableImageUri('data:image/png;base64,AAA'),
+      'data:image/png;base64,AAA',
+    );
+    expect(
+      completeRenderableImageUri('https://img.example/a.png'),
+      'https://img.example/a.png',
+    );
+    expect(
+      completeRenderableImageUri('kelivo-file:///images/a.png'),
+      'kelivo-file:///images/a.png',
+    );
+  });
+
   test('isCompleteImageUri distinguishes URLs from raw base64', () {
     expect(isCompleteImageUri('data:image/png;base64,AAA'), isTrue);
     expect(isCompleteImageUri('https://img.example/a.png'), isTrue);


### PR DESCRIPTION
## Summary
- Add `TextGenerationResult` and `ChatApiService.generateMessage`. Non-stream chat, OCR, and `generateText` fold `sendMessageStream(stream: false)` through `StreamChunkHandler` instead of a second parse path.
- Image URIs are completed at the parse/emit source (`completeRenderableImageUri`). `handleResult` keeps them as-is — no `data:` rewrite at merge (rikkahub `806f7dd6`).
- Two runner entries stay: OpenAI still consumes the first round itself. OpenAI wire helpers moved to `providers/openai/openai_tool_transcript.dart` so `generation/` stays protocol-agnostic.

Stacks on #894.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed lib test`
- [x] `dart analyze --fatal-infos lib test`
- [x] `flutter test` (2520 passed)
- [ ] Smoke `generateText` title/summary (OpenAI + Google + Claude)
- [ ] Smoke chat with stream output off (text + image + tools)
- [ ] Smoke OCR via `generateMessage`