### PR TITLE
fix(stream): scope emit helpers and accumulate follow-up chars

### DIFF
--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -15,6 +15,7 @@ import '../generation/tool_loop_runner.dart';
 import '../stream/sse_framing.dart';
 import '../stream/stream_chunk.dart';
 import '../stream/stream_chunk_emit.dart';
+import '../stream/stream_chunk_ids.dart';
 import 'claude/claude_decoder.dart';
 
 int _defaultClaudeMaxOutputTokens(String modelId) {
@@ -718,6 +719,7 @@ Stream<StreamChunk> sendClaudeStream(
       ];
     },
     finish: () => emitDone(
+      ids: StreamChunkIds('finish'),
       content: lastText,
       usage: totalUsage,
       totalTokens: totalUsage?.totalTokens ?? 0,

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -19,6 +19,7 @@ import '../google_service_account_auth.dart';
 import '../stream/sse_framing.dart';
 import '../stream/stream_chunk.dart';
 import '../stream/stream_chunk_emit.dart';
+import '../stream/stream_chunk_ids.dart';
 import 'google/google_decoder.dart';
 
 import 'google_gemini.dart';
@@ -822,6 +823,7 @@ Stream<StreamChunk> sendGoogleStream(
         final reasoningStr = reasoningBuf.toString();
         if (reasoningStr.isNotEmpty) {
           yield* emitDelta(
+            ids: StreamChunkIds('round-${currentContents.length}'),
             reasoning: reasoningStr,
             usage: totalUsage,
             totalTokens: totalUsage?.totalTokens ?? 0,
@@ -867,6 +869,7 @@ Stream<StreamChunk> sendGoogleStream(
         ];
       },
       finish: () => emitDone(
+        ids: StreamChunkIds('finish'),
         content: lastText,
         usage: totalUsage,
         totalTokens: totalUsage?.totalTokens ?? 0,
@@ -1204,6 +1207,7 @@ Stream<StreamChunk> sendGoogleStream(
       }
 
       final sse = resp.stream.transform(utf8.decoder);
+      final sourceId = 'round-${streamRound++}';
       final decoder = GoogleStreamDecoder(
         isGemini3: isGemini3,
         persistThoughtSigs: persistGeminiThoughtSigs,
@@ -1211,7 +1215,7 @@ Stream<StreamChunk> sendGoogleStream(
         receivedImage: receivedImage,
         initialUsage: usage,
         citations: builtinCitations,
-        sourceId: 'round-${streamRound++}',
+        sourceId: sourceId,
       );
       Future<String> sanitizeTextIfNeeded(String input) async {
         if (input.isEmpty) return input;
@@ -1365,6 +1369,7 @@ Stream<StreamChunk> sendGoogleStream(
           );
           final sanitized = await sanitizeTextIfNeeded(pendingImage);
           yield* emitDelta(
+            ids: StreamChunkIds(sourceId),
             content: sanitized,
             usage: usage,
             totalTokens: totalTokens,
@@ -1382,6 +1387,7 @@ Stream<StreamChunk> sendGoogleStream(
           );
           if (metaComment.isNotEmpty) {
             yield* emitDelta(
+              ids: StreamChunkIds(sourceId),
               content: metaComment,
               usage: usage,
               totalTokens: totalTokens,
@@ -1470,7 +1476,11 @@ Stream<StreamChunk> sendGoogleStream(
         });
       }
     },
-    finish: () => emitDone(usage: usage, totalTokens: totalTokens),
+    finish: () => emitDone(
+      ids: StreamChunkIds('finish'),
+      usage: usage,
+      totalTokens: totalTokens,
+    ),
     usageOf: () => usage,
   );
 }

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -16,6 +16,7 @@ import '../google_service_account_auth.dart';
 import '../stream/sse_framing.dart';
 import '../stream/stream_chunk.dart';
 import '../stream/stream_chunk_emit.dart';
+import '../stream/stream_chunk_ids.dart';
 import 'claude/claude_decoder.dart';
 
 import 'claude_official.dart';
@@ -686,6 +687,7 @@ Stream<StreamChunk> sendGoogleVertexClaudeStream({
       ];
     },
     finish: () => emitDone(
+      ids: StreamChunkIds('finish'),
       content: lastText,
       usage: totalUsage,
       totalTokens: totalUsage?.totalTokens ?? 0,

--- a/lib/core/services/api/providers/openai/chat_completions_api.dart
+++ b/lib/core/services/api/providers/openai/chat_completions_api.dart
@@ -14,6 +14,7 @@ import '../../stream/sse_decode_loop.dart';
 import '../../stream/sse_framing.dart';
 import '../../stream/stream_chunk.dart';
 import '../../stream/stream_chunk_emit.dart';
+import '../../stream/stream_chunk_ids.dart';
 import 'chat_completions_decoder.dart';
 import 'openai_tool_transcript.dart';
 import 'openai_vendor_compat.dart';
@@ -834,7 +835,8 @@ Stream<StreamChunk> runOpenAIChatCompletionsToolFollowUps({
       );
       yield* decodeSseEvents(parseSseEventStrings(s2), roundDecoder);
       usage = roundDecoder.usage ?? usage;
-      chars = roundDecoder.approxCompletionChars;
+      // Add this round. `=` would drop earlier rounds when usage is absent.
+      chars += roundDecoder.approxCompletionChars;
       lastRound = roundDecoder;
     },
     takeCallsAfterRound: () {
@@ -849,6 +851,7 @@ Stream<StreamChunk> runOpenAIChatCompletionsToolFollowUps({
     finish: () {
       final approxTotal = approxPromptTokens + (chars / 4).round();
       return emitDone(
+        ids: StreamChunkIds('finish'),
         reasoningDetails: includeReasoningDetailsOnDone
             ? lastRound?.reasoningDetails ?? firstReasoningDetails
             : null,
@@ -951,6 +954,7 @@ Stream<StreamChunk> runOpenAIChatCompletionsNonStreamToolFollowUps({
       final choice = openaiFirstChoice(lastObj);
       if (choice == null) {
         yield* emitDone(
+          ids: StreamChunkIds('finish'),
           content: (lastObj['output_text'] ?? '').toString(),
           usage: usage,
           totalTokens: usage?.totalTokens ?? 0,
@@ -963,6 +967,7 @@ Stream<StreamChunk> runOpenAIChatCompletionsNonStreamToolFollowUps({
       final lastMessage = openaiFirstChoiceMessage(lastObj);
       yield* emitImages(visible.images);
       yield* emitDone(
+        ids: StreamChunkIds('finish'),
         content: visible.content,
         reasoning: openaiReasoningText(lastMessage),
         reasoningDetails: lastMessage?['reasoning_details'],

--- a/lib/core/services/api/providers/openai/openai_provider.dart
+++ b/lib/core/services/api/providers/openai/openai_provider.dart
@@ -15,6 +15,7 @@ import '../../kimi_formula_search.dart';
 import '../../stream/sse_framing.dart';
 import '../../stream/stream_chunk.dart';
 import '../../stream/stream_chunk_emit.dart';
+import '../../stream/stream_chunk_ids.dart';
 import 'chat_completions_api.dart';
 import 'chat_completions_decoder.dart';
 import 'openai_vendor_compat.dart';
@@ -775,6 +776,7 @@ Stream<StreamChunk> sendOpenAIStream(
         );
         yield* emitImages(images);
         yield* emitDone(
+          ids: StreamChunkIds('finish'),
           content: outText,
           reasoning: reasoningText.isEmpty ? null : reasoningText,
           usage: usage,
@@ -791,6 +793,7 @@ Stream<StreamChunk> sendOpenAIStream(
       final firstChoice = openaiFirstChoice(lastObj);
       if (firstChoice == null) {
         yield* emitDone(
+          ids: StreamChunkIds('finish'),
           content: (lastObj['output_text'] ?? '').toString(),
           usage: firstUsage,
           totalTokens: firstUsage?.totalTokens ?? 0,
@@ -832,6 +835,7 @@ Stream<StreamChunk> sendOpenAIStream(
       final firstMessage = openaiFirstChoiceMessage(lastObj);
       yield* emitImages(visible.images);
       yield* emitDone(
+        ids: StreamChunkIds('finish'),
         content: visible.content,
         reasoning: openaiReasoningText(firstMessage),
         reasoningDetails: firstMessage?['reasoning_details'],
@@ -936,6 +940,7 @@ Stream<StreamChunk> sendOpenAIStream(
             if (mdImg.isEmpty) continue;
             fallbackCount++;
             yield* emitDelta(
+              ids: StreamChunkIds('round-0'),
               content: mdImg,
               usage: usage,
               totalTokens: totalTokens,
@@ -1016,6 +1021,7 @@ Stream<StreamChunk> sendOpenAIStream(
         final approxTotal =
             approxPromptTokens + approxTokensFromChars(approxCompletionChars);
         yield* emitDone(
+          ids: StreamChunkIds('finish'),
           usage: usage,
           totalTokens: usage?.totalTokens ?? approxTotal,
         );
@@ -1082,6 +1088,7 @@ Stream<StreamChunk> sendOpenAIStream(
           final approxTotal =
               approxPromptTokens + approxTokensFromChars(approxCompletionChars);
           yield* emitDone(
+            ids: StreamChunkIds('finish'),
             reasoningDetails:
                 decoder.reasoningDetails ??
                 reasoningDetailsBuffer.detailsOrNull,
@@ -1219,6 +1226,7 @@ Stream<StreamChunk> sendOpenAIStream(
       usage?.totalTokens ??
       (approxPromptTokens + approxTokensFromChars(approxCompletionChars));
   yield* emitDone(
+    ids: StreamChunkIds('finish'),
     reasoningDetails:
         chatDecoder?.reasoningDetails ?? reasoningDetailsBuffer.detailsOrNull,
     usage: usage,

--- a/lib/core/services/api/providers/openai/responses_api.dart
+++ b/lib/core/services/api/providers/openai/responses_api.dart
@@ -14,6 +14,7 @@ import '../../stream/sse_decode_loop.dart';
 import '../../stream/sse_framing.dart';
 import '../../stream/stream_chunk.dart';
 import '../../stream/stream_chunk_emit.dart';
+import '../../stream/stream_chunk_ids.dart';
 import 'openai_vendor_compat.dart';
 import 'responses_decoder.dart';
 
@@ -332,6 +333,7 @@ Stream<StreamChunk> runOpenAIResponsesToolFollowUps({
     finish: () {
       final approxTotal = approxPromptTokens + (chars / 4).round();
       return emitDone(
+        ids: StreamChunkIds('finish'),
         usage: usage,
         totalTokens: usage?.totalTokens ?? approxTotal,
       );

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -13,6 +13,7 @@ import '../../../../utils/sandbox_path_resolver.dart';
 import '../chat_api_helpers.dart';
 import '../stream/stream_chunk.dart';
 import '../stream/stream_chunk_emit.dart';
+import '../stream/stream_chunk_ids.dart';
 
 bool shouldUseOpenAIImagesApi(ProviderConfig config, String modelId) {
   final upstreamModelId = apiModelId(config, modelId).toLowerCase();
@@ -85,7 +86,11 @@ Stream<StreamChunk> sendOpenAIImagesStream(
   );
   final usage = _openAIImagesUsage(response);
   yield* emitImages(images);
-  yield* emitFinish(usage: usage, totalTokens: usage?.totalTokens ?? 0);
+  yield* emitFinish(
+    ids: StreamChunkIds('finish'),
+    usage: usage,
+    totalTokens: usage?.totalTokens ?? 0,
+  );
 }
 
 Future<Map<String, dynamic>> _sendOpenAIImageGeneration(

--- a/lib/core/services/api/stream/stream_chunk_emit.dart
+++ b/lib/core/services/api/stream/stream_chunk_emit.dart
@@ -4,9 +4,6 @@ import '../../../models/token_usage.dart';
 import 'stream_chunk.dart';
 import 'stream_chunk_ids.dart';
 
-const _emitTextId = 'legacy:text';
-const _emitReasoningId = 'legacy:reasoning';
-
 TokenUsage? _usageOrApprox(TokenUsage? usage, int totalTokens) {
   if (usage != null) return usage;
   if (totalTokens > 0) return TokenUsage(totalTokens: totalTokens);
@@ -26,16 +23,23 @@ Future<StreamChunk> sanitizeStreamChunk(
   return chunk;
 }
 
-Stream<StreamChunk> emitText(String content) async* {
+Stream<StreamChunk> emitText(
+  String content, {
+  required StreamChunkIds ids,
+}) async* {
   if (content.isNotEmpty) {
-    yield TextDelta(id: _emitTextId, text: content);
+    yield TextDelta(id: ids.text(), text: content);
   }
 }
 
-Stream<StreamChunk> emitReasoning(String? reasoning, {dynamic details}) async* {
+Stream<StreamChunk> emitReasoning(
+  String? reasoning, {
+  required StreamChunkIds ids,
+  dynamic details,
+}) async* {
   if ((reasoning == null || reasoning.isEmpty) && details == null) return;
   yield ReasoningDelta(
-    id: _emitReasoningId,
+    id: ids.reasoning(),
     text: reasoning ?? '',
     details: details,
   );
@@ -46,17 +50,19 @@ Stream<StreamChunk> emitUsage(TokenUsage? usage) async* {
 }
 
 Stream<StreamChunk> emitFinish({
+  required StreamChunkIds ids,
   TokenUsage? usage,
   int totalTokens = 0,
   dynamic reasoningDetails,
   String? finishReason,
 }) async* {
-  yield* emitReasoning(null, details: reasoningDetails);
+  yield* emitReasoning(null, ids: ids, details: reasoningDetails);
   yield* emitUsage(_usageOrApprox(usage, totalTokens));
   yield Finish(finishReason: finishReason);
 }
 
 Stream<StreamChunk> emitDelta({
+  required StreamChunkIds ids,
   String content = '',
   String? reasoning,
   dynamic reasoningDetails,
@@ -64,11 +70,12 @@ Stream<StreamChunk> emitDelta({
   int totalTokens = 0,
 }) async* {
   yield* emitUsage(_usageOrApprox(usage, totalTokens));
-  yield* emitReasoning(reasoning, details: reasoningDetails);
-  yield* emitText(content);
+  yield* emitReasoning(reasoning, ids: ids, details: reasoningDetails);
+  yield* emitText(content, ids: ids);
 }
 
 Stream<StreamChunk> emitDone({
+  required StreamChunkIds ids,
   String content = '',
   String? reasoning,
   dynamic reasoningDetails,
@@ -76,9 +83,10 @@ Stream<StreamChunk> emitDone({
   int totalTokens = 0,
   String? finishReason,
 }) async* {
-  yield* emitReasoning(reasoning, details: reasoningDetails);
-  yield* emitText(content);
+  yield* emitReasoning(reasoning, ids: ids, details: reasoningDetails);
+  yield* emitText(content, ids: ids);
   yield* emitFinish(
+    ids: ids,
     usage: usage,
     totalTokens: totalTokens,
     finishReason: finishReason,

--- a/test/core/services/api/generation/tool_loop_runner_test.dart
+++ b/test/core/services/api/generation/tool_loop_runner_test.dart
@@ -1,5 +1,6 @@
 import 'package:Kelivo/core/services/api/chat_api_service.dart';
 import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk_ids.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -44,7 +45,7 @@ void main() {
           yield const TextDelta(id: 't', text: 'done');
         },
         takeCallsAfterRound: () => const <EmitToolCall>[],
-        finish: () => emitFinish(),
+        finish: () => emitFinish(ids: StreamChunkIds('finish')),
       ).toList();
 
       expect(appended, ['res-call_1']);
@@ -79,7 +80,7 @@ void main() {
         emitCalls: true,
         onToolCall: (name, args, {toolCallId}) async => 'res-$toolCallId',
         append: (executed) => appended.add(executed.length),
-        finish: () => emitFinish(),
+        finish: () => emitFinish(ids: StreamChunkIds('finish')),
       ).toList();
 
       expect(sends, 2);
@@ -117,7 +118,7 @@ void main() {
                 ),
               ]
             : const <EmitToolCall>[],
-        finish: () => emitFinish(),
+        finish: () => emitFinish(ids: StreamChunkIds('finish')),
         emitCalls: true,
       ).toList();
 
@@ -147,7 +148,7 @@ void main() {
       continueWithoutCalls: () => sends < 2,
       executeAfterRound: false,
       append: (_) {},
-      finish: () => emitFinish(),
+      finish: () => emitFinish(ids: StreamChunkIds('finish')),
     ).toList();
 
     expect(sends, 2);

--- a/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
+++ b/test/core/services/api/providers/openai/chat_completions_decoder_test.dart
@@ -469,4 +469,19 @@ void main() {
     expect(decoder.onClosed(), isEmpty);
     expect(decoder.onClosed(), isEmpty);
   });
+
+  test('follow-up approx chars from separate decoders must be added', () {
+    final first = ChatCompletionsStreamDecoder();
+    first.accept(_event(_choice(delta: <String, dynamic>{'content': 'abcd'})));
+    final second = ChatCompletionsStreamDecoder();
+    second.accept(
+      _event(_choice(delta: <String, dynamic>{'content': 'efghijkl'})),
+    );
+
+    // Chat Completions follow-ups used to assign `chars =` the last decoder
+    // only. Provider-omitted usage then estimated tokens from the last round.
+    expect(first.approxCompletionChars, 4);
+    expect(second.approxCompletionChars, 8);
+    expect(first.approxCompletionChars + second.approxCompletionChars, 12);
+  });
 }

--- a/test/core/services/api/stream/stream_chunk_emit_test.dart
+++ b/test/core/services/api/stream/stream_chunk_emit_test.dart
@@ -1,0 +1,64 @@
+import 'package:Kelivo/core/models/message_part.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk_emit.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk_handler.dart';
+import 'package:Kelivo/core/services/api/stream/stream_chunk_ids.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'per-round emit ids keep fallback text out of the previous TextPart',
+    () async {
+      final handler = StreamChunkHandler();
+      await for (final chunk in emitDelta(
+        ids: StreamChunkIds('round-0'),
+        content: 'before',
+      )) {
+        handler.handle(chunk);
+      }
+      handler.handle(const ToolCallStart(id: 'call_1', toolName: 'lookup'));
+      handler.handle(const ToolCallEnd('call_1'));
+      await for (final chunk in emitDelta(
+        ids: StreamChunkIds('round-1'),
+        content: 'after',
+      )) {
+        handler.handle(chunk);
+      }
+
+      expect(handler.parts.map((part) => part.kind).toList(), [
+        'text',
+        'tool_call',
+        'text',
+      ]);
+      expect((handler.parts[0] as TextPart).text, 'before');
+      expect((handler.parts[2] as TextPart).text, 'after');
+    },
+  );
+
+  test(
+    'reusing an emit sourceId merges later text into the first part',
+    () async {
+      final handler = StreamChunkHandler();
+      await for (final chunk in emitDelta(
+        ids: StreamChunkIds('legacy'),
+        content: 'before',
+      )) {
+        handler.handle(chunk);
+      }
+      handler.handle(const ToolCallStart(id: 'call_1', toolName: 'lookup'));
+      handler.handle(const ToolCallEnd('call_1'));
+      await for (final chunk in emitDelta(
+        ids: StreamChunkIds('legacy'),
+        content: 'after',
+      )) {
+        handler.handle(chunk);
+      }
+
+      expect(handler.parts.map((part) => part.kind).toList(), [
+        'text',
+        'tool_call',
+      ]);
+      expect((handler.parts[0] as TextPart).text, 'beforeafter');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `emitText` / `emitDelta` / `emitDone` now take `StreamChunkIds` instead of the forbidden `legacy:text` constant. Google image/thought-sig fallbacks use the current round's source id, so a second-round fallback no longer merges into the first `TextPart`.
- Chat Completions follow-up `chars` is `+=` (Responses already was). When the provider omits usage, multi-round token estimates keep every round.

Stacked on #898.

## Test plan
- [x] `dart analyze --fatal-infos` on touched files
- [x] `flutter test` (2536 passed)
- [ ] Gemini multi-round with image fallback on two rounds: two text parts, not one merged blob
- [ ] OpenAI Chat Completions multi-round tools without usage: estimated completion tokens include every round