### PR TITLE
fix(ci): make PR checks run to green and fix Linux arm64 backup durability

### DIFF
--- a/lib/core/services/backup/backup_isolate_runner.dart
+++ b/lib/core/services/backup/backup_isolate_runner.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
 import 'dart:isolate';
 
+import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../database/sqlite_interrupt.dart';
@@ -13,6 +16,46 @@ export '../../database/sqlite_interrupt.dart'
 /// Test-only: skip Isolate.kill to simulate a kill-resistant native call.
 @visibleForTesting
 bool debugSkipBackupIsolateKill = false;
+
+/// Test-only: blocks the calling thread in a native sleep that neither
+/// `Isolate.kill` nor a signal can cut short, simulating a kill-resistant
+/// native call.
+///
+/// libc's `sleep` returns early on any signal, and on Linux the Dart VM
+/// profiler samples threads with SIGPROF, so the thread's signals are blocked
+/// first; without that the "stuck" isolate finishes in a millisecond.
+void debugNativeSleepIgnoringKill(int seconds) {
+  if (Platform.isWindows) {
+    DynamicLibrary.open('kernel32.dll')
+        .lookupFunction<Void Function(Uint32), void Function(int)>('Sleep')
+        .call(seconds * 1000);
+    return;
+  }
+  final libc = DynamicLibrary.process();
+  // Larger than any platform's sigset_t (glibc: 128 bytes).
+  final set = calloc<Uint8>(256);
+  try {
+    libc
+        .lookupFunction<
+          Int32 Function(Pointer<Void>),
+          int Function(Pointer<Void>)
+        >('sigfillset')
+        .call(set.cast());
+    // SIG_BLOCK is 0 on Linux/Android and 1 on the BSD-derived Apple libc.
+    final sigBlock = Platform.isMacOS || Platform.isIOS ? 1 : 0;
+    libc
+        .lookupFunction<
+          Int32 Function(Int32, Pointer<Void>, Pointer<Void>),
+          int Function(int, Pointer<Void>, Pointer<Void>)
+        >('pthread_sigmask')
+        .call(sigBlock, set.cast(), nullptr);
+  } finally {
+    calloc.free(set);
+  }
+  libc
+      .lookupFunction<Int32 Function(Uint32), int Function(int)>('sleep')
+      .call(seconds);
+}
 
 final class BackupIsolateTimeoutException extends TimeoutException {
   BackupIsolateTimeoutException({

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -3733,6 +3733,7 @@ class _NullDigestOutputStream extends OutputStream {
     }
   }
 
+  @override
   void writeBackReference(int distance, int count) {
     var remaining = count;
     while (remaining > 0) {

--- a/lib/core/services/backup/restore_bundle_staging.dart
+++ b/lib/core/services/backup/restore_bundle_staging.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
@@ -942,7 +941,7 @@ final class RestoreBundleStaging {
     );
     ctx.throwIfCancelled();
     if (args.hangSeconds > 0) {
-      _nativeSleepSeconds(args.hangSeconds);
+      debugNativeSleepIgnoringKill(args.hangSeconds);
     }
     if (args.stallMs > 0) {
       final until = DateTime.now().add(Duration(milliseconds: args.stallMs));
@@ -993,7 +992,7 @@ final class RestoreBundleStaging {
     );
     ctx.throwIfCancelled();
     if (args.hangSeconds > 0) {
-      _nativeSleepSeconds(args.hangSeconds);
+      debugNativeSleepIgnoringKill(args.hangSeconds);
     }
     if (args.stallMs > 0) {
       final until = DateTime.now().add(Duration(milliseconds: args.stallMs));
@@ -1050,18 +1049,6 @@ final class RestoreBundleStaging {
     }
     ctx.throwIfCancelled();
     return databaseInfo;
-  }
-
-  static void _nativeSleepSeconds(int seconds) {
-    if (Platform.isWindows) {
-      DynamicLibrary.open('kernel32.dll')
-          .lookupFunction<Void Function(Uint32), void Function(int)>('Sleep')
-          .call(seconds * 1000);
-      return;
-    }
-    DynamicLibrary.process()
-        .lookupFunction<Int32 Function(Uint32), int Function(int)>('sleep')
-        .call(seconds);
   }
 
   static Map<String, Object?>? _parseBusinessEntityRowIds(

--- a/lib/core/services/backup/restore_durability.dart
+++ b/lib/core/services/backup/restore_durability.dart
@@ -90,20 +90,24 @@ final class _PosixRestoreDurability implements RestoreDurability {
   late final _ChmodDart _chmod;
   late final _ErrnoDart _errno;
 
-  // Android ARM uses architecture-specific O_DIRECTORY/O_NOFOLLOW values.
-  bool get _usesAndroidArmOpenFlags {
+  // arm and arm64 define their own O_DIRECTORY/O_NOFOLLOW instead of the
+  // asm-generic values; on arm64 the generic O_DIRECTORY is O_DIRECT.
+  bool get _usesArmOpenFlags {
     final abi = Abi.current();
-    return abi == Abi.androidArm || abi == Abi.androidArm64;
+    return abi == Abi.androidArm ||
+        abi == Abi.androidArm64 ||
+        abi == Abi.linuxArm ||
+        abi == Abi.linuxArm64;
   }
 
   int get _oDirectory => _isApple
       ? 0x00100000
-      : _usesAndroidArmOpenFlags
+      : _usesArmOpenFlags
       ? 0x00004000
       : 0x00010000;
   int get _oNoFollow => _isApple
       ? 0x00000100
-      : _usesAndroidArmOpenFlags
+      : _usesArmOpenFlags
       ? 0x00008000
       : 0x00020000;
   int get _oCloseOnExec => _isApple ? 0x01000000 : 0x00080000;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.4
   file_picker: ^10.3.10
-  archive: ^4.0.9
+  archive: ^4.2.0
   xml: ^6.5.0
   open_filex: ^4.5.0
   easy_image_viewer: ^1.4.6

--- a/test/core/services/backup/backup_progress_kernel_test.dart
+++ b/test/core/services/backup/backup_progress_kernel_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -600,17 +599,8 @@ String _nonCancellableThenCancelRace(
   return 'committed';
 }
 
-void _nativeSleepIgnoringKill(BackupIsolateContext context, int seconds) {
-  if (Platform.isWindows) {
-    DynamicLibrary.open('kernel32.dll')
-        .lookupFunction<Void Function(Uint32), void Function(int)>('Sleep')
-        .call(seconds * 1000);
-    return;
-  }
-  DynamicLibrary.process()
-      .lookupFunction<Int32 Function(Uint32), int Function(int)>('sleep')
-      .call(seconds);
-}
+void _nativeSleepIgnoringKill(BackupIsolateContext context, int seconds) =>
+    debugNativeSleepIgnoringKill(seconds);
 
 void _stuckHeartbeatLoop(BackupIsolateContext context, String path) {
   final file = File(path);


### PR DESCRIPTION
## 做了什么

三个彼此独立、但都卡着所有 PR 的问题，各自一个 commit：

- **`dart analyze` 在 CI 上失败（`7560e603`）。** `pubspec.lock` 不入库，CI 把 `archive: ^4.0.9` 解析到 4.2.0；该版本给 `OutputStream` 新增了 `writeBackReference`，`data_sync.dart` 里同名方法没标 `@override`，`--fatal-infos` 因 `annotate_overrides` 失败。约束升到 `^4.2.0` 并加注解，让本地与 CI 解析到同一版本。
- **`flutter test` 在 CI 上 5 个失败（`361a30f9`）。** 以前 analyze 先挂、测试从未在 CI 跑过，所以这次才浮现。`backup_progress_kernel_test` 与 `restore_bundle_staging_test` 用 libc `sleep()` 模拟"无视 `Isolate.kill` 的原生调用"，但 Linux 上 Dart VM profiler 用 SIGPROF 采样线程，`sleep()` 遇信号就返回——"卡死"的 isolate 1 ms 就结束了（探针：`sleep(3)` 实测 1 ms 返回、剩 2 s 未睡）。macOS 不用信号采样，所以本地能过。修法：抽一个 `debugNativeSleepIgnoringKill` 共用于测试与 `RestoreBundleStaging` 的 debug hang，先 `pthread_sigmask` 屏蔽本线程信号再 `sleep`。
- **Linux arm64 桌面版备份 / 恢复失效（`1f8eacec`）。** `restore_durability.dart` 只给 Android ARM 用 arm 的 `O_DIRECTORY`/`O_NOFOLLOW`（0x4000/0x8000）；Linux arm64 拿到 asm-generic 的 0x10000，在 arm64 上那是 `O_DIRECT`，对目录 `open()` 直接 EINVAL（`restore_durability_open:22`），durability 层一个目录都 sync 不了。arm / arm64 在 `arch/{arm,arm64}/include/uapi/asm/fcntl.h` 里自定义了这两个值，x86 与 riscv 用 asm-generic——修法是把 `Abi.linuxArm` / `Abi.linuxArm64` 加进 ARM 分支，其他架构与 Apple / Windows 路径不变。

## 测试

- 本地 Linux aarch64（Flutter 3.44.6，与 CI 同版本）：`test/core/services/backup` + `test/core/database` 从 122 个失败到 671 个全过。
- x86_64 CI 在 #953 上验证了前两项：`dart analyze` 与 `flutter test` 首次全绿。arm64 那项 CI 验不出（runner 是 x86_64），依赖上面的本地结果。
- `dart analyze --fatal-infos lib test` 无告警。

#943 / #950 / #953 合入本 PR 后 rebase 即可全绿。
