### PR TITLE
fix(stream): repair six merge-blocking ai-stream regressions

### DIFF
--- a/lib/core/services/api/generation/tool_loop_runner.dart
+++ b/lib/core/services/api/generation/tool_loop_runner.dart
@@ -63,12 +63,14 @@ Stream<StreamChunk> runClientToolFollowUps({
   TokenUsage? Function()? usageOf,
 }) async* {
   var calls = List<EmitToolCall>.from(initialCalls);
-  var shouldEmitCalls = emitCalls;
   while (calls.isNotEmpty) {
     final usage = usageOf?.call();
     final totalTokens = usage?.totalTokens ?? 0;
     final executed = <ExecutedClientTool>[];
-    if (shouldEmitCalls) {
+    // Do not clear [emitCalls] after the first round. OpenAI non-stream
+    // follow-ups have no decoder emitting ToolCall*, so later rounds would
+    // otherwise land as ToolCallResult-only cards with empty name/args.
+    if (emitCalls) {
       yield* emitToolCalls(calls, usage: usage, totalTokens: totalTokens);
     }
     for (final call in calls) {
@@ -100,7 +102,6 @@ Stream<StreamChunk> runClientToolFollowUps({
     append(executed);
     yield* sendFollowUp();
     calls = takeCallsAfterRound();
-    shouldEmitCalls = false;
   }
   yield* finish();
 }

--- a/lib/core/services/api/providers/openai/chat_completions_api.dart
+++ b/lib/core/services/api/providers/openai/chat_completions_api.dart
@@ -10,6 +10,7 @@ import '../../../../utils/multimodal_input_utils.dart';
 import '../../../../../utils/sandbox_path_resolver.dart';
 import '../../chat_api_helpers.dart';
 import '../../generation/tool_loop_runner.dart';
+import '../../stream/sse_decode_loop.dart';
 import '../../stream/sse_framing.dart';
 import '../../stream/stream_chunk.dart';
 import '../../stream/stream_chunk_emit.dart';
@@ -831,16 +832,7 @@ Stream<StreamChunk> runOpenAIChatCompletionsToolFollowUps({
         initialUsage: usage,
         sourceId: 'round-${round++}',
       );
-      await for (final event in parseSseEventStrings(s2)) {
-        final data = event.data;
-        if (data == '[DONE]') continue;
-        throwIfInBandStreamError(data);
-        try {
-          for (final chunk in roundDecoder.accept(event).chunks) {
-            yield chunk;
-          }
-        } catch (_) {}
-      }
+      yield* decodeSseEvents(parseSseEventStrings(s2), roundDecoder);
       usage = roundDecoder.usage ?? usage;
       chars = roundDecoder.approxCompletionChars;
       lastRound = roundDecoder;

--- a/lib/core/services/api/providers/openai/chat_completions_decoder.dart
+++ b/lib/core/services/api/providers/openai/chat_completions_decoder.dart
@@ -182,7 +182,7 @@ class ChatCompletionsStreamDecoder implements StreamChunkDecoder {
             'title': citations[k].toString(),
           },
       ];
-      final searchId = _ids.search();
+      final searchId = _ids.searchSticky();
       chunks.add(ServerToolStart(id: searchId, toolName: 'search_web'));
       chunks.add(
         ServerToolEnd(id: searchId, output: <String, dynamic>{'items': items}),

--- a/lib/core/services/api/providers/openai/openai_provider.dart
+++ b/lib/core/services/api/providers/openai/openai_provider.dart
@@ -896,63 +896,9 @@ Stream<StreamChunk> sendOpenAIStream(
 
   await for (final event in parseSseEventStrings(sse)) {
     final data = event.data;
-    if (data == '[DONE]') {
-      // If model streamed tool_calls but didn't include finish_reason on prior chunks,
-      // execute tool flow now and start follow-up request.
-      if (effectiveOnToolCall != null && toolAcc.isNotEmpty) {
-        yield* runOpenAIChatCompletionsToolFollowUps(
-          client: client,
-          config: config,
-          modelId: modelId,
-          upstreamModelId: upstreamModelId,
-          url: url,
-          info: info,
-          messages: messages,
-          firstToolAcc: toolAcc,
-          firstAssistantContent: assistantContentBuffer,
-          firstReasoning: reasoningBuffer,
-          firstReasoningDetails:
-              chatDecoder?.reasoningDetails ??
-              reasoningDetailsBuffer.detailsOrNull,
-          onToolCall: effectiveOnToolCall,
-          userImagePaths: userImagePaths,
-          canImageInput: canImageInput,
-          allowRemoteImages: allowRemoteImages,
-          isClaudeUpstream: isClaudeUpstream,
-          isReasoning: isReasoning,
-          effort: effort,
-          thinkingBudget: thinkingBudget,
-          temperature: temperature,
-          topP: topP,
-          tools: tools,
-          extraBodyCfg: extraBodyCfg,
-          extraHeaders: extraHeaders,
-          wantsImageOutput: wantsImageOutput,
-          needsReasoningEcho: needsReasoningEcho,
-          reasoningDetailsAllowSnapshots: reasoningDetailsAllowSnapshots,
-          applyMaxTokens: setMaxTokens,
-          initialUsage: usage,
-          streamRound: streamRound,
-          approxPromptTokens: approxPromptTokens,
-          approxCompletionChars: approxCompletionChars,
-          includeReasoningDetailsOnDone: true,
-        );
-        return;
-      }
-
-      final approxTotal =
-          approxPromptTokens + approxTokensFromChars(approxCompletionChars);
-      yield* emitDone(
-        reasoningDetails:
-            chatDecoder?.reasoningDetails ??
-            reasoningDetailsBuffer.detailsOrNull,
-        usage: usage,
-        totalTokens: usage?.totalTokens ?? approxTotal,
-      );
-      return;
+    if (data.isNotEmpty && data != '[DONE]') {
+      throwIfInBandStreamError(data);
     }
-
-    throwIfInBandStreamError(data);
     try {
       if (config.useResponseApi == true) {
         final decoder = responsesDecoder!;
@@ -961,6 +907,9 @@ Stream<StreamChunk> sendOpenAIStream(
           yield chunk;
         }
         if (!decoded.completed) continue;
+        for (final chunk in decoder.onClosed()) {
+          yield chunk;
+        }
 
         usage = decoder.usage ?? usage;
         totalTokens = usage?.totalTokens ?? totalTokens;
@@ -1086,6 +1035,61 @@ Stream<StreamChunk> sendOpenAIStream(
         approxCompletionChars = decoder.approxCompletionChars;
         reasoningBuffer = decoder.reasoningEcho;
         assistantContentBuffer = decoder.assistantContent;
+        if (data == '[DONE]') {
+          for (final chunk in decoder.onClosed()) {
+            yield chunk;
+          }
+          if (effectiveOnToolCall != null && toolAcc.isNotEmpty) {
+            yield* runOpenAIChatCompletionsToolFollowUps(
+              client: client,
+              config: config,
+              modelId: modelId,
+              upstreamModelId: upstreamModelId,
+              url: url,
+              info: info,
+              messages: messages,
+              firstToolAcc: toolAcc,
+              firstAssistantContent: assistantContentBuffer,
+              firstReasoning: reasoningBuffer,
+              firstReasoningDetails:
+                  decoder.reasoningDetails ??
+                  reasoningDetailsBuffer.detailsOrNull,
+              onToolCall: effectiveOnToolCall,
+              userImagePaths: userImagePaths,
+              canImageInput: canImageInput,
+              allowRemoteImages: allowRemoteImages,
+              isClaudeUpstream: isClaudeUpstream,
+              isReasoning: isReasoning,
+              effort: effort,
+              thinkingBudget: thinkingBudget,
+              temperature: temperature,
+              topP: topP,
+              tools: tools,
+              extraBodyCfg: extraBodyCfg,
+              extraHeaders: extraHeaders,
+              wantsImageOutput: wantsImageOutput,
+              needsReasoningEcho: needsReasoningEcho,
+              reasoningDetailsAllowSnapshots: reasoningDetailsAllowSnapshots,
+              applyMaxTokens: setMaxTokens,
+              initialUsage: usage,
+              streamRound: streamRound,
+              approxPromptTokens: approxPromptTokens,
+              approxCompletionChars: approxCompletionChars,
+              includeReasoningDetailsOnDone: true,
+            );
+            return;
+          }
+          final approxTotal =
+              approxPromptTokens + approxTokensFromChars(approxCompletionChars);
+          yield* emitDone(
+            reasoningDetails:
+                decoder.reasoningDetails ??
+                reasoningDetailsBuffer.detailsOrNull,
+            usage: usage,
+            totalTokens: usage?.totalTokens ?? approxTotal,
+          );
+          return;
+        }
       }
 
       // Some providers (e.g., OpenRouter) may omit the [DONE] sentinel
@@ -1097,6 +1101,9 @@ Stream<StreamChunk> sendOpenAIStream(
           finishReason == 'tool_calls' &&
           toolAcc.isNotEmpty &&
           effectiveOnToolCall != null) {
+        for (final chunk in chatDecoder.onClosed()) {
+          yield chunk;
+        }
         yield* runOpenAIChatCompletionsToolFollowUps(
           client: client,
           config: config,
@@ -1146,6 +1153,9 @@ Stream<StreamChunk> sendOpenAIStream(
         if (hasPendingToolCalls && pendingHandler != null) {
           // Some providers (like XinLiu/iflow.cn) may return tool_calls with finish_reason='stop'
           // and may not send a [DONE] marker. Execute tools immediately in this case.
+          for (final chunk in chatDecoder.onClosed()) {
+            yield chunk;
+          }
           yield* runOpenAIChatCompletionsToolFollowUps(
             client: client,
             config: config,
@@ -1199,6 +1209,12 @@ Stream<StreamChunk> sendOpenAIStream(
   }
 
   // Fallback: provider closed SSE without sending [DONE]
+  for (final chunk in chatDecoder?.onClosed() ?? const <StreamChunk>[]) {
+    yield chunk;
+  }
+  for (final chunk in responsesDecoder?.onClosed() ?? const <StreamChunk>[]) {
+    yield chunk;
+  }
   final approxTotal =
       usage?.totalTokens ??
       (approxPromptTokens + approxTokensFromChars(approxCompletionChars));

--- a/lib/core/services/api/providers/openai/responses_api.dart
+++ b/lib/core/services/api/providers/openai/responses_api.dart
@@ -10,6 +10,7 @@ import '../../../../../utils/app_directories.dart';
 import '../../../../../utils/sandbox_path_resolver.dart';
 import '../../chat_api_helpers.dart';
 import '../../generation/tool_loop_runner.dart';
+import '../../stream/sse_decode_loop.dart';
 import '../../stream/sse_framing.dart';
 import '../../stream/stream_chunk.dart';
 import '../../stream/stream_chunk_emit.dart';
@@ -298,19 +299,7 @@ Stream<StreamChunk> runOpenAIResponsesToolFollowUps({
         initialUsage: usage,
         sourceId: 'round-${round++}',
       );
-      await for (final event in parseSseEventStrings(s2)) {
-        final d = event.data;
-        if (d == '[DONE]') {
-          followUpDecoder.accept(event);
-          break;
-        }
-        throwIfInBandStreamError(d);
-        final decoded = followUpDecoder.accept(event);
-        for (final chunk in decoded.chunks) {
-          yield chunk;
-        }
-        if (decoded.completed) break;
-      }
+      yield* decodeSseEvents(parseSseEventStrings(s2), followUpDecoder);
       usage = followUpDecoder.usage ?? usage;
       chars += followUpDecoder.approxCompletionChars;
       outputItemsForAppend = followUpDecoder.outputItems;

--- a/lib/core/services/api/stream/sse_decode_loop.dart
+++ b/lib/core/services/api/stream/sse_decode_loop.dart
@@ -1,0 +1,30 @@
+import '../chat_api_helpers.dart';
+import 'sse_event.dart';
+import 'stream_chunk.dart';
+import 'stream_chunk_decoder.dart';
+
+/// Feed [events] through [decoder], including `[DONE]`, then [onClosed].
+///
+/// OpenAI follow-up loops must yield the `[DONE]` chunks — that is how
+/// [StreamChunkDecoder.accept] closes open tool / image / search series.
+/// Call [onClosed] afterwards so a stream that ends without `[DONE]` still
+/// flushes those ends. The two are idempotent.
+Stream<StreamChunk> decodeSseEvents(
+  Stream<SseEvent> events,
+  StreamChunkDecoder decoder,
+) async* {
+  await for (final event in events) {
+    final data = event.data;
+    if (data.isNotEmpty && data != '[DONE]') {
+      throwIfInBandStreamError(data);
+    }
+    final decoded = decoder.accept(event);
+    for (final chunk in decoded.chunks) {
+      yield chunk;
+    }
+    if (data == '[DONE]' || decoded.completed) break;
+  }
+  for (final chunk in decoder.onClosed()) {
+    yield chunk;
+  }
+}

--- a/lib/core/services/api/stream/stream_chunk_handler.dart
+++ b/lib/core/services/api/stream/stream_chunk_handler.dart
@@ -11,6 +11,13 @@ import 'stream_chunk.dart';
 /// arrivals do not clobber the last part. Tool calls are located by tool id.
 /// One instance per response stream; do not reuse after [Finish].
 class StreamChunkHandler {
+  StreamChunkHandler({Iterable<MessagePart> seed = const <MessagePart>[]}) {
+    for (final part in seed) {
+      if (_isBlankPart(part)) continue;
+      _seedPart(part);
+    }
+  }
+
   final List<MessagePart> _parts = <MessagePart>[];
   final Map<String, int> _textIndex = <String, int>{};
   final Map<String, int> _reasoningIndex = <String, int>{};
@@ -69,6 +76,31 @@ class StreamChunkHandler {
     }
     finishReason = result.finishReason ?? finishReason;
     finished = true;
+  }
+
+  void _seedPart(MessagePart part) {
+    _parts.add(part);
+    if (part is! ToolCallPart) return;
+    try {
+      final decoded = jsonDecode(part.payloadJson);
+      if (decoded is! Map) return;
+      final id = (decoded['id'] ?? '').toString();
+      if (id.isEmpty) return;
+      final buffer = _tools.putIfAbsent(id, _ToolBuffer.new);
+      final name = (decoded['name'] ?? '').toString();
+      if (name.isNotEmpty) buffer.name = name;
+      if (decoded.containsKey('arguments')) {
+        buffer.arguments = decoded['arguments'];
+      }
+      if (decoded.containsKey('content')) {
+        buffer.content = decoded['content'];
+      }
+      buffer.server = decoded['server'] == true;
+      final metadata = decoded['metadata'];
+      if (metadata is Map) {
+        buffer.metadata = Map<String, dynamic>.from(metadata);
+      }
+    } catch (_) {}
   }
 
   void handle(StreamChunk chunk) {

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -672,6 +672,35 @@ class ChatActions {
   /// When no visible text arrived, the error string is written through
   /// [ChatMessage.partsWithReplacedText] so reasoning / tool / image parts
   /// already accumulated stay in place.
+  /// Truncate [parts] so joined [TextPart]s match the typewriter slice.
+  ///
+  /// Non-text cards stay in place. Text after the visible prefix is omitted
+  /// so the consumer can keep using `content: parts == null ? display : null`.
+  @visibleForTesting
+  static List<MessagePart> assistantPartsForVisibleText({
+    required List<MessagePart> parts,
+    required String visibleText,
+  }) {
+    if (parts.isEmpty) return <MessagePart>[TextPart(visibleText)];
+    var remaining = visibleText.length;
+    final out = <MessagePart>[];
+    for (final part in parts) {
+      if (part is! TextPart) {
+        out.add(part);
+        continue;
+      }
+      if (remaining <= 0) continue;
+      if (part.text.length <= remaining) {
+        out.add(part);
+        remaining -= part.text.length;
+      } else {
+        out.add(TextPart(part.text.substring(0, remaining)));
+        remaining = 0;
+      }
+    }
+    return out;
+  }
+
   @visibleForTesting
   static List<MessagePart> assistantPartsForStreamError({
     required List<MessagePart> parts,
@@ -899,18 +928,28 @@ class ChatActions {
     );
   }
 
-  List<MessagePart> _assistantPartsForState(stream_ctrl.StreamingState state) {
+  List<MessagePart> _assistantPartsForState(
+    stream_ctrl.StreamingState state, {
+    String? visibleText,
+  }) {
     final parts = state.partsHandler.parts;
     if (parts.isEmpty) {
-      return <MessagePart>[TextPart(_transformAssistantContent(state))];
+      return <MessagePart>[
+        TextPart(visibleText ?? _transformAssistantContent(state)),
+      ];
     }
-    return [
+    final transformed = [
       for (final part in parts)
         if (part is TextPart)
           TextPart(_transformAssistantContent(state, part.text))
         else
           part,
     ];
+    if (visibleText == null) return transformed;
+    return assistantPartsForVisibleText(
+      parts: transformed,
+      visibleText: visibleText,
+    );
   }
 
   Future<List<MessagePart>> _sanitizeAssistantImageParts(
@@ -1836,9 +1875,12 @@ class ChatActions {
           state.streamStartedAt ??= DateTime.now();
           await _markGenerationStreaming(state);
           state.partsHandler.handleResult(result);
-          state.fullContentRaw = result.text;
+          state.fullContentRaw = [
+            for (final part in state.partsHandler.parts)
+              if (part is TextPart) part.text,
+          ].join();
           state.bufferedReasoning = [
-            for (final part in result.parts)
+            for (final part in state.partsHandler.parts)
               if (part is ReasoningPart && part.text.isNotEmpty) part.text,
           ].join();
           if (result.usage != null) _applyUsage(state, result.usage!);
@@ -2085,7 +2127,8 @@ class ChatActions {
         messageId,
         conversationId,
         () => _transformAssistantContent(state),
-        partsBuilder: () => _assistantPartsForState(state),
+        partsBuilder: (visibleText) =>
+            _assistantPartsForState(state, visibleText: visibleText),
         totalTokens: state.totalTokens,
         promptTokens: state.usage?.promptTokens,
         completionTokens: state.usage?.completionTokens,

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -537,7 +537,7 @@ class StreamController {
     String messageId,
     String conversationId,
     String Function() contentBuilder, {
-    List<MessagePart> Function()? partsBuilder,
+    List<MessagePart> Function(String visibleText)? partsBuilder,
     required void Function(String messageId, String content, int totalTokens)
     updateMessageInList,
     required int totalTokens,
@@ -636,7 +636,7 @@ class StreamController {
       messageId,
       content,
       state.totalTokens,
-      parts: state.partsBuilder?.call(),
+      parts: state.partsBuilder?.call(content),
       contentSplitOffsets: state.contentSplitOffsets,
       reasoningCountAtSplit: state.reasoningCountAtSplit,
       toolCountAtSplit: state.toolCountAtSplit,
@@ -1560,7 +1560,9 @@ class GenerationContext {
 
 /// State object for streaming message generation.
 class StreamingState {
-  StreamingState(this.ctx) : fullContentRaw = ctx.assistantMessage.content;
+  StreamingState(this.ctx)
+    : fullContentRaw = ctx.assistantMessage.content,
+      partsHandler = StreamChunkHandler(seed: ctx.assistantMessage.parts);
 
   final GenerationContext ctx;
   String fullContentRaw;
@@ -1578,7 +1580,7 @@ class StreamingState {
   List<int> contentSplitOffsets = <int>[];
   List<int> reasoningCountAtSplit = <int>[];
   List<int> toolCountAtSplit = <int>[];
-  final StreamChunkHandler partsHandler = StreamChunkHandler();
+  final StreamChunkHandler partsHandler;
 
   String get messageId => ctx.assistantMessage.id;
   String get conversationId => ctx.assistantMessage.conversationId;
@@ -1704,7 +1706,7 @@ class _StreamSmoothState {
   String targetContent = '';
   String visibleContent = '';
   String Function()? contentBuilder;
-  List<MessagePart> Function()? partsBuilder;
+  List<MessagePart> Function(String visibleText)? partsBuilder;
   int totalTokens = 0;
   List<int>? contentSplitOffsets;
   List<int>? reasoningCountAtSplit;

--- a/test/core/services/api/generation/tool_loop_runner_test.dart
+++ b/test/core/services/api/generation/tool_loop_runner_test.dart
@@ -90,6 +90,52 @@ void main() {
     },
   );
 
+  test(
+    'runClientToolFollowUps still emits ToolCall* on later rounds',
+    () async {
+      var rounds = 0;
+      final chunks = await runClientToolFollowUps(
+        initialCalls: [
+          emitToolCall(
+            id: 'call_1',
+            name: 'lookup',
+            arguments: const <String, dynamic>{'q': '1'},
+          ),
+        ],
+        onToolCall: (name, args, {toolCallId}) async => 'res-$toolCallId',
+        append: (_) {},
+        sendFollowUp: () async* {
+          rounds += 1;
+          yield TextDelta(id: 't-$rounds', text: 'round-$rounds');
+        },
+        takeCallsAfterRound: () => rounds == 1
+            ? [
+                emitToolCall(
+                  id: 'call_2',
+                  name: 'lookup',
+                  arguments: const <String, dynamic>{'q': '2'},
+                ),
+              ]
+            : const <EmitToolCall>[],
+        finish: () => emitFinish(),
+        emitCalls: true,
+      ).toList();
+
+      expect(chunks.whereType<ToolCallStart>().map((chunk) => chunk.id), [
+        'call_1',
+        'call_2',
+      ]);
+      expect(chunks.whereType<ToolCallStart>().map((chunk) => chunk.toolName), [
+        'lookup',
+        'lookup',
+      ]);
+      expect(chunks.whereType<ToolCallResult>().map((chunk) => chunk.id), [
+        'call_1',
+        'call_2',
+      ]);
+    },
+  );
+
   test('runProviderToolRounds continues without calls when asked', () async {
     var sends = 0;
     final chunks = await runProviderToolRounds(

--- a/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
+++ b/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
@@ -403,7 +403,7 @@ void main() {
     expect(decoder.reasoningDetails, hasLength(2));
   });
 
-  test('scopes text ids per sourceId and search ids per citation burst', () {
+  test('scopes text ids per sourceId', () {
     final first = ChatCompletionsStreamDecoder(sourceId: 'round-0');
     final second = ChatCompletionsStreamDecoder(sourceId: 'round-1');
     expect(
@@ -424,31 +424,41 @@ void main() {
           .id,
       'round-1:text-1',
     );
+  });
 
-    final citations = ChatCompletionsStreamDecoder(sourceId: 'round-0');
-    final firstSearch = citations
-        .accept(
-          _event(<String, dynamic>{
-            ..._choice(delta: <String, dynamic>{'content': 'see'}),
-            'citations': <String>['https://a.example'],
-          }),
-        )
-        .chunks
-        .whereType<ServerToolStart>()
-        .single
-        .id;
-    final secondSearch = citations
-        .accept(
-          _event(<String, dynamic>{
-            'citations': <String>['https://b.example'],
-          }),
-        )
-        .chunks
-        .whereType<ServerToolStart>()
-        .single
-        .id;
-    expect(firstSearch, isNot(secondSearch));
+  test('keeps cumulative citations on one sticky search card', () {
+    final decoder = ChatCompletionsStreamDecoder(sourceId: 'round-0');
+    final handler = StreamChunkHandler();
+
+    final first = decoder.accept(
+      _event(<String, dynamic>{
+        ..._choice(delta: <String, dynamic>{'content': 'see'}),
+        'citations': <String>['https://a.example'],
+      }),
+    );
+    for (final chunk in first.chunks) {
+      handler.handle(chunk);
+    }
+    final firstSearch = first.chunks.whereType<ServerToolStart>().single.id;
+
+    final second = decoder.accept(
+      _event(<String, dynamic>{
+        'citations': <String>['https://a.example', 'https://b.example'],
+      }),
+    );
+    for (final chunk in second.chunks) {
+      handler.handle(chunk);
+    }
+    final secondSearch = second.chunks.whereType<ServerToolStart>().single.id;
+
+    expect(firstSearch, secondSearch);
     expect(firstSearch, startsWith('round-0:search-'));
+    expect(handler.parts.whereType<ToolCallPart>(), hasLength(1));
+    final payload = jsonDecode(
+      handler.parts.whereType<ToolCallPart>().single.payloadJson,
+    );
+    expect(payload['name'], 'search_web');
+    expect((payload['content'] as Map)['items'], hasLength(2));
   });
 
   test('skips malformed JSON and does not complete on onClosed', () {

--- a/test/core/services/api/stream/sse_decode_loop_test.dart
+++ b/test/core/services/api/stream/sse_decode_loop_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:Kelivo/core/services/api/providers/openai/chat_completions_decoder.dart';
+import 'package:Kelivo/core/services/api/providers/openai/responses_decoder.dart';
+import 'package:Kelivo/core/services/api/stream/sse_decode_loop.dart';
+import 'package:Kelivo/core/services/api/stream/sse_event.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+SseEvent _json(Map<String, dynamic> data) => SseEvent(data: jsonEncode(data));
+
+SseEvent _chatChoice({Map<String, dynamic>? delta, String? finishReason}) {
+  return _json(<String, dynamic>{
+    'choices': [
+      <String, dynamic>{
+        if (delta != null) 'delta': delta,
+        'finish_reason': finishReason,
+      },
+    ],
+  });
+}
+
+void main() {
+  test(
+    'Responses [DONE] yields ServerToolEnd for an in-progress search',
+    () async {
+      final decoder = ResponsesStreamDecoder();
+      final chunks = await decodeSseEvents(
+        Stream<SseEvent>.fromIterable([
+          _json({
+            'type': 'response.output_item.added',
+            'item': {
+              'id': 'st_1',
+              'type': 'web_search_call',
+              'status': 'in_progress',
+            },
+          }),
+          const SseEvent(data: '[DONE]'),
+        ]),
+        decoder,
+      ).toList();
+
+      expect(chunks.whereType<ServerToolStart>().single.id, 'st_1');
+      expect(chunks.whereType<ServerToolEnd>().single.id, 'st_1');
+      expect(decoder.onClosed(), isEmpty);
+    },
+  );
+
+  test(
+    'Chat Completions [DONE] ends tools when finish_reason is stop',
+    () async {
+      final decoder = ChatCompletionsStreamDecoder();
+      final chunks = await decodeSseEvents(
+        Stream<SseEvent>.fromIterable([
+          _chatChoice(
+            delta: <String, dynamic>{
+              'tool_calls': [
+                <String, dynamic>{
+                  'index': 0,
+                  'id': 'call_1',
+                  'function': <String, dynamic>{
+                    'name': 'lookup',
+                    'arguments': '{}',
+                  },
+                },
+              ],
+            },
+          ),
+          _chatChoice(finishReason: 'stop'),
+          const SseEvent(data: '[DONE]'),
+        ]),
+        decoder,
+      ).toList();
+
+      expect(chunks.whereType<ToolCallStart>().single.id, 'call_1');
+      expect(chunks.whereType<ToolCallEnd>().single.id, 'call_1');
+    },
+  );
+
+  test('onClosed ends open tools when the SSE stream omits [DONE]', () async {
+    final decoder = ChatCompletionsStreamDecoder();
+    final chunks = await decodeSseEvents(
+      Stream<SseEvent>.fromIterable([
+        _chatChoice(
+          delta: <String, dynamic>{
+            'tool_calls': [
+              <String, dynamic>{
+                'index': 0,
+                'id': 'call_1',
+                'function': <String, dynamic>{
+                  'name': 'lookup',
+                  'arguments': '{}',
+                },
+              },
+            ],
+          },
+        ),
+        _chatChoice(finishReason: 'stop'),
+      ]),
+      decoder,
+    ).toList();
+
+    expect(chunks.whereType<ToolCallEnd>().single.id, 'call_1');
+  });
+}

--- a/test/core/services/api/stream/stream_chunk_handler_test.dart
+++ b/test/core/services/api/stream/stream_chunk_handler_test.dart
@@ -355,6 +355,59 @@ void main() {
     expect(result.parts, hasLength(1));
   });
 
+  test('seed keeps prior parts and later ToolCallResult updates that card', () {
+    final seed = <MessagePart>[
+      const TextPart('before'),
+      const ReasoningPart('plan'),
+      ToolCallPart(
+        jsonEncode(<String, dynamic>{
+          'id': 'call_1',
+          'name': 'lookup',
+          'arguments': <String, dynamic>{'q': 'kelivo'},
+          'server': false,
+        }),
+      ),
+    ];
+    final handler = StreamChunkHandler(seed: seed);
+    handler.handle(const ToolCallResult(id: 'call_1', output: '{"ok":true}'));
+    handler.handle(const TextDelta(id: 'round-1:text-1', text: 'after'));
+
+    expect(handler.parts.map((part) => part.kind).toList(), [
+      'text',
+      'reasoning',
+      'tool_call',
+      'text',
+    ]);
+    expect((handler.parts[0] as TextPart).text, 'before');
+    expect((handler.parts[1] as ReasoningPart).text, 'plan');
+    final tool = jsonDecode((handler.parts[2] as ToolCallPart).payloadJson);
+    expect(tool['name'], 'lookup');
+    expect(tool['arguments'], <String, dynamic>{'q': 'kelivo'});
+    expect(tool['content'], '{"ok":true}');
+    expect((handler.parts[3] as TextPart).text, 'after');
+  });
+
+  test(
+    'handleResult after seed appends the new round instead of replacing',
+    () {
+      final handler = StreamChunkHandler(
+        seed: const [TextPart('before'), ReasoningPart('plan')],
+      );
+      handler.handleResult(
+        const TextGenerationResult(
+          parts: [TextPart('after')],
+          finishReason: 'stop',
+        ),
+      );
+
+      expect(handler.parts.whereType<TextPart>().map((part) => part.text), [
+        'before',
+        'after',
+      ]);
+      expect(handler.parts.whereType<ReasoningPart>().single.text, 'plan');
+    },
+  );
+
   test('handleResult keeps image URIs as-is and does not add data:', () {
     final handler = StreamChunkHandler();
     handler.handleResult(

--- a/test/features/home/controllers/chat_actions_stream_error_parts_test.dart
+++ b/test/features/home/controllers/chat_actions_stream_error_parts_test.dart
@@ -39,4 +39,39 @@ void main() {
       'https://example.com/gen.png',
     ]);
   });
+
+  test(
+    'visible-text parts keep prior cards and truncate the last TextPart',
+    () {
+      final parts = ChatActions.assistantPartsForVisibleText(
+        parts: const [
+          TextPart('Hello world'),
+          ReasoningPart('plan'),
+          ToolCallPart('{"id":"call_1","name":"lookup"}'),
+          TextPart(' and more'),
+        ],
+        visibleText: 'Hello wo',
+      );
+
+      expect(parts.map((part) => part.kind).toList(), [
+        'text',
+        'reasoning',
+        'tool_call',
+      ]);
+      expect((parts.first as TextPart).text, 'Hello wo');
+      expect((parts[1] as ReasoningPart).text, 'plan');
+    },
+  );
+
+  test('visible-text parts reveal the last TextPart as the slice grows', () {
+    final parts = ChatActions.assistantPartsForVisibleText(
+      parts: const [TextPart('Hello '), TextPart('world')],
+      visibleText: 'Hello wo',
+    );
+
+    expect(parts.whereType<TextPart>().map((part) => part.text), [
+      'Hello ',
+      'wo',
+    ]);
+  });
 }

--- a/test/features/home/controllers/stream_controller_typewriter_parts_test.dart
+++ b/test/features/home/controllers/stream_controller_typewriter_parts_test.dart
@@ -1,0 +1,68 @@
+import "../../../support/business_test_harness.dart";
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/chat/chat_service.dart';
+import 'package:Kelivo/features/home/controllers/chat_actions.dart';
+import 'package:Kelivo/features/home/controllers/stream_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues(const {});
+
+  const messageId = 'assistant-message';
+  const fullText = 'Hello world, this is a long enough burst for smoothing.';
+
+  StreamController buildController(SettingsProvider settings) {
+    return StreamController(
+      chatService: ChatService(),
+      onStateChanged: () {},
+      getSettingsProvider: () => settings,
+      getCurrentConversationId: () => 'conversation-1',
+    );
+  }
+
+  testWidgets('throttled parts follow the visible slice, then flush complete', (
+    tester,
+  ) async {
+    final settings = SettingsProvider(createBusinessTestPreferences());
+    final controller = buildController(settings);
+    final notifier = controller.streamingContentNotifier.getNotifier(messageId);
+    final fullParts = <MessagePart>[
+      const TextPart(fullText),
+      const ReasoningPart('plan'),
+    ];
+
+    controller.scheduleThrottledUpdate(
+      messageId,
+      'conversation-1',
+      () => fullText,
+      partsBuilder: (visibleText) => ChatActions.assistantPartsForVisibleText(
+        parts: fullParts,
+        visibleText: visibleText,
+      ),
+      updateMessageInList: (_, _, _) {},
+      totalTokens: 10,
+    );
+
+    await tester.pump(const Duration(milliseconds: 50));
+    final mid = notifier.value;
+    expect(mid.content.length, lessThan(fullText.length));
+    expect(mid.parts, isNotNull);
+    expect((mid.parts!.first as TextPart).text, mid.content);
+    expect(mid.parts!.whereType<ReasoningPart>().single.text, 'plan');
+
+    final drain = controller.drainSmoothStream(messageId);
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await drain;
+    controller.cleanupTimers(messageId);
+    final end = notifier.value;
+    expect(end.content, fullText);
+    expect((end.parts!.first as TextPart).text, fullText);
+    expect(end.parts!.whereType<ReasoningPart>().single.text, 'plan');
+    controller.dispose();
+  });
+}

--- a/test/features/home/controllers/streaming_state_seed_test.dart
+++ b/test/features/home/controllers/streaming_state_seed_test.dart
@@ -1,0 +1,110 @@
+import "../../../support/business_test_harness.dart";
+import 'dart:convert';
+
+import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/generation/text_generation_result.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:Kelivo/features/home/controllers/stream_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues(const {});
+
+  StreamingState buildState(List<MessagePart> parts) {
+    final settings = SettingsProvider(createBusinessTestPreferences());
+    return StreamingState(
+      GenerationContext(
+        assistantMessage: ChatMessage(
+          id: 'assistant-message',
+          role: 'assistant',
+          parts: parts,
+          conversationId: 'conversation-1',
+          isStreaming: true,
+        ),
+        apiMessages: const [],
+        userImagePaths: const [],
+        allowImagesApiRouting: false,
+        providerKey: 'test',
+        modelId: 'test-model',
+        assistant: null,
+        settings: settings,
+        config: ProviderConfig(
+          id: 'test',
+          enabled: true,
+          name: 'Test',
+          apiKey: '',
+          baseUrl: '',
+        ),
+        toolDefs: const [],
+        supportsReasoning: true,
+        enableReasoning: true,
+        streamOutput: true,
+      ),
+    );
+  }
+
+  test('StreamingState seeds partsHandler from the assistant message', () {
+    final state = buildState(const [
+      TextPart('before'),
+      ReasoningPart('plan'),
+      ToolCallPart('{"id":"call_1","name":"lookup"}'),
+    ]);
+
+    expect(state.fullContentRaw, 'before');
+    expect(state.partsHandler.parts.map((part) => part.kind).toList(), [
+      'text',
+      'reasoning',
+      'tool_call',
+    ]);
+    expect((state.partsHandler.parts[0] as TextPart).text, 'before');
+  });
+
+  test('non-stream handleResult keeps seeded parts and joins all text', () {
+    final state = buildState(const [TextPart('before'), ReasoningPart('plan')]);
+    state.partsHandler.handleResult(
+      const TextGenerationResult(parts: [TextPart('after')]),
+    );
+    state.fullContentRaw = [
+      for (final part in state.partsHandler.parts)
+        if (part is TextPart) part.text,
+    ].join();
+
+    expect(state.fullContentRaw, 'beforeafter');
+    expect(
+      state.partsHandler.parts.whereType<TextPart>().map((part) => part.text),
+      ['before', 'after'],
+    );
+    expect(
+      state.partsHandler.parts.whereType<ReasoningPart>().single.text,
+      'plan',
+    );
+  });
+
+  test('continuation text after a tool answer does not drop prior cards', () {
+    final state = buildState([
+      const TextPart('before'),
+      ToolCallPart(
+        jsonEncode(<String, dynamic>{
+          'id': 'call_1',
+          'name': 'lookup',
+          'arguments': <String, dynamic>{'q': 'kelivo'},
+        }),
+      ),
+    ]);
+    state.partsHandler.handle(
+      const TextDelta(id: 'round-1:text-1', text: 'after'),
+    );
+
+    expect(state.partsHandler.parts.map((part) => part.kind).toList(), [
+      'text',
+      'tool_call',
+      'text',
+    ]);
+    expect((state.partsHandler.parts.first as TextPart).text, 'before');
+    expect((state.partsHandler.parts.last as TextPart).text, 'after');
+  });
+}


### PR DESCRIPTION
## Summary
- Sticky Chat Completions search cards (`searchSticky`) so Grok/OpenRouter/Perplexity cumulative citations no longer spawn one card per frame.
- OpenAI `[DONE]` now goes through the decoder; follow-up loops yield those close chunks and all three transport paths call `onClosed()`, so XinLiu `finish_reason: stop` + open tools emit `ToolCallEnd`.
- Tool-answer continuations seed `StreamChunkHandler` from existing parts (stream + non-stream), and later non-stream tool rounds keep emitting `ToolCall*` names/args.
- Typewriter `partsBuilder` now receives the visible slice and truncates text parts to match; drain/flush still publishes complete parts.

## Test plan
- [x] `dart analyze --fatal-infos` on touched files
- [x] `flutter test` (2533 passed)
- [ ] Chat Completions + Grok/OpenRouter/Perplexity search: one card that updates, not N cards
- [ ] Responses follow-up with hosted search: card leaves `in_progress` after `[DONE]`
- [ ] Ask-user / tool approval continue: prior text, reasoning, and tool cards stay
- [ ] OpenAI non-stream multi-round tools: second-round cards have name + args
- [ ] Long stream (~300+ chars): typewriter still slices instead of jumping whole paragraphs