### PR TITLE
fix(gemini): route every 3.x model through thinkingLevel

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -73,12 +73,21 @@ bool _isGemma4Model(String modelId) {
   ).hasMatch(modelId);
 }
 
-// Non-text Gemini variants: they take a raw budget, not a thinking level, so
-// they fall through to the Gemini 2.x branch. Holding them out here also stops
-// the `-` terminator in the family patterns below from swallowing the suffix and
-// reading `gemini-3.1-flash-image` as plain `gemini-3.1-flash`.
+// Non-text Gemini variants: they do not share the text families' thinking
+// contract, so they never reach the pro/flash branches. Holding them out here
+// also stops the `-` terminator in the family patterns below from swallowing
+// the suffix and reading `gemini-3.1-flash-image` as plain `gemini-3.1-flash`.
 final _gemini3NonTextSuffix = RegExp(
   r'(^|[-_/])(image|tts|live)([-._:@/]|$)',
+  caseSensitive: false,
+);
+
+// Gemini 3.x Flash Image and Flash-Lite Image do take a thinking level, but
+// only 'minimal' (the default) and 'high'. Every other image id -- the legacy
+// gemini-3-pro-image included -- stays on the raw-budget branch.
+// https://ai.google.dev/gemini-api/docs/generate-content/image-generation#controlling-thinking-levels
+final _gemini3FlashImageId = RegExp(
+  r'gemini-3(?:\.\d+)?-flash(-lite)?-image([._:@/-]|$)',
   caseSensitive: false,
 );
 
@@ -88,6 +97,11 @@ const _gemini3ProMediumMinor = 1; // pro gained 'medium' in 3.1
 const _gemini3FlashModernMinor =
     5; // flash defaults to 'medium' and 64K from 3.5
 const _gemini3FlashNoMinimalMinor = 7; // flash dropped 'minimal' in 3.7
+
+// Budget presets the sheet offers: 1024 (light), 16000 (medium), 32000 (heavy).
+// These split them into the named thinking levels.
+const _gemini3LowBudgetCeiling = 8000;
+const _gemini3MediumBudgetCeiling = 24000;
 
 final _gemini3FlashId = RegExp(
   r'gemini-3(?:\.(?<minor>\d+))?-flash([._:@/-]|$)',
@@ -140,6 +154,16 @@ Map<String, dynamic> _googleThinkingConfig(
     };
   }
 
