### PR TITLE
refactor(providers): share one DeepSeek Claude-compatible check

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -550,7 +550,10 @@ class SettingsProvider extends ChangeNotifier {
         final rawOv = cfg.modelOverrides[modelId];
         final ov = rawOv is Map ? rawOv.cast<String, dynamic>() : null;
         final modelForCheck = resolveApiModelIdOverride(ov, modelId);
-        return !_isDeepSeekClaudeCompatible(cfg, modelForCheck) &&
+        return !ProviderConfig.isDeepSeekClaudeCompatible(
+              modelForCheck,
+              config: cfg,
+            ) &&
             _claudeSupportsXhighReasoning(modelForCheck);
       case ProviderKind.google:
         return false;
@@ -576,7 +579,10 @@ class SettingsProvider extends ChangeNotifier {
         final rawOv = cfg.modelOverrides[modelId];
         final ov = rawOv is Map ? rawOv.cast<String, dynamic>() : null;
         final modelForCheck = resolveApiModelIdOverride(ov, modelId);
-        return _isDeepSeekClaudeCompatible(cfg, modelForCheck) ||
+        return ProviderConfig.isDeepSeekClaudeCompatible(
+              modelForCheck,
+              config: cfg,
+            ) ||
             _claudeSupportsMaxReasoning(modelForCheck);
     }
   }
@@ -648,17 +654,6 @@ class SettingsProvider extends ChangeNotifier {
     }
     if (major == 4 && minor == 6) return true;
     return false;
-  }
-
-  bool _isDeepSeekClaudeCompatible(ProviderConfig cfg, String modelId) {
-    final lowerModelId = modelId.trim().toLowerCase();
-    if (lowerModelId.contains('deepseek')) return true;
-    final baseUrl = cfg.baseUrl.trim().toLowerCase();
-    final providerId = cfg.id.trim().toLowerCase();
-    final providerName = cfg.name.trim().toLowerCase();
-    return baseUrl.contains('api.deepseek.com') ||
-        providerId.contains('deepseek') ||
-        providerName.contains('deepseek');
   }
 
   // Explicitly ensure a provider config exists in memory (without persisting to storage).
@@ -5772,6 +5767,19 @@ class ProviderConfig {
   // Anthropic/OpenRouter Claude prompt caching for stable system prompts.
   final bool? claudePromptCachingEnabled;
   final String? claudePromptCachingTtl;
+
+  /// Whether this config talks to DeepSeek's Claude-compatible endpoint,
+  /// which diverges from Anthropic on thinking/effort handling.
+  static bool isDeepSeekClaudeCompatible(
+    String modelId, {
+    ProviderConfig? config,
+  }) {
+    if (modelId.trim().toLowerCase().contains('deepseek')) return true;
+    if (config == null) return false;
+    return config.baseUrl.trim().toLowerCase().contains('api.deepseek.com') ||
+        config.id.trim().toLowerCase().contains('deepseek') ||
+        config.name.trim().toLowerCase().contains('deepseek');
+  }
 
   static const String claudePromptCachingTtl5m = '5m';
   static const String claudePromptCachingTtl1h = '1h';

--- a/lib/core/services/api/chat_api_helpers.dart
+++ b/lib/core/services/api/chat_api_helpers.dart
@@ -443,18 +443,6 @@ String effortForBudget(int? budget) {
 
 bool isClaudeReasoningEnabled(int? budget) => budget != 0;
 
-bool _isDeepSeekClaudeCompatible(String modelId, {ProviderConfig? config}) {
-  final lowerModelId = modelId.trim().toLowerCase();
-  if (lowerModelId.contains('deepseek')) return true;
-  if (config == null) return false;
-  final baseUrl = config.baseUrl.trim().toLowerCase();
-  final providerId = config.id.trim().toLowerCase();
-  final providerName = config.name.trim().toLowerCase();
-  return baseUrl.contains('api.deepseek.com') ||
-      providerId.contains('deepseek') ||
-      providerName.contains('deepseek');
-}
-
 bool _isClaude5AdaptiveThinkingModel(String modelId) {
   return RegExp(
     r'claude-(?:opus|sonnet)-5(?:$|[._:@/-])',
@@ -574,7 +562,7 @@ Map<String, dynamic>? claudeThinkingConfig(
   if (!isClaudeReasoningEnabled(budget)) {
     return <String, dynamic>{'type': 'disabled'};
   }
-  if (_isDeepSeekClaudeCompatible(modelId, config: config)) {
+  if (ProviderConfig.isDeepSeekClaudeCompatible(modelId, config: config)) {
     return <String, dynamic>{'type': 'enabled'};
   }
   if (_supportsClaudeAdaptiveThinking(modelId)) {
@@ -599,7 +587,7 @@ Map<String, dynamic>? claudeOutputConfig(
     if (effort == 'auto' || effort == 'off') return null;
     return <String, dynamic>{'effort': effort};
   }
-  if (_isDeepSeekClaudeCompatible(modelId, config: config)) {
+  if (ProviderConfig.isDeepSeekClaudeCompatible(modelId, config: config)) {
     if (!isClaudeReasoningEnabled(budget)) return null;
     final effort = _claudeEffortForBudget(budget);
     if (effort == 'auto' || effort == 'off') return null;


### PR DESCRIPTION
## 缘由

  Review #935 时顺手发现的：判断「这个供应商是不是 DeepSeek 的 Claude 兼容端点」这段逻辑，在 `settings_provider.dart` 和 `chat_api_helpers.dart` 各写了一份，判据完全相同（型号名含 deepseek，或 baseUrl / 供应商 id / 供应商名命中 deepseek）。

  这个判断决定 DeepSeek 走哪套 thinking / effort 契约，两份不同步的话行为会分叉。

## 修改

  提为 `ProviderConfig.isDeepSeekClaudeCompatible` 共用，删掉两份副本。纯清理，没有行为变化，用户侧无感。

## 验证

  - `flutter test test/openai_deepseek_compat_test.dart test/claude_thinking_compat_test.dart test/core/services/api/`
