### PR TITLE
fix: upper border area uneasy to drag problem

### DIFF
--- a/lib/desktop/desktop_home_page.dart
+++ b/lib/desktop/desktop_home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:Kelivo/theme/app_font_weights.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
+
 import 'desktop_nav_rail.dart';
 import 'desktop_chat_page.dart';
 import 'window_title_bar.dart';
@@ -9,8 +10,11 @@ import 'desktop_settings_page.dart';
 import 'desktop_translate_page.dart';
 import '../features/settings/pages/storage_space_page.dart';
 import '../l10n/app_localizations.dart';
+
 import 'package:window_manager/window_manager.dart';
+
 import 'dart:async';
+
 import 'hotkeys/hotkey_event_bus.dart';
 import 'hotkeys/chat_action_bus.dart';
 import 'desktop_settings_navigation_bus.dart';
@@ -273,7 +277,16 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
             child: SizedBox(
               width: needsWidthPad ? minWidth : w,
               height: needsHeightPad ? minHeight : h,
-              child: content,
+              // Provide a reliably thick, grabbable resize border on all
+              // edges (including the top, which otherwise only had the thin
+              // native frame after the title bar was hidden). The title bar
+              // keeps its DragToMoveArea for moving; only its top few pixels
+              // become a resize grip, matching native Windows behavior.
+              child: DragToResizeArea(
+                resizeEdgeSize: 8,
+                resizeEdgeColor: Colors.transparent,
+                child: content,
+              ),
             ),
           ),
         );

--- a/lib/desktop/desktop_home_page.dart
+++ b/lib/desktop/desktop_home_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:Kelivo/theme/app_font_weights.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
-
 import 'desktop_nav_rail.dart';
 import 'desktop_chat_page.dart';
 import 'window_title_bar.dart';
@@ -10,11 +9,8 @@ import 'desktop_settings_page.dart';
 import 'desktop_translate_page.dart';
 import '../features/settings/pages/storage_space_page.dart';
 import '../l10n/app_localizations.dart';
-
 import 'package:window_manager/window_manager.dart';
-
 import 'dart:async';
-
 import 'hotkeys/hotkey_event_bus.dart';
 import 'hotkeys/chat_action_bus.dart';
 import 'desktop_settings_navigation_bus.dart';


### PR DESCRIPTION
fix: upper border area uneasy to drag problem. Sets an 8px thick resize border on all edges (top, bottom, left, right). This replaces the native 0-1px borders that are nearly impossible to grab.