+  if (_gemini3FlashImageId.hasMatch(upstreamModelId)) {
+    // Only 'minimal' and 'high' exist here, so the light preset shares the
+    // 'minimal' floor with "off"; minimal still thinks, so "off" only hides
+    // the thoughts.
+    final level = !off && budget != null && budget >= _gemini3LowBudgetCeiling
+        ? 'high'
+        : 'minimal';
+    return {'includeThoughts': !off, 'thinkingLevel': level};
+  }
+
   final proMinor = _gemini3ProMinor(upstreamModelId);
   if (proMinor != null) {
     // gemini-3-pro has only 'low' and 'high'; 3.1 added 'medium'.
@@ -148,9 +172,9 @@ Map<String, dynamic> _googleThinkingConfig(
     if (off) {
       level = 'low';
     } else if (budget != null && budget > 0) {
-      if (budget < 8000) {
+      if (budget < _gemini3LowBudgetCeiling) {
         level = 'low';
-      } else if (budget < 24000 && hasMedium) {
+      } else if (budget < _gemini3MediumBudgetCeiling && hasMedium) {
         level = 'medium';
       }
     }
@@ -171,9 +195,9 @@ Map<String, dynamic> _googleThinkingConfig(
       level = lowest;
     } else if (budget != null && budget > 0) {
       // Light (1024) -> low, Medium (16000) -> medium, Heavy (32000) -> high
-      if (budget < 8000) {
+      if (budget < _gemini3LowBudgetCeiling) {
         level = 'low';
-      } else if (budget < 24000) {
+      } else if (budget < _gemini3MediumBudgetCeiling) {
         level = 'medium';
       } else {
         level = 'high';

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -73,23 +73,49 @@ bool _isGemma4Model(String modelId) {
   ).hasMatch(modelId);
 }
 
-bool _isGemini35FlashModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.5-flash([._:@/-]|$)', caseSensitive: false),
-  );
+// Non-text Gemini variants: they take a raw budget, not a thinking level, so
+// they fall through to the Gemini 2.x branch. Holding them out here also stops
+// the `-` terminator in the family patterns below from swallowing the suffix and
+// reading `gemini-3.1-flash-image` as plain `gemini-3.1-flash`.
+final _gemini3NonTextSuffix = RegExp(
+  r'(^|[-_/])(image|tts|live)([-._:@/]|$)',
+  caseSensitive: false,
+);
+
+// Thresholds where a Gemini 3 family changed its thinking contract. Naming them
+// keeps the next release a one-line edit instead of a hunt for bare numbers.
+const _gemini3ProMediumMinor = 1; // pro gained 'medium' in 3.1
+const _gemini3FlashModernMinor =
+    5; // flash defaults to 'medium' and 64K from 3.5
+const _gemini3FlashNoMinimalMinor = 7; // flash dropped 'minimal' in 3.7
+
+final _gemini3FlashId = RegExp(
+  r'gemini-3(?:\.(?<minor>\d+))?-flash([._:@/-]|$)',
+  caseSensitive: false,
+);
+final _gemini3ProId = RegExp(
+  r'gemini-3(?:\.(?<minor>\d+))?-pro(-preview)?([._:@/-]|$)',
+  caseSensitive: false,
+);
+final _gemini3FlashLiteId = RegExp(
+  r'gemini-3(?:\.\d+)?-flash-lite([._:@/-]|$)',
+  caseSensitive: false,
+);
+
+// Minor version behind a Gemini 3 id (0 for plain `gemini-3-`), or null when the
+// id is not that family. Matching by version keeps unreleased 3.x models on the
+// Gemini 3 branches instead of the Gemini 2.x fallback.
+int? _gemini3Minor(String modelId, RegExp family) {
+  if (_gemini3NonTextSuffix.hasMatch(modelId)) return null;
+  final match = family.firstMatch(modelId);
+  if (match == null) return null;
+  return int.tryParse(match.namedGroup('minor') ?? '0') ?? 0;
 }
 
-bool _isGemini35FlashLiteModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.5-flash-lite([._:@/-]|$)', caseSensitive: false),
-  );
-}
+int? _gemini3FlashMinor(String modelId) =>
+    _gemini3Minor(modelId, _gemini3FlashId);
 
-bool _isGemini36FlashModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.6-flash([._:@/-]|$)', caseSensitive: false),
-  );
-}
+int? _gemini3ProMinor(String modelId) => _gemini3Minor(modelId, _gemini3ProId);
 
 bool _isGemini3TextModel(String modelId) {
   return modelId.contains(
@@ -114,59 +140,35 @@ Map<String, dynamic> _googleThinkingConfig(
     };
   }
 
-  // Match gemini-3-pro or gemini-3-pro-preview (and similar variants)
-  final isGemini3ProImage = upstreamModelId.contains(
-    RegExp(r'gemini-3-pro-image(-preview)?', caseSensitive: false),
-  );
-  final isGemini31Pro = upstreamModelId.contains(
-    RegExp(r'gemini-3\.1-pro(-preview)?', caseSensitive: false),
-  );
-  final isGemini3Pro = upstreamModelId.contains(
-    RegExp(r'gemini-3-pro(-preview)?', caseSensitive: false),
-  );
-  final isGemini3Flash = upstreamModelId.contains(
-    RegExp(r'gemini-3-flash(-preview)?', caseSensitive: false),
-  );
-  final isGemini35Flash = _isGemini35FlashModel(upstreamModelId);
-  final isGemini35FlashLite = _isGemini35FlashLiteModel(upstreamModelId);
-  final isGemini36Flash = _isGemini36FlashModel(upstreamModelId);
-  if (isGemini3ProImage) {
-    return {
-      'includeThoughts': true,
-      if (budget != null && budget >= 0) 'thinkingBudget': budget,
-    };
-  }
-  // Gemini 3.1 Pro: supports 'low', 'medium', 'high' (no minimal)
-  if (isGemini31Pro) {
+  final proMinor = _gemini3ProMinor(upstreamModelId);
+  if (proMinor != null) {
+    // gemini-3-pro has only 'low' and 'high'; 3.1 added 'medium'.
+    final hasMedium = proMinor >= _gemini3ProMediumMinor;
     String level = 'high';
     if (off) {
       level = 'low';
     } else if (budget != null && budget > 0) {
       if (budget < 8000) {
         level = 'low';
-      } else if (budget < 24000) {
-        level = 'medium'; // gemini 3.1 pro support medium
+      } else if (budget < 24000 && hasMedium) {
+        level = 'medium';
       }
     }
-    return {'includeThoughts': true, 'thinkingLevel': level};
+    // Gemini 3 always thinks, so "off" means hiding thoughts at the lowest level.
+    return {'includeThoughts': !off, 'thinkingLevel': level};
   }
-  // Gemini 3 Pro: supports 'low' and 'high' only (no off)
-  if (isGemini3Pro) {
-    String level = 'high';
-    if (off || (budget != null && budget > 0 && budget < 8000)) {
-      // Off or Light (1024) -> low
-      level = 'low';
-    }
-    return {'includeThoughts': true, 'thinkingLevel': level};
-  }
-  // Gemini 3 Flash, 3.5 Flash/Lite, and 3.6 Flash support
-  // 'minimal', 'low', 'medium', and 'high'.
-  if (isGemini3Flash || isGemini35Flash || isGemini36Flash) {
-    String level = isGemini35FlashLite
-        ? 'minimal'
-        : (isGemini35Flash || isGemini36Flash ? 'medium' : 'high');
+
+  final flashMinor = _gemini3FlashMinor(upstreamModelId);
+  if (flashMinor != null) {
+    // Flash dropped 'minimal' in 3.7, so the floor there is 'low' instead.
+    final lowest = flashMinor >= _gemini3FlashNoMinimalMinor
+        ? 'low'
+        : 'minimal';
+    String level = _gemini3FlashLiteId.hasMatch(upstreamModelId)
+        ? lowest
+        : (flashMinor >= _gemini3FlashModernMinor ? 'medium' : 'high');
     if (off) {
-      level = 'minimal';
+      level = lowest;
     } else if (budget != null && budget > 0) {
       // Light (1024) -> low, Medium (16000) -> medium, Heavy (32000) -> high
       if (budget < 8000) {
@@ -177,7 +179,7 @@ Map<String, dynamic> _googleThinkingConfig(
         level = 'high';
       }
     }
-    return {'includeThoughts': true, 'thinkingLevel': level};
+    return {'includeThoughts': !off, 'thinkingLevel': level};
   }
   // Gemini 2.x and below: use thinkingBudget
   if (off) return {'includeThoughts': false};
@@ -291,8 +293,8 @@ Map<String, dynamic> _googleApiPart(Map part) {
 }
 
 int? _defaultGeminiMaxOutputTokens(String upstreamModelId) {
-  if (_isGemini35FlashModel(upstreamModelId) ||
-      _isGemini36FlashModel(upstreamModelId)) {
+  final flashMinor = _gemini3FlashMinor(upstreamModelId);
+  if (flashMinor != null && flashMinor >= _gemini3FlashModernMinor) {
     return 65536;
   }
   return null;

--- a/test/google_thinking_config_test.dart
+++ b/test/google_thinking_config_test.dart
@@ -82,6 +82,33 @@ Map<String, dynamic>? _thinkingConfig(Map<String, dynamic> body) {
   return thinkingConfig.cast<String, dynamic>();
 }
 
+// Runs one request against a throwaway local server and returns the body it saw.
+Future<Map<String, dynamic>> _capture({
+  required String modelId,
+  int? thinkingBudget,
+}) async {
+  late Map<String, dynamic> body;
+  final server = await _startGeminiServer((b) => body = b);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  final chunks = await ChatApiService.sendMessageStream(
+    config: _geminiConfig(
+      'http://${server.address.address}:${server.port}/v1beta',
+    ),
+    modelId: modelId,
+    messages: const [
+      {'role': 'user', 'content': 'hello'},
+    ],
+    thinkingBudget: thinkingBudget,
+    stream: false,
+  ).toList();
+
+  expect(chunks.isGenerationDone, isTrue, reason: modelId);
+  return body;
+}
+
 void main() {
   group('Google Gemma 4 thinking config', () {
     test('non-stream request maps custom budget to thinking level', () async {
@@ -172,7 +199,7 @@ void main() {
     });
   });
 
-  group('latest Gemini Flash thinking config', () {
+  group('Gemini 3.x thinking config', () {
     test('Gemini 3.6 Flash defaults to medium with 64K output', () async {
       late Map<String, dynamic> capturedBody;
       final server = await _startGeminiServer((body) {
@@ -232,6 +259,87 @@ void main() {
       expect(
         (capturedBody['generationConfig'] as Map)['maxOutputTokens'],
         65536,
+      );
+    });
+    test('Gemini 3.7 Flash uses thinkingLevel, never thinkingBudget', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.7-flash',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'medium',
+      });
+      expect((body['generationConfig'] as Map)['maxOutputTokens'], 65536);
+    });
+
+    test('Gemini 3.1 Pro maps budget to medium thinkingLevel', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-pro-preview',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'medium',
+      });
+    });
+
+    test(
+      'Gemini 3.7 Flash floors at low because minimal is unsupported',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.7-flash',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': false,
+          'thinkingLevel': 'low',
+        });
+      },
+    );
+
+    test(
+      'Gemini 3.6 Flash still floors at minimal when thinking is off',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.6-flash',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': false,
+          'thinkingLevel': 'minimal',
+        });
+      },
+    );
+
+    // Image ids fall through to the raw-budget branch; the off case is the only
+    // one that distinguishes that from the old dedicated image branch.
+    test('image ids hide thoughts when thinking is off', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-flash-image',
+        thinkingBudget: 0,
+      );
+
+      expect(_thinkingConfig(body), {'includeThoughts': false});
+    });
+
+    test('TTS ids never get a thinkingLevel', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-flash-tts-preview',
+        thinkingBudget: 16000,
+      );
+
+      expect(
+        _thinkingConfig(body)?.containsKey('thinkingLevel'),
+        isNot(isTrue),
+      );
+      expect(
+        (body['generationConfig'] as Map).containsKey('maxOutputTokens'),
+        isFalse,
       );
     });
   });

--- a/test/google_thinking_config_test.dart
+++ b/test/google_thinking_config_test.dart
@@ -337,15 +337,73 @@ void main() {
       },
     );
 
-    // Image ids fall through to the raw-budget branch; the off case is the only
-    // one that distinguishes that from the old dedicated image branch.
-    test('image ids hide thoughts when thinking is off', () async {
+    test(
+      'Flash Image maps a positive budget to high, never a budget',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.1-flash-image',
+          thinkingBudget: 16000,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': true,
+          'thinkingLevel': 'high',
+        });
+      },
+    );
+
+    test('Flash-Lite Image keeps the light preset at minimal', () async {
       final body = await _capture(
-        modelId: 'gemini-3.1-flash-image',
-        thinkingBudget: 0,
+        modelId: 'gemini-3.1-flash-lite-image',
+        thinkingBudget: 1024,
       );
 
-      expect(_thinkingConfig(body), {'includeThoughts': false});
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'minimal',
+      });
+    });
+
+    test('Flash Image defaults to minimal without a budget', () async {
+      final body = await _capture(modelId: 'gemini-3.1-flash-image-preview');
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'minimal',
+      });
+      expect(
+        (body['generationConfig'] as Map).containsKey('maxOutputTokens'),
+        isFalse,
+      );
+    });
+
+    test(
+      'Flash Image floors at minimal with thoughts hidden when off',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.1-flash-image',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': false,
+          'thinkingLevel': 'minimal',
+        });
+      },
+    );
+
+    // The legacy Pro Image model is absent from the thinking-level docs, so it
+    // stays on the raw-budget branch.
+    test('Gemini 3 Pro Image stays on thinkingBudget', () async {
+      final body = await _capture(
+        modelId: 'gemini-3-pro-image-preview',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingBudget': 16000,
+      });
     });
 
     test('TTS ids never get a thinkingLevel', () async {


### PR DESCRIPTION
8/24 更新：已同步 master 并解决冲突 —— 新增的`gemini-3.7-flash` 专用分支已由本 PR 的版本号解析覆盖，档位与 64K默认值两种写法一致。

## 概述

  使用中发现最新的 `gemini-3.7-flash` 模型发出的请求中，思考用的是 `thinkingBudget`，而不是 Gemini 3 家族该用的 `thinkingLevel`。

## 原因

  型号判断用的是硬编码名单，`gemini-3.7-flash` 不在里面，于是掉到最后的 Gemini 2.x 分支。这份名单已经很长，所以这次不是再往里加一行，而是把它收敛成按版本号判断。

  同一个名单还漏掉了 3.7 的 64K `maxOutputTokens` 默认值，以及后续所有未发布的 3.x 型号。

## 修改

  - 型号判断从匹配 id 名单改为解析次版本号，未发布的 3.x 型号自动落到正确分支。
  - 各家族改变 thinking 契约的三个节点提为命名常量：pro 从 3.1 起支持 `medium`，flash 从 3.5 起默认 `medium` 且上限 64K，flash 从 3.7 起不再支持 `minimal`（发送会报错）。其中 `>= 3.5` 原本在两个函数里各写了一遍，现已共用。
  - 「关闭思考」改为发送 `includeThoughts: false` 并压到该型号的最低档。Gemini 3 无法真正停止思考，但可以不回报思考过程；此前 Gemini 3 分支在关闭时仍发送 `includeThoughts: true`，与 2.x 分支相反。
  - 将 image / tts / live 后缀的 id 排除在版本匹配之外。家族 pattern 以 `-` 为终止符，否则 `gemini-3.1-flash-image` 会被读成 `gemini-3.1-flash`。
  - 删除 image 专用分支。它原本用于避免 `gemini-3-pro-image-preview` 被 `gemini-3-pro` 匹配，现已由上一条从根源处理；该分支的代码是从 2.x 分支复制的，但漏掉了 `if (off)` 一行，导致 image 型号是唯一在关闭思考时仍回报思考过程的型号。
  - 现有型号的档位映射与改动前一致，仅 image 型号在「关闭」时的请求体有变化（`{includeThoughts: true, thinkingBudget: 0}` → `{includeThoughts: false}`）。

## 验证

  - `flutter test test/google_thinking_config_test.dart`
  - 测试文件此前已同时覆盖 Gemma 4 与 Gemini Flash，现覆盖整个 3.x 范围，故从 `google_gemma4_thinking_config_test.dart` 重命名。
  - 新增 6 个用例，均使用真实型号 id，覆盖 3.7 走 `thinkingLevel`、3.7 无 `minimal`、3.6 仍有 `minimal`、pro 的 `medium` 闸门、image 与 tts 型号不走 `thinkingLevel`。
  - 另以 12 个型号 × 4 个档位的实际请求体与改动前逐格比对，确认除上述 image 关闭档外行为一致。

## 附：两处可能不需要的代码

  与本 PR 无关，均无用户可感知影响，未作改动。

  - `model_provider.dart` 中 `gemini-3.5-flash` 的推断分支是空操作：通用 `vision` / `tool` / `reasoning` pattern 已覆盖，而分支独有的 `outMods..clear()..add(text)` 在所有 `infer` 调用点上都是恒等操作（`output` 默认即 `[text]`）。实测删除后 11 个型号的推断结果不变。
  - `_isGemini3TextModel` 中的 `(?!pro-image)` 例外早于 sampling 参数的弃用，导致 `pro-image` 保留而 `flash-image` 丢弃 `temperature` / `topP`。这些参数目前会被忽略，两种行为均无实际影响。
