### PR TITLE
fix(markdown): render LaTeX environments, tags and operators

### DIFF
--- a/dependencies/flutter_math_fork/lib/src/ast/nodes/equation_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/ast/nodes/equation_array.dart
@@ -23,6 +23,19 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
   /// Arrayed equations.
   final List<EquationRowNode> body;
 
+  /// Optional equation labels, parallel to [body].
+  ///
+  /// Keeping labels in their own slots lets the renderer center equation
+  /// bodies independently from labels placed at the edge of a display.
+  final List<EquationRowNode?> tags;
+
+  /// Whether this array owns the available display width.
+  ///
+  /// This is true for outer display environments such as `align` and
+  /// `gather`, and for a standalone equation with an explicit tag. Inner
+  /// environments such as `aligned` remain intrinsically sized.
+  final bool displayLayout;
+
   /// Style for horizontal separator lines.
   ///
   /// This includes outermost lines. Different from MathML!
@@ -34,10 +47,14 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
   EquationArrayNode({
     this.addJot = false,
     required this.body,
+    List<EquationRowNode?>? tags,
+    this.displayLayout = false,
     this.arrayStretch = 1.0,
     List<MatrixSeparatorStyle>? hlines,
     List<Measurement>? rowSpacings,
-  })  : hlines = (hlines ?? [])
+  })  : assert(tags == null || tags.length == body.length),
+        tags = tags ?? List<EquationRowNode?>.filled(body.length, null),
+        hlines = (hlines ?? [])
             .extendToByFill(body.length + 1, MatrixSeparatorStyle.none),
         rowSpacings =
             (rowSpacings ?? []).extendToByFill(body.length, Measurement.zero);
@@ -56,21 +73,37 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
             jotSize: addJot ? 3.0.pt.toLpUnder(options) : 0.0,
             arrayskip: 12.0.pt.toLpUnder(options) * arrayStretch,
             hlines: hlines,
+            tagGap: 1.0.em.toLpUnder(options),
+            expandToMaxWidth: displayLayout,
             rowSpacings: rowSpacings
                 .map((e) => e.toLpUnder(options))
                 .toList(growable: false),
-            children:
-                childBuildResults.map((e) => e!.widget).toList(growable: false),
+            rows: List.generate(
+              body.length,
+              (index) => childBuildResults[index * 2]!.widget,
+              growable: false,
+            ),
+            tags: List.generate(
+              body.length,
+              (index) => childBuildResults[index * 2 + 1]?.widget,
+              growable: false,
+            ),
           ),
         ),
+        isDisplayLayout: displayLayout,
       );
 
   @override
   List<MathOptions> computeChildOptions(MathOptions options) =>
-      List.filled(body.length, options, growable: false);
+      List.filled(children.length, options, growable: false);
 
   @override
-  List<EquationRowNode> computeChildren() => body;
+  List<EquationRowNode?> computeChildren() => [
+        for (var index = 0; index < body.length; index++) ...[
+          body[index],
+          tags[index],
+        ],
+      ];
 
   @override
   AtomType get leftType => AtomType.ord;
@@ -83,14 +116,29 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
       false;
 
   @override
-  EquationArrayNode updateChildren(List<EquationRowNode> newChildren) =>
-      copyWith(body: newChildren);
+  EquationArrayNode updateChildren(List<EquationRowNode?> newChildren) {
+    assert(newChildren.length == body.length * 2);
+    return copyWith(
+      body: List.generate(
+        body.length,
+        (index) => newChildren[index * 2]!,
+        growable: false,
+      ),
+      tags: List.generate(
+        body.length,
+        (index) => newChildren[index * 2 + 1],
+        growable: false,
+      ),
+    );
+  }
 
   @override
   Map<String, Object?> toJson() => super.toJson()
     ..addAll({
       if (addJot != false) 'addJot': addJot,
       'body': body.map((e) => e.toJson()),
+      'tags': tags.map((e) => e?.toJson()),
+      if (displayLayout != false) 'displayLayout': displayLayout,
       if (arrayStretch != 1.0) 'arrayStretch': arrayStretch,
       'hlines': hlines.map((e) => e.toString()),
       'rowSpacings': rowSpacings.map((e) => e.toString())
@@ -100,6 +148,8 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
     double? arrayStretch,
     bool? addJot,
     List<EquationRowNode>? body,
+    List<EquationRowNode?>? tags,
+    bool? displayLayout,
     List<MatrixSeparatorStyle>? hlines,
     List<Measurement>? rowSpacings,
   }) =>
@@ -107,6 +157,8 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
         arrayStretch: arrayStretch ?? this.arrayStretch,
         addJot: addJot ?? this.addJot,
         body: body ?? this.body,
+        tags: tags ?? this.tags,
+        displayLayout: displayLayout ?? this.displayLayout,
         hlines: hlines ?? this.hlines,
         rowSpacings: rowSpacings ?? this.rowSpacings,
       );

--- a/dependencies/flutter_math_fork/lib/src/ast/nodes/equation_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/ast/nodes/equation_array.dart
@@ -1,10 +1,145 @@
+import 'package:flutter/widgets.dart';
+
 import '../../render/layout/eqn_array.dart';
 import '../../render/layout/shift_baseline.dart';
 import '../../utils/iterable_extensions.dart';
 import '../options.dart';
 import '../size.dart';
+import '../style.dart';
 import '../syntax_tree.dart';
+import '../types.dart';
 import 'matrix.dart';
+import 'style.dart';
+import 'symbol.dart';
+
+/// TeX environment represented by an [EquationArrayNode].
+enum EquationArrayEnvironment {
+  equation('equation'),
+  equationStar('equation*'),
+  aligned('aligned', alignsColumns: true),
+  align('align', alignsColumns: true),
+  alignStar('align*', alignsColumns: true),
+  split('split', alignsColumns: true),
+  gathered('gathered'),
+  gather('gather'),
+  gatherStar('gather*'),
+  alignedAt('alignedat', alignsColumns: true, takesColumnCount: true),
+  alignAt('alignat', alignsColumns: true, takesColumnCount: true),
+  alignAtStar('alignat*', alignsColumns: true, takesColumnCount: true);
+
+  const EquationArrayEnvironment(
+    this.texName, {
+    this.alignsColumns = false,
+    this.takesColumnCount = false,
+  });
+
+  final String texName;
+  final bool alignsColumns;
+  final bool takesColumnCount;
+
+  static EquationArrayEnvironment fromTexName(String name) =>
+      values.firstWhere((environment) => environment.texName == name);
+}
+
+/// A semantic equation label and its rendered form.
+///
+/// [body] is derived from the current text-style display subtree, excluding the
+/// synthetic parentheses of a non-literal tag. Keeping the display subtree as
+/// the single source of truth means structural edits are reflected in TeX.
+class EquationTagNode extends EquationRowNode {
+  EquationTagNode({
+    required this.literal,
+    required EquationRowNode displayBody,
+  }) : super(
+          overrideType: displayBody.overrideType,
+          children: displayBody.children,
+        );
+
+  EquationTagNode._({
+    required this.literal,
+    required AtomType? overrideType,
+    required List<GreenNode> displayChildren,
+  }) : super(overrideType: overrideType, children: displayChildren);
+
+  final bool literal;
+
+  late final EquationRowNode body = _deriveBody();
+
+  EquationRowNode _deriveBody() {
+    final outer = children.length == 1 ? children.single : null;
+    if (outer is! StyleNode || !_isSyntheticWrapper(outer.optionsDiff)) {
+      return EquationRowNode(children: children);
+    }
+    final displayChildren = outer.children;
+    if (literal) return EquationRowNode(children: displayChildren);
+    if (displayChildren.length >= 2 &&
+        _isParenthesis(displayChildren.first, '(') &&
+        _isParenthesis(displayChildren.last, ')')) {
+      return EquationRowNode(
+        children: displayChildren.sublist(1, displayChildren.length - 1),
+      );
+    }
+    return EquationRowNode(children: children);
+  }
+
+  static bool _isSyntheticWrapper(OptionsDiff diff) =>
+      diff.style == MathStyle.text &&
+      diff.textFontOptions == const PartialFontOptions(fontFamily: 'Main') &&
+      diff.color == null &&
+      diff.size == null &&
+      diff.mathFontOptions == null;
+
+  static bool _isParenthesis(GreenNode node, String symbol) =>
+      node is SymbolNode && node.mode == Mode.text && node.symbol == symbol;
+
+  @override
+  EquationTagNode updateChildren(List<GreenNode> newChildren) =>
+      copyWith(children: newChildren);
+
+  @override
+  EquationTagNode copyWith({
+    AtomType? overrideType,
+    List<GreenNode>? children,
+  }) =>
+      EquationTagNode._(
+        literal: literal,
+        overrideType: overrideType ?? this.overrideType,
+        displayChildren: children ?? this.children,
+      );
+
+  @override
+  Map<String, Object?> toJson() => super.toJson()
+    ..addAll({
+      'body': body.toJson(),
+      if (literal) 'literal': literal,
+    });
+}
+
+/// Zero-width placeholder left where a `\\tag` command appeared in a row.
+///
+/// The semantic tag is owned by [EquationArrayNode], so this marker renders and
+/// encodes as nothing while preserving an unambiguous parse result.
+class EquationTagMarkerNode extends LeafNode {
+  @override
+  Mode get mode => Mode.math;
+
+  @override
+  BuildResult buildWidget(
+    MathOptions options,
+    List<BuildResult?> childBuildResults,
+  ) =>
+      BuildResult(widget: const SizedBox.shrink(), options: options);
+
+  @override
+  AtomType get leftType => AtomType.spacing;
+
+  @override
+  AtomType get rightType => AtomType.spacing;
+
+  @override
+  bool shouldRebuildWidget(MathOptions oldOptions, MathOptions newOptions) =>
+      false;
+}
 
 /// Equantion array node. Brings support for equationa alignment.
 class EquationArrayNode extends SlotableNode<EquationRowNode?> {
@@ -36,6 +171,16 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
   /// environments such as `aligned` remain intrinsically sized.
   final bool displayLayout;
 
+  /// TeX environment needed to reconstruct this array during encoding.
+  ///
+  /// A standalone display equation with `\\tag` has no environment. Inner
+  /// arrays retain environments such as `aligned` so an enclosing tagged
+  /// equation can also round-trip.
+  final EquationArrayEnvironment? environment;
+
+  /// Column count argument for `alignedat` and `alignat` environments.
+  final int? alignmentColumns;
+
   /// Style for horizontal separator lines.
   ///
   /// This includes outermost lines. Different from MathML!
@@ -49,10 +194,17 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
     required this.body,
     List<EquationRowNode?>? tags,
     this.displayLayout = false,
+    this.environment,
+    this.alignmentColumns,
     this.arrayStretch = 1.0,
     List<MatrixSeparatorStyle>? hlines,
     List<Measurement>? rowSpacings,
   })  : assert(tags == null || tags.length == body.length),
+        assert(
+          environment?.takesColumnCount == true
+              ? alignmentColumns != null
+              : alignmentColumns == null,
+        ),
         tags = tags ?? List<EquationRowNode?>.filled(body.length, null),
         hlines = (hlines ?? [])
             .extendToByFill(body.length + 1, MatrixSeparatorStyle.none),
@@ -139,6 +291,8 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
       'body': body.map((e) => e.toJson()),
       'tags': tags.map((e) => e?.toJson()),
       if (displayLayout != false) 'displayLayout': displayLayout,
+      if (environment != null) 'environment': environment!.texName,
+      if (alignmentColumns != null) 'alignmentColumns': alignmentColumns,
       if (arrayStretch != 1.0) 'arrayStretch': arrayStretch,
       'hlines': hlines.map((e) => e.toString()),
       'rowSpacings': rowSpacings.map((e) => e.toString())
@@ -150,6 +304,8 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
     List<EquationRowNode>? body,
     List<EquationRowNode?>? tags,
     bool? displayLayout,
+    EquationArrayEnvironment? environment,
+    int? alignmentColumns,
     List<MatrixSeparatorStyle>? hlines,
     List<Measurement>? rowSpacings,
   }) =>
@@ -159,6 +315,8 @@ class EquationArrayNode extends SlotableNode<EquationRowNode?> {
         body: body ?? this.body,
         tags: tags ?? this.tags,
         displayLayout: displayLayout ?? this.displayLayout,
+        environment: environment ?? this.environment,
+        alignmentColumns: alignmentColumns ?? this.alignmentColumns,
         hlines: hlines ?? this.hlines,
         rowSpacings: rowSpacings ?? this.rowSpacings,
       );

--- a/dependencies/flutter_math_fork/lib/src/ast/nodes/function.dart
+++ b/dependencies/flutter_math_fork/lib/src/ast/nodes/function.dart
@@ -1,7 +1,11 @@
 import '../../render/layout/line.dart';
 import '../options.dart';
+import '../style.dart';
 import '../spacing.dart';
 import '../syntax_tree.dart';
+import 'multiscripts.dart';
+import 'over.dart';
+import 'under.dart';
 
 /// Function node
 ///
@@ -73,4 +77,143 @@ class FunctionNode extends SlotableNode<EquationRowNode> {
         functionName: functionName ?? this.functionName,
         argument: argument ?? this.argument,
       );
+}
+
+/// An operator name with scripts whose default placement follows math style.
+///
+/// Starred TeX operators such as `\operatorname*{argmax}` place their scripts
+/// above and below in display style, and beside the name in all smaller styles.
+/// Explicit `\limits` and `\nolimits` override that default.
+class OperatorNameNode extends SlotableNode<EquationRowNode?> {
+  /// The roman-styled operator name.
+  final EquationRowNode functionName;
+
+  /// The atom following the operator.
+  final EquationRowNode argument;
+
+  /// Optional lower and upper scripts.
+  final EquationRowNode? lowerLimit;
+  final EquationRowNode? upperLimit;
+
+  /// An explicit limits override, or null to use [limitsInDisplayStyle].
+  final bool? limits;
+
+  /// Whether display style defaults to above-and-below limits.
+  final bool limitsInDisplayStyle;
+
+  OperatorNameNode({
+    required this.functionName,
+    required this.argument,
+    this.lowerLimit,
+    this.upperLimit,
+    this.limits,
+    this.limitsInDisplayStyle = false,
+  });
+
+  @override
+  BuildResult buildWidget(
+      MathOptions options, List<BuildResult?> childBuildResults) {
+    var functionNameResult = childBuildResults[0]!;
+    final shouldUseLimits = limits ??
+        (limitsInDisplayStyle && options.style.size == MathStyle.display.size);
+
+    if (lowerLimit != null || upperLimit != null) {
+      if (shouldUseLimits) {
+        GreenNode renderedName = functionName;
+        if (upperLimit != null) {
+          final over = OverNode(
+            base: renderedName.wrapWithEquationRow(),
+            above: upperLimit!,
+          );
+          functionNameResult = over.buildWidget(
+            options,
+            [functionNameResult, childBuildResults[2]],
+          );
+          renderedName = over;
+        }
+        if (lowerLimit != null) {
+          final under = UnderNode(
+            base: renderedName.wrapWithEquationRow(),
+            below: lowerLimit!,
+          );
+          functionNameResult = under.buildWidget(
+            options,
+            [functionNameResult, childBuildResults[1]],
+          );
+        }
+      } else {
+        functionNameResult = MultiscriptsNode(
+          base: functionName,
+          sub: lowerLimit,
+          sup: upperLimit,
+        ).buildWidget(
+          options,
+          [
+            functionNameResult,
+            childBuildResults[1],
+            childBuildResults[2],
+            null,
+            null,
+          ],
+        );
+      }
+    }
+
+    return FunctionNode(
+      functionName: functionName,
+      argument: argument,
+    ).buildWidget(
+      options,
+      [functionNameResult, childBuildResults[3]],
+    );
+  }
+
+  @override
+  List<MathOptions> computeChildOptions(MathOptions options) => [
+        options,
+        options.havingStyle(options.style.sub()),
+        options.havingStyle(options.style.sup()),
+        options,
+      ];
+
+  @override
+  List<EquationRowNode?> computeChildren() => [
+        functionName,
+        lowerLimit,
+        upperLimit,
+        argument,
+      ];
+
+  @override
+  AtomType get leftType => AtomType.op;
+
+  @override
+  AtomType get rightType => argument.rightType;
+
+  @override
+  bool shouldRebuildWidget(MathOptions oldOptions, MathOptions newOptions) =>
+      oldOptions.style.size != newOptions.style.size ||
+      oldOptions.sizeMultiplier != newOptions.sizeMultiplier;
+
+  @override
+  OperatorNameNode updateChildren(List<EquationRowNode?> newChildren) =>
+      OperatorNameNode(
+        functionName: newChildren[0]!,
+        lowerLimit: newChildren[1],
+        upperLimit: newChildren[2],
+        argument: newChildren[3]!,
+        limits: limits,
+        limitsInDisplayStyle: limitsInDisplayStyle,
+      );
+
+  @override
+  Map<String, Object?> toJson() => super.toJson()
+    ..addAll({
+      'functionName': functionName.toJson(),
+      'argument': argument.toJson(),
+      if (lowerLimit != null) 'lowerLimit': lowerLimit!.toJson(),
+      if (upperLimit != null) 'upperLimit': upperLimit!.toJson(),
+      if (limits != null) 'limits': limits,
+      if (limitsInDisplayStyle) 'limitsInDisplayStyle': true,
+    });
 }

--- a/dependencies/flutter_math_fork/lib/src/ast/syntax_tree.dart
+++ b/dependencies/flutter_math_fork/lib/src/ast/syntax_tree.dart
@@ -491,6 +491,11 @@ class EquationRowNode extends ParentableNode<GreenNode>
         flattenedBuildResults.map((e) => e.options).toList(growable: false);
     // assert(flattenedChildList.length == actualChildWidgets.length);
 
+    final displayLayout = flattenedBuildResults.length == 1 &&
+            flattenedBuildResults.single.isDisplayLayout
+        ? flattenedBuildResults.single
+        : null;
+
     // We need to calculate spacings between nodes
     // There are several caveats to consider
     // - bin can only be bin, if it satisfies some conditions. Otherwise it will
@@ -560,6 +565,10 @@ class EquationRowNode extends ParentableNode<GreenNode>
 
     final widget = Consumer<FlutterMathMode>(builder: (context, mode, child) {
       if (mode == FlutterMathMode.view) {
+        // A display layout must receive the constraints of the surrounding
+        // Math widget directly. A Line first lays its children out with
+        // unconstrained width, which would hide the display edge from labels.
+        if (displayLayout != null) return displayLayout.widget;
         return Line(
           key: _key!,
           children: lineChildren,
@@ -642,6 +651,7 @@ class EquationRowNode extends ParentableNode<GreenNode>
           ? flattenedBuildResults.first.italic
           : 0.0,
       widget: widget,
+      isDisplayLayout: displayLayout != null,
     );
   }
 
@@ -813,7 +823,6 @@ enum AtomType {
   inner,
 
   spacing, // symbols
-
 }
 
 /// Only for improvisional use during parsing. Do not use.
@@ -849,12 +858,14 @@ class BuildResult {
   final double italic;
   final double skew;
   final List<BuildResult>? results;
+  final bool isDisplayLayout;
   const BuildResult({
     required this.widget,
     required this.options,
     this.italic = 0.0,
     this.skew = 0.0,
     this.results,
+    this.isDisplayLayout = false,
   });
 }
 

--- a/dependencies/flutter_math_fork/lib/src/ast/syntax_tree.dart
+++ b/dependencies/flutter_math_fork/lib/src/ast/syntax_tree.dart
@@ -559,6 +559,7 @@ class EquationRowNode extends ParentableNode<GreenNode>
         alignerOrSpacer: flattenedChildList[index] is SpaceNode &&
             (flattenedChildList[index] as SpaceNode).alignerOrSpacer,
         trailingMargin: childSpacingConfs[index].spacingAfter,
+        useParentWidthConstraints: displayLayout != null,
       ),
       growable: false,
     );

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions.dart
@@ -11,6 +11,7 @@ import '../../ast/nodes/left_right.dart';
 import '../../ast/nodes/multiscripts.dart';
 import '../../ast/nodes/nary_op.dart';
 import '../../ast/nodes/over.dart';
+import '../../ast/nodes/space.dart';
 import '../../ast/nodes/sqrt.dart';
 import '../../ast/nodes/stretchy_op.dart';
 import '../../ast/nodes/style.dart';
@@ -51,6 +52,8 @@ const Map<Type, EncoderFun> encoderFunctions = {
   AccentNode: _accentEncoder,
   AccentUnderNode: _accentUnderEncoder,
   EquationArrayNode: _equationArrayEncoder,
+  EquationTagNode: _equationTagEncoder,
+  EquationTagMarkerNode: _equationTagMarkerEncoder,
   FracNode: _fracEncoder,
   FunctionNode: _functionEncoder,
   OperatorNameNode: _operatorNameEncoder,

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 
 import '../../ast/nodes/accent.dart';
 import '../../ast/nodes/accent_under.dart';
+import '../../ast/nodes/equation_array.dart';
 import '../../ast/nodes/frac.dart';
 import '../../ast/nodes/function.dart';
 import '../../ast/nodes/left_right.dart';
@@ -34,6 +35,7 @@ import 'encoder.dart';
 
 part 'functions/accent.dart';
 part 'functions/accent_under.dart';
+part 'functions/equation_array.dart';
 part 'functions/frac.dart';
 part 'functions/function.dart';
 part 'functions/left_right.dart';
@@ -48,8 +50,10 @@ const Map<Type, EncoderFun> encoderFunctions = {
   EquationRowNode: _equationRowNodeEncoderFun,
   AccentNode: _accentEncoder,
   AccentUnderNode: _accentUnderEncoder,
+  EquationArrayNode: _equationArrayEncoder,
   FracNode: _fracEncoder,
   FunctionNode: _functionEncoder,
+  OperatorNameNode: _operatorNameEncoder,
   LeftRightNode: _leftRightEncoder,
   MultiscriptsNode: _multisciprtsEncoder,
   NaryOperatorNode: _naryEncoder,

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/equation_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/equation_array.dart
@@ -1,0 +1,19 @@
+part of '../functions.dart';
+
+EncodeResult _equationArrayEncoder(GreenNode node) =>
+    _EquationArrayEncodeResult(node as EquationArrayNode);
+
+class _EquationArrayEncodeResult extends EncodeResult {
+  const _EquationArrayEncodeResult(this.node);
+
+  final EquationArrayNode node;
+
+  @override
+  String stringify(TexEncodeConf conf) => List.generate(node.body.length, (
+        index,
+      ) {
+        final body = node.body[index].encodeTeX(conf: conf.mathParam());
+        final tag = node.tags[index]?.encodeTeX(conf: conf.mathParam()) ?? '';
+        return '$body$tag';
+      }).join(r'\\');
+}

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/equation_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/equation_array.dart
@@ -3,17 +3,114 @@ part of '../functions.dart';
 EncodeResult _equationArrayEncoder(GreenNode node) =>
     _EquationArrayEncodeResult(node as EquationArrayNode);
 
+EncodeResult _equationTagEncoder(GreenNode node) =>
+    _EquationTagEncodeResult(node as EquationTagNode);
+
+EncodeResult _equationTagMarkerEncoder(GreenNode node) =>
+    const StaticEncodeResult('');
+
+class _EquationTagEncodeResult extends EncodeResult {
+  const _EquationTagEncodeResult(this.node);
+
+  final EquationTagNode node;
+
+  @override
+  String stringify(TexEncodeConf conf) {
+    final body = _encodeTagChildren(node.body.children, conf.text());
+    return '\\tag${node.literal ? '*' : ''}{$body}';
+  }
+
+  String _encodeTagChildren(List<GreenNode> children, TexEncodeConf conf) =>
+      children.map((child) => _encodeTagChild(child, conf)).texJoin();
+
+  String _encodeTagChild(GreenNode child, TexEncodeConf conf) {
+    if (child is EquationRowNode) {
+      return '{${_encodeTagChildren(child.children, conf)}}';
+    }
+    if (child is StyleNode &&
+        conf.mode == Mode.text &&
+        child.optionsDiff.style == MathStyle.text &&
+        _containsMathNode(child)) {
+      final remainingDiff = child.optionsDiff.removeStyle();
+      final mathConf = conf.math();
+      final content = _encodeTagChildren(child.children, mathConf);
+      final encoded = _encodeStyle(remainingDiff, content, mathConf);
+      return r'\(' + encoded + r'\)';
+    }
+    if (child is StyleNode) {
+      final content = _encodeTagChildren(child.children, conf);
+      return _encodeStyle(child.optionsDiff, content, conf);
+    }
+    return child.encodeTeX(conf: conf.ord());
+  }
+
+  String _encodeStyle(
+    OptionsDiff diff,
+    String content,
+    TexEncodeConf conf,
+  ) =>
+      diff.isEmpty
+          ? content
+          : _optionsDiffEncode(
+              diff,
+              <dynamic>[StaticEncodeResult(content)],
+            ).stringify(conf);
+
+  bool _containsMathNode(GreenNode node) {
+    if (node is LeafNode) return node.mode == Mode.math;
+    return node.children.whereType<GreenNode>().any(_containsMathNode);
+  }
+}
+
 class _EquationArrayEncodeResult extends EncodeResult {
   const _EquationArrayEncodeResult(this.node);
 
   final EquationArrayNode node;
 
   @override
-  String stringify(TexEncodeConf conf) => List.generate(node.body.length, (
-        index,
-      ) {
-        final body = node.body[index].encodeTeX(conf: conf.mathParam());
-        final tag = node.tags[index]?.encodeTeX(conf: conf.mathParam()) ?? '';
-        return '$body$tag';
-      }).join(r'\\');
+  String stringify(TexEncodeConf conf) {
+    final rows = List.generate(node.body.length, (index) {
+      final body = _encodeEquationRow(node.body[index], conf);
+      final tag = node.tags[index];
+      if (tag == null) return body;
+      if (tag is! EquationTagNode) {
+        conf.reportNonstrict(
+          'unknown equation tag source',
+          'Equation tag has no \\tag source metadata',
+        );
+        return body;
+      }
+      return '$body${tag.encodeTeX(conf: conf.mathParam())}';
+    });
+    final body = rows.join(r'\\');
+    final environment = node.environment;
+    if (environment == null) return body;
+
+    final argument =
+        environment.takesColumnCount ? '{${node.alignmentColumns}}' : '';
+    return '\\begin{${environment.texName}}$argument'
+        '$body\\end{${environment.texName}}';
+  }
+
+  String _encodeEquationRow(EquationRowNode row, TexEncodeConf conf) {
+    final children = row.children
+        .where((child) => child is! EquationTagMarkerNode)
+        .toList(growable: false);
+    if (node.environment?.alignsColumns != true) {
+      return EquationRowTexEncodeResult(
+        children.map(encodeTex).toList(growable: false),
+      ).stringify(conf.mathParam());
+    }
+
+    final lastAligner = children.lastIndexWhere(
+      (child) => child is SpaceNode && child.alignerOrSpacer,
+    );
+    return List.generate(children.length, (index) {
+      final child = children[index];
+      if (child is SpaceNode && child.alignerOrSpacer) {
+        return index == lastAligner ? '' : '&';
+      }
+      return child.encodeTeX(conf: conf.ord());
+    }).texJoin();
+  }
 }

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/function.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/function.dart
@@ -16,6 +16,50 @@ EncodeResult _functionEncoder(GreenNode node) {
   );
 }
 
+EncodeResult _operatorNameEncoder(GreenNode node) {
+  final operatorName = node as OperatorNameNode;
+  dynamic name = operatorName.functionName;
+  final firstNameChild = operatorName.functionName.children.firstOrNull;
+  if (operatorName.functionName.children.length == 1 &&
+      firstNameChild is StyleNode &&
+      firstNameChild.optionsDiff.mathFontOptions ==
+          texMathFontOptions['\\mathrm']) {
+    name = _optionsDiffEncode(
+      firstNameChild.optionsDiff.removeMathFont(),
+      firstNameChild.children,
+    );
+  }
+  return _OperatorNameEncodeResult(operatorName, name);
+}
+
+class _OperatorNameEncodeResult extends EncodeResult {
+  final OperatorNameNode node;
+  final dynamic name;
+
+  const _OperatorNameEncodeResult(this.node, this.name);
+
+  @override
+  String stringify(TexEncodeConf conf) {
+    final command = TexCommandEncodeResult(
+      command: node.limitsInDisplayStyle ? '\\operatorname*' : '\\operatorname',
+      args: [name],
+    ).stringify(conf);
+    final limits = node.limits == null
+        ? ''
+        : node.limits!
+            ? '\\limits'
+            : '\\nolimits';
+    final subscript = node.lowerLimit == null
+        ? ''
+        : '_{${node.lowerLimit!.encodeTeX(conf: conf.mathParam())}}';
+    final superscript = node.upperLimit == null
+        ? ''
+        : '^{${node.upperLimit!.encodeTeX(conf: conf.mathParam())}}';
+    final argument = node.argument.encodeTeX(conf: conf.ord());
+    return '$command$limits$subscript$superscript$argument';
+  }
+}
+
 final _functionOptimizationEntries = [
   OptimizationEntry(
     matcher: isA<FunctionNode>(

--- a/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/style.dart
+++ b/dependencies/flutter_math_fork/lib/src/encoder/tex/functions/style.dart
@@ -78,10 +78,11 @@ EncodeResult _optionsDiffEncode(OptionsDiff diff, List<dynamic> children) {
     }
   }
   if (diff.color != null) {
+    final rgb = diff.color!.toARGB32() & 0x00ffffff;
     res = TexCommandEncodeResult(
       command: '\\textcolor',
       args: <dynamic>[
-        '#${diff.color!.value.toRadixString(16).padLeft(6, '0')}',
+        '#${rgb.toRadixString(16).padLeft(6, '0')}',
         res,
       ],
     );

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
@@ -67,7 +67,10 @@ GreenNode _equationHandler(TexParser parser, EnvContext context) {
   parser.equationTag = null;
   try {
     final body = parser.parseExpression().wrapWithEquationRow();
-    return parser.finishTaggedEquation(body);
+    return parser.finishTaggedEquation(
+      body,
+      environment: EquationArrayEnvironment.fromTexName(context.envName),
+    );
   } finally {
     parser.equationTag = outerTag;
   }
@@ -121,6 +124,7 @@ GreenNode _alignedHandler(TexParser parser, EnvContext context) =>
       parser,
       addJot: true,
       tagged: context.envName == 'align' || context.envName == 'align*',
+      environment: EquationArrayEnvironment.fromTexName(context.envName),
       concatRow: (cells) {
         if (context.envName == 'split' && cells.length > 2) {
           throw ParseException('{split} can contain only two columns');
@@ -137,6 +141,7 @@ GreenNode _gatheredHandler(TexParser parser, EnvContext context) =>
       parser,
       addJot: true,
       tagged: context.envName != 'gathered',
+      environment: EquationArrayEnvironment.fromTexName(context.envName),
       concatRow: (cells) {
         if (cells.length != 1) {
           throw ParseException(
@@ -161,6 +166,8 @@ GreenNode _alignedAtHandler(TexParser parser, EnvContext context) {
     parser,
     addJot: true,
     tagged: context.envName != 'alignedat',
+    environment: EquationArrayEnvironment.fromTexName(context.envName),
+    alignmentColumns: cols,
     concatRow: (cells) {
       if (cells.length > 2 * cols) {
         throw ParseException('Too many math in a row: '
@@ -178,6 +185,8 @@ EquationArrayNode parseEqnArray(
   TexParser parser, {
   bool addJot = false,
   bool tagged = false,
+  EquationArrayEnvironment? environment,
+  int? alignmentColumns,
   required EquationRowNode Function(List<EquationRowNode> cells) concatRow,
 }) {
   // Only outer display environments own a tag for each row. Inner environments
@@ -277,5 +286,7 @@ EquationArrayNode parseEqnArray(
     body: rows,
     tags: tagged ? tags : null,
     displayLayout: tagged,
+    environment: environment,
+    alignmentColumns: alignmentColumns,
   );
 }

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
@@ -51,13 +51,27 @@ const eqnArrayEntries = {
     numArgs: 0,
     handler: _casesHandler,
   ),
-  ['aligned']: EnvSpec(
+  ['equation', 'equation*']: EnvSpec(numArgs: 0, handler: _equationHandler),
+  ['aligned', 'align', 'align*', 'split']: EnvSpec(
     numArgs: 0,
     handler: _alignedHandler,
   ),
-  // ['gathered']: EnvSpec(numArgs: 0, handler: _gatheredHandler),
-  ['alignedat']: EnvSpec(numArgs: 1, handler: _alignedAtHandler),
+  ['gathered', 'gather', 'gather*']:
+      EnvSpec(numArgs: 0, handler: _gatheredHandler),
+  ['alignedat', 'alignat', 'alignat*']:
+      EnvSpec(numArgs: 1, handler: _alignedAtHandler),
 };
+
+GreenNode _equationHandler(TexParser parser, EnvContext context) {
+  final outerTag = parser.equationTag;
+  parser.equationTag = null;
+  try {
+    final body = parser.parseExpression().wrapWithEquationRow();
+    return parser.finishTaggedEquation(body);
+  } finally {
+    parser.equationTag = outerTag;
+  }
+}
 
 GreenNode _casesHandler(TexParser parser, EnvContext context) {
   final body = parseEqnArray(
@@ -106,7 +120,11 @@ GreenNode _alignedHandler(TexParser parser, EnvContext context) =>
     parseEqnArray(
       parser,
       addJot: true,
+      tagged: context.envName == 'align' || context.envName == 'align*',
       concatRow: (cells) {
+        if (context.envName == 'split' && cells.length > 2) {
+          throw ParseException('{split} can contain only two columns');
+        }
         final expanded = cells
             .expand((cell) => [...cell.children, SpaceNode.alignerOrSpacer()])
             .toList(growable: true);
@@ -114,7 +132,19 @@ GreenNode _alignedHandler(TexParser parser, EnvContext context) =>
       },
     );
 
-// GreenNode _gatheredHandler(TexParser parser, EnvContext context) {}
+GreenNode _gatheredHandler(TexParser parser, EnvContext context) =>
+    parseEqnArray(
+      parser,
+      addJot: true,
+      tagged: context.envName != 'gathered',
+      concatRow: (cells) {
+        if (cells.length != 1) {
+          throw ParseException(
+              '{${context.envName}} can contain only one column');
+        }
+        return cells.single;
+      },
+    );
 
 GreenNode _alignedAtHandler(TexParser parser, EnvContext context) {
   final arg = parser.parseArgNode(mode: null, optional: false);
@@ -123,12 +153,14 @@ GreenNode _alignedAtHandler(TexParser parser, EnvContext context) {
       .map((e) => assertNodeType<SymbolNode>(e).symbol)
       .join('');
   final cols = int.tryParse(string);
-  if (cols == null) {
-    throw ParseException('Invalid argument for environment: alignedat');
+  if (cols == null || cols < 1) {
+    throw ParseException(
+        'Invalid argument for environment: ${context.envName}');
   }
   return parseEqnArray(
     parser,
     addJot: true,
+    tagged: context.envName != 'alignedat',
     concatRow: (cells) {
       if (cells.length > 2 * cols) {
         throw ParseException('Too many math in a row: '
@@ -145,8 +177,13 @@ GreenNode _alignedAtHandler(TexParser parser, EnvContext context) {
 EquationArrayNode parseEqnArray(
   TexParser parser, {
   bool addJot = false,
+  bool tagged = false,
   required EquationRowNode Function(List<EquationRowNode> cells) concatRow,
 }) {
+  // Only outer display environments own a tag for each row. Inner environments
+  // such as aligned leave their label on the enclosing equation.
+  final outerTag = parser.equationTag;
+  if (tagged) parser.equationTag = null;
   // Parse body of array with \\ temporarily mapped to \cr
   parser.macroExpander.beginGroup();
   parser.macroExpander.macros.set('\\\\', MacroDefinition.fromString('\\cr'));
@@ -170,7 +207,7 @@ EquationArrayNode parseEqnArray(
   parser.macroExpander.beginGroup();
 
   var row = <EquationRowNode>[];
-  final body = [row];
+  final rows = <EquationRowNode>[];
   final rowGaps = <Measurement>[];
   final hLinesBeforeRow = <MatrixSeparatorStyle>[];
 
@@ -195,14 +232,19 @@ EquationArrayNode parseEqnArray(
       // Arrays terminate newlines with `\crcr` which consumes a `\cr` if
       // the last line is empty.
       // NOTE: Currently, `cell` is the last item added into `row`.
-      if (row.length == 1 && cell is StyleNode && cell.children.isEmpty) {
-        body.removeLast();
+      if (row.length != 1 ||
+          cellBody.isNotEmpty ||
+          (tagged && parser.equationTag != null)) {
+        final equation = concatRow(row);
+        rows.add(tagged ? parser.finishTaggedEquation(equation) : equation);
       }
-      if (hLinesBeforeRow.length < body.length + 1) {
+      if (hLinesBeforeRow.length < rows.length + 1) {
         hLinesBeforeRow.add(MatrixSeparatorStyle.none);
       }
       break;
     } else if (next == '\\cr') {
+      final equation = concatRow(row);
+      rows.add(tagged ? parser.finishTaggedEquation(equation) : equation);
       final cr = assertNodeType<CrNode>(parser.parseFunction(null, null, null));
       rowGaps.add(cr.size ?? Measurement.zero);
 
@@ -211,7 +253,6 @@ EquationArrayNode parseEqnArray(
           .add(getHLines(parser).lastOrNull ?? MatrixSeparatorStyle.none);
 
       row = [];
-      body.add(row);
     } else {
       throw ParseException(
           'Expected & or \\\\ or \\cr or \\end', parser.nextToken);
@@ -223,7 +264,7 @@ EquationArrayNode parseEqnArray(
   // End array group defining \\
   parser.macroExpander.endGroup();
 
-  final rows = body.map<EquationRowNode>(concatRow).toList();
+  if (tagged) parser.equationTag = outerTag;
 
   return EquationArrayNode(
     arrayStretch: arrayStretch,

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/environments/eqn_array.dart
@@ -208,6 +208,7 @@ EquationArrayNode parseEqnArray(
 
   var row = <EquationRowNode>[];
   final rows = <EquationRowNode>[];
+  final tags = <EquationRowNode?>[];
   final rowGaps = <Measurement>[];
   final hLinesBeforeRow = <MatrixSeparatorStyle>[];
 
@@ -236,7 +237,8 @@ EquationArrayNode parseEqnArray(
           cellBody.isNotEmpty ||
           (tagged && parser.equationTag != null)) {
         final equation = concatRow(row);
-        rows.add(tagged ? parser.finishTaggedEquation(equation) : equation);
+        rows.add(equation);
+        tags.add(tagged ? parser.takeEquationTag() : null);
       }
       if (hLinesBeforeRow.length < rows.length + 1) {
         hLinesBeforeRow.add(MatrixSeparatorStyle.none);
@@ -244,7 +246,8 @@ EquationArrayNode parseEqnArray(
       break;
     } else if (next == '\\cr') {
       final equation = concatRow(row);
-      rows.add(tagged ? parser.finishTaggedEquation(equation) : equation);
+      rows.add(equation);
+      tags.add(tagged ? parser.takeEquationTag() : null);
       final cr = assertNodeType<CrNode>(parser.parseFunction(null, null, null));
       rowGaps.add(cr.size ?? Measurement.zero);
 
@@ -272,5 +275,7 @@ EquationArrayNode parseEqnArray(
     rowSpacings: rowGaps,
     addJot: addJot,
     body: rows,
+    tags: tagged ? tags : null,
+    displayLayout: tagged,
   );
 }

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base.dart
@@ -3,6 +3,7 @@ library katex_base;
 import '../../../ast/nodes/accent.dart';
 import '../../../ast/nodes/accent_under.dart';
 import '../../../ast/nodes/enclosure.dart';
+import '../../../ast/nodes/equation_array.dart';
 import '../../../ast/nodes/frac.dart';
 import '../../../ast/nodes/function.dart';
 import '../../../ast/nodes/left_right.dart';

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base.dart
@@ -54,6 +54,7 @@ part 'katex_base/rule.dart';
 part 'katex_base/sizing.dart';
 part 'katex_base/sqrt.dart';
 part 'katex_base/styling.dart';
+part 'katex_base/tag.dart';
 part 'katex_base/text.dart';
 part 'katex_base/underover.dart';
 
@@ -83,6 +84,7 @@ const katexBaseFunctionEntries = {
   ..._sizingEntries,
   ..._sqrtEntries,
   ..._stylingEntries,
+  ..._tagEntries,
   ..._textEntries,
   ..._underOverEntries,
 };

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/operator_name.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/operator_name.dart
@@ -47,32 +47,12 @@ GreenNode _operatorNameHandler(TexParser parser, FunctionContext context) {
     ),
   );
 
-  if (!scripts.empty) {
-    final limits = scripts.limits ?? (starred && parser.settings.displayMode);
-    if (limits) {
-      name = scripts.superscript != null
-          ? OverNode(
-              base: name.wrapWithEquationRow(),
-              above: scripts.superscript!,
-            )
-          : name;
-      name = scripts.subscript != null
-          ? UnderNode(
-              base: name.wrapWithEquationRow(),
-              below: scripts.subscript!,
-            )
-          : name;
-    } else {
-      name = MultiscriptsNode(
-        base: name.wrapWithEquationRow(),
-        sub: scripts.subscript,
-        sup: scripts.superscript,
-      );
-    }
-  }
-
-  return FunctionNode(
+  return OperatorNameNode(
     functionName: name.wrapWithEquationRow(),
     argument: body.wrapWithEquationRow(),
+    lowerLimit: scripts.subscript,
+    upperLimit: scripts.superscript,
+    limits: scripts.limits,
+    limitsInDisplayStyle: starred,
   );
 }

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/operator_name.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/operator_name.dart
@@ -28,9 +28,14 @@ const _operatorNameEntries = {
       FunctionSpec(numArgs: 1, handler: _operatorNameHandler),
 };
 GreenNode _operatorNameHandler(TexParser parser, FunctionContext context) {
+  var starred = context.funcName == '\\operatorname*';
+  parser.consumeSpaces();
+  if (!starred && parser.fetch().text == '*') {
+    starred = true;
+    parser.consume();
+  }
   var name = parser.parseArgNode(mode: null, optional: false)!;
-  final scripts =
-      parser.parseScripts(allowLimits: context.funcName == '\\operatorname*');
+  final scripts = parser.parseScripts(allowLimits: starred);
   parser.consumeSpaces();
   final body =
       parser.parseAtom(context.breakOnTokenText) ?? EquationRowNode.empty();
@@ -43,7 +48,8 @@ GreenNode _operatorNameHandler(TexParser parser, FunctionContext context) {
   );
 
   if (!scripts.empty) {
-    if (scripts.limits == true) {
+    final limits = scripts.limits ?? (starred && parser.settings.displayMode);
+    if (limits) {
       name = scripts.superscript != null
           ? OverNode(
               base: name.wrapWithEquationRow(),

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/tag.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/tag.dart
@@ -15,8 +15,10 @@ GreenNode _tagHandler(TexParser parser, FunctionContext context) {
   parser.consumeSpaces();
   final literal = parser.fetch().text == '*';
   if (literal) parser.consume();
-  final body = parser.parseArgNode(mode: Mode.text, optional: false)!;
-  parser.equationTag = StyleNode(
+  final body = parser
+      .parseArgNode(mode: Mode.text, optional: false)!
+      .wrapWithEquationRow();
+  final displayBody = StyleNode(
     optionsDiff: OptionsDiff(
       style: MathStyle.text,
       textFontOptions: texTextFontOptions['\\textnormal'],
@@ -27,5 +29,9 @@ GreenNode _tagHandler(TexParser parser, FunctionContext context) {
       if (!literal) SymbolNode(symbol: ')', mode: Mode.text),
     ],
   ).wrapWithEquationRow();
-  return EquationRowNode.empty();
+  parser.equationTag = EquationTagNode(
+    literal: literal,
+    displayBody: displayBody,
+  );
+  return EquationTagMarkerNode();
 }

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/tag.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/functions/katex_base/tag.dart
@@ -1,0 +1,31 @@
+part of katex_base;
+
+const _tagEntries = {
+  ['\\tag']: FunctionSpec(numArgs: 1, handler: _tagHandler),
+};
+
+GreenNode _tagHandler(TexParser parser, FunctionContext context) {
+  if (!parser.settings.displayMode) {
+    throw ParseException(
+        '\\tag works only in display equations', context.token);
+  }
+  if (parser.equationTag != null) {
+    throw ParseException('Multiple \\tag in one equation', context.token);
+  }
+  parser.consumeSpaces();
+  final literal = parser.fetch().text == '*';
+  if (literal) parser.consume();
+  final body = parser.parseArgNode(mode: Mode.text, optional: false)!;
+  parser.equationTag = StyleNode(
+    optionsDiff: OptionsDiff(
+      style: MathStyle.text,
+      textFontOptions: texTextFontOptions['\\textnormal'],
+    ),
+    children: [
+      if (!literal) SymbolNode(symbol: '(', mode: Mode.text),
+      ...body.expandEquationRow(),
+      if (!literal) SymbolNode(symbol: ')', mode: Mode.text),
+    ],
+  ).wrapWithEquationRow();
+  return EquationRowNode.empty();
+}

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/macros.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/macros.dart
@@ -603,17 +603,6 @@ final Map<String, MacroDefinition> builtinMacros = {
 // \def\qquad{\hskip2em\relax}
   '\\qquad': MacroDefinition.fromString("\\hskip2em\\relax"),
 
-// \tag@in@display form of \tag
-// TODO tag
-  '\\tag': MacroDefinition.fromString("\\@ifstar\\tag@literal\\tag@paren"),
-  '\\tag@paren': MacroDefinition.fromString("\\tag@literal{({#1})}"),
-  '\\tag@literal': MacroDefinition.fromCtxString((context) {
-    if (context.macros.get("\\df@tag") != null) {
-      throw ParseException("Multiple \\tag");
-    }
-    return "\\gdef\\df@tag{\\text{#1}}";
-  }),
-
 // \renewcommand{\bmod}{\nonscript\mskip-\medmuskip\mkern5mu\mathbin
 //   {\operator@font mod}\penalty900
 //   \mkern5mu\nonscript\mskip-\medmuskip}

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
@@ -26,9 +26,9 @@ import 'dart:ui';
 
 import 'package:collection/collection.dart';
 
+import '../../ast/nodes/equation_array.dart';
 import '../../ast/nodes/multiscripts.dart';
 import '../../ast/nodes/over.dart';
-import '../../ast/nodes/space.dart';
 import '../../ast/nodes/style.dart';
 import '../../ast/nodes/symbol.dart';
 import '../../ast/nodes/under.dart';
@@ -69,15 +69,21 @@ class TexParser {
   /// Explicit label for the current display equation or alignment row.
   EquationRowNode? equationTag;
 
-  EquationRowNode finishTaggedEquation(EquationRowNode body) {
+  EquationRowNode? takeEquationTag() {
     final tag = equationTag;
     equationTag = null;
+    return tag;
+  }
+
+  GreenNode finishTaggedEquation(EquationRowNode body) {
+    final tag = takeEquationTag();
     if (tag == null) return body;
-    return EquationRowNode(children: [
-      ...body.children,
-      SpaceNode(height: Measurement.zero, width: 1.0.em, mode: Mode.math),
-      tag,
-    ]);
+    return EquationArrayNode(
+      body: [body],
+      tags: [tag],
+      displayLayout: true,
+      arrayStretch: 0.0,
+    );
   }
 
   /// Get parse result
@@ -98,7 +104,8 @@ class TexParser {
     if (!this.settings.globalGroup) {
       this.macroExpander.endGroup();
     }
-    return finishTaggedEquation(parse.wrapWithEquationRow());
+    return finishTaggedEquation(parse.wrapWithEquationRow())
+        .wrapWithEquationRow();
   }
 
   List<GreenNode> parseExpression({
@@ -206,7 +213,12 @@ class TexParser {
     // Operators may look ahead for an argument at the end of an environment.
     // Leave its delimiter for the enclosing expression to consume.
     final next = this.fetch().text;
-    if (endOfExpression.contains(next) || next == breakOnTokenText) {
+    final middleBelongsToCurrentLeftRight = next == '\\middle' &&
+        argParsingContexts.isNotEmpty &&
+        currArgParsingContext.funcName == '\\left';
+    if (endOfExpression.contains(next) ||
+        next == breakOnTokenText ||
+        (next == '\\middle' && !middleBelongsToCurrentLeftRight)) {
       return null;
     }
     final base = this.parseGroup('atom',

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
@@ -28,6 +28,7 @@ import 'package:collection/collection.dart';
 
 import '../../ast/nodes/multiscripts.dart';
 import '../../ast/nodes/over.dart';
+import '../../ast/nodes/space.dart';
 import '../../ast/nodes/style.dart';
 import '../../ast/nodes/symbol.dart';
 import '../../ast/nodes/under.dart';
@@ -65,6 +66,20 @@ class TexParser {
   final MacroExpander macroExpander;
   Token? nextToken;
 
+  /// Explicit label for the current display equation or alignment row.
+  EquationRowNode? equationTag;
+
+  EquationRowNode finishTaggedEquation(EquationRowNode body) {
+    final tag = equationTag;
+    equationTag = null;
+    if (tag == null) return body;
+    return EquationRowNode(children: [
+      ...body.children,
+      SpaceNode(height: Measurement.zero, width: 1.0.em, mode: Mode.math),
+      tag,
+    ]);
+  }
+
   /// Get parse result
   EquationRowNode parse() {
     if (!this.settings.globalGroup) {
@@ -83,7 +98,7 @@ class TexParser {
     if (!this.settings.globalGroup) {
       this.macroExpander.endGroup();
     }
-    return parse.wrapWithEquationRow();
+    return finishTaggedEquation(parse.wrapWithEquationRow());
   }
 
   List<GreenNode> parseExpression({
@@ -188,6 +203,12 @@ class TexParser {
   }
 
   GreenNode? parseAtom(String? breakOnTokenText) {
+    // Operators may look ahead for an argument at the end of an environment.
+    // Leave its delimiter for the enclosing expression to consume.
+    final next = this.fetch().text;
+    if (endOfExpression.contains(next) || next == breakOnTokenText) {
+      return null;
+    }
     final base = this.parseGroup('atom',
         optional: false, greediness: null, breakOnTokenText: breakOnTokenText);
 

--- a/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
+++ b/dependencies/flutter_math_fork/lib/src/parser/tex/parser.dart
@@ -24,8 +24,6 @@
 import 'dart:collection';
 import 'dart:ui';
 
-import 'package:collection/collection.dart';
-
 import '../../ast/nodes/equation_array.dart';
 import '../../ast/nodes/multiscripts.dart';
 import '../../ast/nodes/over.dart';
@@ -67,21 +65,25 @@ class TexParser {
   Token? nextToken;
 
   /// Explicit label for the current display equation or alignment row.
-  EquationRowNode? equationTag;
+  EquationTagNode? equationTag;
 
-  EquationRowNode? takeEquationTag() {
+  EquationTagNode? takeEquationTag() {
     final tag = equationTag;
     equationTag = null;
     return tag;
   }
 
-  GreenNode finishTaggedEquation(EquationRowNode body) {
+  GreenNode finishTaggedEquation(
+    EquationRowNode body, {
+    EquationArrayEnvironment? environment,
+  }) {
     final tag = takeEquationTag();
     if (tag == null) return body;
     return EquationArrayNode(
       body: [body],
       tags: [tag],
       displayLayout: true,
+      environment: environment,
       arrayStretch: 0.0,
     );
   }
@@ -649,7 +651,7 @@ class TexParser {
     } else {
       return StyleNode(
         optionsDiff: OptionsDiff(style: MathStyle.text),
-        children: res?.children.whereNotNull().toList(growable: false) ?? [],
+        children: res?.children.nonNulls.toList(growable: false) ?? [],
       );
     }
   }

--- a/dependencies/flutter_math_fork/lib/src/render/layout/eqn_array.dart
+++ b/dependencies/flutter_math_fork/lib/src/render/layout/eqn_array.dart
@@ -6,16 +6,47 @@ import 'package:flutter/widgets.dart';
 
 import '../../ast/nodes/matrix.dart';
 import '../constants.dart';
-import '../utils/render_box_offset.dart';
 import '../utils/render_box_layout.dart';
+import '../utils/render_box_offset.dart';
 import 'line.dart';
 
-class EqnArrayParentData extends ContainerBoxParentData<RenderBox> {}
+class EqnArrayParentData extends ContainerBoxParentData<RenderBox> {
+  int rowIndex = 0;
+  bool isTag = false;
+}
+
+class _EqnArrayElement extends ParentDataWidget<EqnArrayParentData> {
+  const _EqnArrayElement({
+    required this.rowIndex,
+    required this.isTag,
+    required Widget child,
+  }) : super(child: child);
+
+  final int rowIndex;
+  final bool isTag;
+
+  @override
+  void applyParentData(RenderObject renderObject) {
+    assert(renderObject.parentData is EqnArrayParentData);
+    final parentData = renderObject.parentData! as EqnArrayParentData;
+    if (parentData.rowIndex == rowIndex && parentData.isTag == isTag) return;
+    parentData
+      ..rowIndex = rowIndex
+      ..isTag = isTag;
+    final targetParent = renderObject.parent;
+    if (targetParent is RenderObject) targetParent.markNeedsLayout();
+  }
+
+  @override
+  Type get debugTypicalAncestorWidgetClass => EqnArray;
+}
 
 class EqnArray extends MultiChildRenderObjectWidget {
   final double ruleThickness;
   final double jotSize;
   final double arrayskip;
+  final double tagGap;
+  final bool expandToMaxWidth;
   final List<MatrixSeparatorStyle> hlines;
   final List<double> rowSpacings;
 
@@ -24,19 +55,57 @@ class EqnArray extends MultiChildRenderObjectWidget {
     required this.ruleThickness,
     required this.jotSize,
     required this.arrayskip,
+    required this.tagGap,
+    required this.expandToMaxWidth,
     required this.hlines,
     required this.rowSpacings,
-    required List<Widget> children,
-  }) : super(key: key, children: children);
+    required List<Widget> rows,
+    required List<Widget?> tags,
+  })  : assert(rows.length == tags.length),
+        super(
+          key: key,
+          children: [
+            for (var index = 0; index < rows.length; index++) ...[
+              _EqnArrayElement(
+                rowIndex: index,
+                isTag: false,
+                child: rows[index],
+              ),
+              if (tags[index] != null)
+                _EqnArrayElement(
+                  rowIndex: index,
+                  isTag: true,
+                  child: tags[index]!,
+                ),
+            ],
+          ],
+        );
 
   @override
   RenderObject createRenderObject(BuildContext context) => RenderEqnArray(
         ruleThickness: ruleThickness,
         jotSize: jotSize,
         arrayskip: arrayskip,
+        tagGap: tagGap,
+        expandToMaxWidth: expandToMaxWidth,
         hlines: hlines,
         rowSpacings: rowSpacings,
       );
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderEqnArray renderObject,
+  ) {
+    renderObject
+      ..ruleThickness = ruleThickness
+      ..jotSize = jotSize
+      ..arrayskip = arrayskip
+      ..tagGap = tagGap
+      ..expandToMaxWidth = expandToMaxWidth
+      ..hlines = hlines
+      ..rowSpacings = rowSpacings;
+  }
 }
 
 class RenderEqnArray extends RenderBox
@@ -49,11 +118,15 @@ class RenderEqnArray extends RenderBox
     required double ruleThickness,
     required double jotSize,
     required double arrayskip,
+    required double tagGap,
+    required bool expandToMaxWidth,
     required List<MatrixSeparatorStyle> hlines,
     required List<double> rowSpacings,
   })  : _ruleThickness = ruleThickness,
         _jotSize = jotSize,
         _arrayskip = arrayskip,
+        _tagGap = tagGap,
+        _expandToMaxWidth = expandToMaxWidth,
         _hlines = hlines,
         _rowSpacings = rowSpacings {
     addAll(children);
@@ -86,10 +159,28 @@ class RenderEqnArray extends RenderBox
     }
   }
 
+  double get tagGap => _tagGap;
+  double _tagGap;
+  set tagGap(double value) {
+    if (_tagGap != value) {
+      _tagGap = value;
+      markNeedsLayout();
+    }
+  }
+
+  bool get expandToMaxWidth => _expandToMaxWidth;
+  bool _expandToMaxWidth;
+  set expandToMaxWidth(bool value) {
+    if (_expandToMaxWidth != value) {
+      _expandToMaxWidth = value;
+      markNeedsLayout();
+    }
+  }
+
   List<MatrixSeparatorStyle> get hlines => _hlines;
   List<MatrixSeparatorStyle> _hlines;
   set hlines(List<MatrixSeparatorStyle> value) {
-    if (_hlines != value) {
+    if (!const ListEquality<MatrixSeparatorStyle>().equals(_hlines, value)) {
       _hlines = value;
       markNeedsLayout();
     }
@@ -98,7 +189,7 @@ class RenderEqnArray extends RenderBox
   List<double> get rowSpacings => _rowSpacings;
   List<double> _rowSpacings;
   set rowSpacings(List<double> value) {
-    if (_rowSpacings != value) {
+    if (!const ListEquality<double>().equals(_rowSpacings, value)) {
       _rowSpacings = value;
       markNeedsLayout();
     }
@@ -115,6 +206,87 @@ class RenderEqnArray extends RenderBox
 
   double width = 0.0;
 
+  int get _rowCount => rowSpacings.length;
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      _computeIntrinsicWidth(height, (child, extent) {
+        return child.getMinIntrinsicWidth(extent);
+      });
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      _computeIntrinsicWidth(height, (child, extent) {
+        return child.getMaxIntrinsicWidth(extent);
+      });
+
+  double _computeIntrinsicWidth(
+    double height,
+    double Function(RenderBox child, double extent) childWidth,
+  ) {
+    final colWidths = <double>[];
+    var nonAligningWidth = 0.0;
+    var maxTagWidth = 0.0;
+    var child = firstChild;
+    while (child != null) {
+      final parentData = child.parentData! as EqnArrayParentData;
+      if (parentData.isTag) {
+        maxTagWidth = math.max(maxTagWidth, childWidth(child, height));
+      } else {
+        final childColWidths = _intrinsicColumnWidths(
+          child,
+          height,
+          childWidth,
+        );
+        if (childColWidths == null) {
+          nonAligningWidth =
+              math.max(nonAligningWidth, childWidth(child, height));
+        } else {
+          _mergeColumnWidths(colWidths, childColWidths);
+        }
+      }
+      child = parentData.nextSibling;
+    }
+    final bodyWidth = math.max(nonAligningWidth, colWidths.sum);
+    return _requiredWidth(bodyWidth, maxTagWidth);
+  }
+
+  List<double>? _intrinsicColumnWidths(
+    RenderBox row,
+    double height,
+    double Function(RenderBox child, double extent) childWidth,
+  ) {
+    if (row is! RenderLine) return null;
+    final widths = <double>[0.0];
+    var child = row.firstChild;
+    var hasAligner = false;
+    while (child != null) {
+      final parentData = child.parentData! as LineParentData;
+      if (parentData.alignerOrSpacer) {
+        hasAligner = true;
+        widths.add(0.0);
+      } else {
+        widths[widths.length - 1] +=
+            childWidth(child, height) + parentData.trailingMargin;
+      }
+      child = parentData.nextSibling;
+    }
+    return hasAligner ? widths : null;
+  }
+
+  void _mergeColumnWidths(List<double> target, List<double> candidate) {
+    for (var index = 0; index < candidate.length; index++) {
+      if (index == target.length) {
+        target.add(candidate[index]);
+      } else {
+        target[index] = math.max(target[index], candidate[index]);
+      }
+    }
+  }
+
+  double _requiredWidth(double bodyWidth, double maxTagWidth) =>
+      maxTagWidth == 0.0 ? bodyWidth : bodyWidth + 2 * (tagGap + maxTagWidth);
+
   @override
   Size computeDryLayout(BoxConstraints constraints) =>
       _computeLayout(constraints);
@@ -128,99 +300,141 @@ class RenderEqnArray extends RenderBox
     BoxConstraints constraints, {
     bool dry = true,
   }) {
-    final nonAligningSizes = <Size>[];
-    // First pass, calculate width for each column.
+    final rows = List<RenderBox?>.filled(_rowCount, null);
+    final tags = List<RenderBox?>.filled(_rowCount, null);
     var child = firstChild;
-    var width = 0.0;
+    while (child != null) {
+      final parentData = child.parentData! as EqnArrayParentData;
+      assert(parentData.rowIndex < _rowCount);
+      if (parentData.isTag) {
+        tags[parentData.rowIndex] = child;
+      } else {
+        rows[parentData.rowIndex] = child;
+      }
+      child = parentData.nextSibling;
+    }
+    assert(rows.every((row) => row != null));
+
+    final rowSizes = List<Size>.filled(_rowCount, Size.zero);
+    final tagSizes = List<Size>.filled(_rowCount, Size.zero);
     final colWidths = <double>[];
-    final sizeMap = <RenderBox, Size>{};
-    while (child != null) {
-      Size childSize = Size.zero;
-      if (child is RenderLine) {
-        child.alignColWidth = null;
-        childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
-        final childColWidth = child.alignColWidth;
-        if (childColWidth != null) {
-          for (var i = 0; i < childColWidth.length; i++) {
-            if (i >= colWidths.length) {
-              colWidths.add(childColWidth[i]);
-            } else {
-              colWidths[i] = math.max(
-                colWidths[i],
-                childColWidth[i],
-              );
-            }
-          }
-        } else {
-          nonAligningSizes.add(childSize);
-        }
-      } else {
-        childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
-        colWidths[0] = math.max(
-          colWidths[0],
-          childSize.width,
-        );
+    var nonAligningChildrenWidth = 0.0;
+    var maxTagWidth = 0.0;
+
+    // First pass: measure bodies and labels independently. Only equation
+    // bodies participate in the alignment-column calculation.
+    for (var index = 0; index < _rowCount; index++) {
+      final row = rows[index]!;
+      if (row is RenderLine) row.alignColWidth = null;
+      final rowSize = row.getLayoutSize(infiniteConstraint, dry: dry);
+      rowSizes[index] = rowSize;
+
+      List<double>? childColWidths;
+      if (row is RenderLine) {
+        childColWidths = dry
+            ? _intrinsicColumnWidths(
+                row,
+                double.infinity,
+                (child, height) => child.getMaxIntrinsicWidth(height),
+              )
+            : row.alignColWidth;
       }
-      sizeMap[child] = childSize;
-      child = (child.parentData as EqnArrayParentData).nextSibling;
+      if (childColWidths == null) {
+        nonAligningChildrenWidth =
+            math.max(nonAligningChildrenWidth, rowSize.width);
+      } else {
+        _mergeColumnWidths(colWidths, childColWidths);
+      }
+
+      final tag = tags[index];
+      if (tag != null) {
+        final tagSize = tag.getLayoutSize(infiniteConstraint, dry: dry);
+        tagSizes[index] = tagSize;
+        maxTagWidth = math.max(maxTagWidth, tagSize.width);
+      }
     }
 
-    final nonAligningChildrenWidth =
-        nonAligningSizes.map((size) => size.width).maxOrNull ?? 0.0;
     final aligningChildrenWidth = colWidths.sum;
-    width = math.max(nonAligningChildrenWidth, aligningChildrenWidth);
+    final bodyWidth = math.max(nonAligningChildrenWidth, aligningChildrenWidth);
+    final requiredWidth = _requiredWidth(bodyWidth, maxTagWidth);
+    final desiredWidth = expandToMaxWidth && constraints.hasBoundedWidth
+        ? constraints.maxWidth
+        : requiredWidth;
+    final layoutWidth = constraints.constrainWidth(desiredWidth);
 
-    // Second pass, re-layout each RenderLine using column width constraint
-    var index = 0;
     var vPos = 0.0;
-    if (!dry) {
-      hlinePos.add(vPos);
-    }
-    index++;
-    child = firstChild;
-    while (child != null) {
-      final childParentData = child.parentData as EqnArrayParentData;
+    if (!dry) hlinePos = [vPos];
+
+    // Second pass: share alignment widths between body rows, center the body
+    // block, then place each label independently at the physical right edge.
+    for (var index = 0; index < _rowCount; index++) {
+      final row = rows[index]!;
+      final tag = tags[index];
+      var rowSize = rowSizes[index];
+      final tagSize = tagSizes[index];
       var hPos = 0.0;
-      final childSize = sizeMap[child] ?? Size.zero;
-      if (child is RenderLine && child.alignColWidth != null) {
-        child.alignColWidth = colWidths;
-        // Hack: We use a different constraint to trigger another layout or
-        // else it would be bypassed
-        child.layout(BoxConstraints(maxWidth: aligningChildrenWidth),
-            parentUsesSize: true);
-        hPos = (width - aligningChildrenWidth) / 2 +
-            colWidths[0] -
-            child.alignColWidth![0];
-      } else {
-        hPos = (width - childSize.width) / 2;
-      }
-      final layoutHeight = dry ? 0 : child.layoutHeight;
-      final layoutDepth = dry ? childSize.height : child.layoutDepth;
 
-      vPos += math.max(layoutHeight, 0.7 * arrayskip);
-      if (!dry) {
-        childParentData.offset = Offset(
-          hPos,
-          vPos - child.layoutHeight,
+      if (row is RenderLine && row.alignColWidth != null && !dry) {
+        row.alignColWidth = colWidths;
+        row.layout(
+          BoxConstraints(maxWidth: aligningChildrenWidth),
+          parentUsesSize: true,
         );
+        rowSize = row.size;
+        hPos = (layoutWidth - aligningChildrenWidth) / 2 +
+            colWidths[0] -
+            row.alignColWidth![0];
+      } else {
+        hPos = (layoutWidth - rowSize.width) / 2;
       }
-      vPos += math.max(layoutDepth, 0.3 * arrayskip) +
-          jotSize +
-          rowSpacings[index - 1];
-      if (!dry) {
-        hlinePos.add(vPos);
-      }
-      vPos += hlines[index] != MatrixSeparatorStyle.none ? ruleThickness : 0.0;
-      index++;
 
-      child = childParentData.nextSibling;
+      final tagHPos = layoutWidth - tagSize.width;
+      final tagFitsBesideBody =
+          tag == null || hPos + rowSize.width + tagGap <= tagHPos;
+
+      final rowHeight = dry ? 0.0 : row.layoutHeight;
+      final rowDepth = dry ? rowSize.height : row.layoutDepth;
+      final tagHeight = dry || tag == null ? 0.0 : tag.layoutHeight;
+      final tagDepth = dry || tag == null ? tagSize.height : tag.layoutDepth;
+
+      if (tagFitsBesideBody) {
+        final height = math.max(rowHeight, tagHeight);
+        final depth = math.max(rowDepth, tagDepth);
+        vPos += math.max(height, 0.7 * arrayskip);
+        if (!dry) {
+          (row.parentData! as EqnArrayParentData).offset =
+              Offset(hPos, vPos - rowHeight);
+          if (tag != null) {
+            (tag.parentData! as EqnArrayParentData).offset =
+                Offset(tagHPos, vPos - tagHeight);
+          }
+        }
+        vPos += math.max(depth, 0.3 * arrayskip);
+      } else {
+        // A genuinely tight parent cannot satisfy body centering, right-edge
+        // placement, and non-overlap on one line. Keep the first two promises
+        // and move this row's label below the equation.
+        vPos += math.max(rowHeight, 0.7 * arrayskip);
+        if (!dry) {
+          (row.parentData! as EqnArrayParentData).offset =
+              Offset(hPos, vPos - rowHeight);
+        }
+        vPos += math.max(rowDepth, 0.3 * arrayskip);
+        if (!dry) {
+          (tag.parentData! as EqnArrayParentData).offset =
+              Offset(tagHPos, vPos);
+        }
+        vPos += tagSize.height;
+      }
+
+      vPos += jotSize + rowSpacings[index];
+      if (!dry) hlinePos.add(vPos);
+      vPos +=
+          hlines[index + 1] != MatrixSeparatorStyle.none ? ruleThickness : 0.0;
     }
 
-    if (!dry) {
-      this.width = width;
-    }
-
-    return Size(width, vPos);
+    if (!dry) width = layoutWidth;
+    return constraints.constrain(Size(layoutWidth, vPos));
   }
 
   @override
@@ -230,11 +444,12 @@ class RenderEqnArray extends RenderBox
   @override
   void paint(PaintingContext context, Offset offset) {
     defaultPaint(context, offset);
-    for (var i = 0; i < hlines.length; i++) {
-      if (hlines[i] != MatrixSeparatorStyle.none) {
+    for (var index = 0; index < hlines.length; index++) {
+      if (hlines[index] != MatrixSeparatorStyle.none) {
+        final y = hlinePos[index] + ruleThickness / 2;
         context.canvas.drawLine(
-          Offset(0, hlinePos[i] + ruleThickness / 2),
-          Offset(width, hlinePos[i] + ruleThickness / 2),
+          offset + Offset(0, y),
+          offset + Offset(width, y),
           Paint()..strokeWidth = ruleThickness,
         );
       }

--- a/dependencies/flutter_math_fork/lib/src/render/layout/line.dart
+++ b/dependencies/flutter_math_fork/lib/src/render/layout/line.dart
@@ -19,9 +19,11 @@ class LineParentData extends ContainerBoxParentData<RenderBox> {
 
   bool alignerOrSpacer = false;
 
+  bool useParentWidthConstraints = false;
+
   @override
   String toString() =>
-      '${super.toString()}; canBreakBefore = $canBreakBefore; customSize = ${customCrossSize != null}; trailingMargin = $trailingMargin; alignerOrSpacer = $alignerOrSpacer';
+      '${super.toString()}; canBreakBefore = $canBreakBefore; customSize = ${customCrossSize != null}; trailingMargin = $trailingMargin; alignerOrSpacer = $alignerOrSpacer; useParentWidthConstraints = $useParentWidthConstraints';
 }
 
 class LineElement extends ParentDataWidget<LineParentData> {
@@ -29,6 +31,7 @@ class LineElement extends ParentDataWidget<LineParentData> {
   final BoxConstraints Function(double height, double depth)? customCrossSize;
   final double trailingMargin;
   final bool alignerOrSpacer;
+  final bool useParentWidthConstraints;
 
   const LineElement({
     Key? key,
@@ -36,6 +39,7 @@ class LineElement extends ParentDataWidget<LineParentData> {
     this.customCrossSize,
     this.trailingMargin = 0.0,
     this.alignerOrSpacer = false,
+    this.useParentWidthConstraints = false,
     required Widget child,
   }) : super(key: key, child: child);
 
@@ -65,6 +69,11 @@ class LineElement extends ParentDataWidget<LineParentData> {
       needsLayout = true;
     }
 
+    if (parentData.useParentWidthConstraints != useParentWidthConstraints) {
+      parentData.useParentWidthConstraints = useParentWidthConstraints;
+      needsLayout = true;
+    }
+
     if (needsLayout) {
       final targetParent = renderObject.parent;
       if (targetParent is RenderObject) targetParent.markNeedsLayout();
@@ -81,6 +90,9 @@ class LineElement extends ParentDataWidget<LineParentData> {
     properties.add(DoubleProperty('trailingMargin', trailingMargin));
     properties.add(FlagProperty('alignerOrSpacer',
         value: alignerOrSpacer, ifTrue: 'is a alignment symbol'));
+    properties.add(FlagProperty('useParentWidthConstraints',
+        value: useParentWidthConstraints,
+        ifTrue: 'uses the parent line width constraints'));
   }
 
   @override
@@ -340,7 +352,14 @@ class RenderLine extends RenderBox
       } else if (childParentData.alignerOrSpacer) {
         alignerAndSpacers.add(child);
       } else {
-        final childSize = child.getLayoutSize(infiniteConstraint, dry: dry);
+        final childConstraints = childParentData.useParentWidthConstraints &&
+                constraints.hasBoundedWidth
+            ? BoxConstraints(
+                minWidth: constraints.minWidth,
+                maxWidth: constraints.maxWidth,
+              )
+            : infiniteConstraint;
+        final childSize = child.getLayoutSize(childConstraints, dry: dry);
         sizeMap[child] = childSize;
         final distance = dry ? 0.0 : child.getDistanceToBaseline(textBaseline)!;
         maxHeightAboveBaseline = math.max(maxHeightAboveBaseline, distance);

--- a/dependencies/flutter_math_fork/test/ams_environments_test.dart
+++ b/dependencies/flutter_math_fork/test/ams_environments_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_math_fork/ast.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/encoder/tex/encoder.dart';
 import 'package:flutter_math_fork/src/parser/tex/parser.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -75,8 +76,13 @@ void main() {
       ]) {
         final result = parse(source);
         expect(symbols(result), 'a=bc=d(A)');
-        final array = descendants(result).whereType<EquationArrayNode>().single;
-        expect(array.body.map(symbols), ['a=b', 'c=d']);
+        final arrays = descendants(result).whereType<EquationArrayNode>();
+        final tagged = arrays.singleWhere((array) => array.displayLayout);
+        final aligned = arrays.singleWhere((array) => !array.displayLayout);
+        expect(tagged.tags.map((tag) => tag == null ? null : symbols(tag)), [
+          '(A)',
+        ]);
+        expect(aligned.body.map(symbols), ['a=b', 'c=d']);
       }
     });
 
@@ -102,6 +108,29 @@ void main() {
       expect(symbols(parse(r'x\tag{\textbf{A} $n+1$}')), 'x(A n+1)');
     });
 
+    test('encoding retains equation bodies and visible labels', () {
+      final regular = parse(r'x\tag{A}').encodeTeX(
+        conf: TexEncodeConf.mathParamConf,
+      );
+      final literal = parse(r'x\tag*{A}').encodeTeX(
+        conf: TexEncodeConf.mathParamConf,
+      );
+      final multiline = parse(
+        r'\begin{align}a=b\tag{A}\\c=d\tag*{B}\end{align}',
+      ).encodeTeX(conf: TexEncodeConf.mathParamConf);
+
+      expect(regular, contains('x'));
+      expect(regular, contains('(A)'));
+      expect(literal, contains('x'));
+      expect(literal, contains('A'));
+      expect(literal, isNot(contains('(A)')));
+      expect(multiline, contains('a=b'));
+      expect(multiline, contains('(A)'));
+      expect(multiline, contains(r'\\'));
+      expect(multiline, contains('c=d'));
+      expect(multiline, contains('B'));
+    });
+
     test('each alignment row owns its tag', () {
       for (final name in ['align', 'align*', 'alignat', 'alignat*', 'gather']) {
         final columns = name.startsWith('alignat') ? '{1}' : '';
@@ -113,7 +142,12 @@ void main() {
             name +
             '}');
         final array = descendants(result).whereType<EquationArrayNode>().single;
-        expect(array.body.map(symbols), ['a=b(A)', 'c=dB', 'e=f']);
+        expect(array.body.map(symbols), ['a=b', 'c=d', 'e=f']);
+        expect(array.tags.map((tag) => tag == null ? null : symbols(tag)), [
+          '(A)',
+          'B',
+          null,
+        ]);
       }
     });
 
@@ -133,7 +167,9 @@ void main() {
     test('allows whitespace before the optional star', () {
       final result = parse(r'\operatorname *{arg\,max}_x f(x)');
       expect(symbols(result), 'argmaxxf(x)');
-      expect(descendants(result).whereType<UnderNode>(), hasLength(1));
+      final operator = descendants(result).whereType<OperatorNameNode>().single;
+      expect(operator.limitsInDisplayStyle, isTrue);
+      expect(operator.lowerLimit, isNotNull);
     });
 
     test('leaves right delimiters and environment endings for their owner', () {
@@ -146,20 +182,19 @@ void main() {
       }
     });
 
-    test('starred names put limits below in display mode only', () {
+    test('starred names retain their default and explicit limit policy', () {
       const source = r'\operatorname*{arg\,max}_{x}f(x)';
-      expect(descendants(parse(source)).whereType<UnderNode>(), hasLength(1));
-      expect(
-          descendants(parse(source, displayMode: false)).whereType<UnderNode>(),
-          isEmpty);
-      expect(
-          descendants(parse(source, displayMode: false))
-              .whereType<MultiscriptsNode>(),
-          hasLength(1));
-      expect(
-          descendants(parse(r'\operatorname*{arg\,max}\nolimits_x f(x)'))
-              .whereType<UnderNode>(),
-          isEmpty);
+      final starred =
+          descendants(parse(source)).whereType<OperatorNameNode>().single;
+      expect(starred.limitsInDisplayStyle, isTrue);
+      expect(starred.limits, isNull);
+      expect(starred.lowerLimit, isNotNull);
+
+      final noLimits = descendants(
+        parse(r'\operatorname*{arg\,max}\nolimits_x f(x)'),
+      ).whereType<OperatorNameNode>().single;
+      expect(noLimits.limitsInDisplayStyle, isTrue);
+      expect(noLimits.limits, isFalse);
     });
   });
 

--- a/dependencies/flutter_math_fork/test/ams_environments_test.dart
+++ b/dependencies/flutter_math_fork/test/ams_environments_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_math_fork/ast.dart';
+import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/parser/tex/parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EquationRowNode parse(String source, {bool displayMode = true}) =>
+    TexParser(source, TexParserSettings(displayMode: displayMode)).parse();
+
+Iterable<GreenNode> descendants(GreenNode node) sync* {
+  yield node;
+  for (final child in node.children) {
+    if (child != null) yield* descendants(child);
+  }
+}
+
+String symbols(GreenNode node) => descendants(node)
+    .whereType<SymbolNode>()
+    .map((symbol) => symbol.symbol)
+    .join();
+
+void main() {
+  group('AMS environments', () {
+    for (final name in ['equation', 'equation*']) {
+      test('$name preserves the equation body', () {
+        final result =
+            parse(r'\begin{' + name + r'}a^2+b^2=c^2\end{' + name + '}');
+        expect(symbols(result), 'a2+b2=c2');
+      });
+    }
+
+    for (final name in ['align', 'align*', 'aligned', 'split']) {
+      test('$name preserves alignment and omits a trailing empty row', () {
+        final result =
+            parse(r'\begin{' + name + r'}a&=b\\c&=d\\\end{' + name + '}');
+        final array = descendants(result).whereType<EquationArrayNode>().single;
+        expect(array.body.map(symbols), ['a=b', 'c=d']);
+        expect(
+            descendants(array)
+                .whereType<SpaceNode>()
+                .where((space) => space.alignerOrSpacer),
+            isNotEmpty);
+      });
+    }
+
+    for (final name in ['gather', 'gather*', 'gathered']) {
+      test('$name keeps independent centered rows', () {
+        final result =
+            parse(r'\begin{' + name + r'}a=b\\c=d\end{' + name + '}');
+        final array = descendants(result).whereType<EquationArrayNode>().single;
+        expect(array.body.map(symbols), ['a=b', 'c=d']);
+        expect(
+            descendants(array)
+                .whereType<SpaceNode>()
+                .where((space) => space.alignerOrSpacer),
+            isEmpty);
+      });
+    }
+
+    for (final name in ['alignat', 'alignat*', 'alignedat']) {
+      test('$name validates its column count', () {
+        expect(() => parse(r'\begin{' + name + r'}{1}a&=b\end{' + name + '}'),
+            returnsNormally);
+        expect(() => parse(r'\begin{' + name + r'}{1}a&b&c\end{' + name + '}'),
+            throwsA(isA<ParseException>()));
+      });
+    }
+
+    test('nested aligned environment and outer tag stay together', () {
+      for (final source in [
+        r'\begin{equation}\begin{aligned}'
+            r'a&=b\\c&=d\end{aligned}\tag{A}\end{equation}',
+        r'\begin{equation}\tag{A}\begin{aligned}'
+            r'a&=b\\c&=d\\\end{aligned}\end{equation}',
+      ]) {
+        final result = parse(source);
+        expect(symbols(result), 'a=bc=d(A)');
+        final array = descendants(result).whereType<EquationArrayNode>().single;
+        expect(array.body.map(symbols), ['a=b', 'c=d']);
+      }
+    });
+
+    test('rejects mismatched environments and invalid columns', () {
+      for (final source in [
+        r'\begin{equation}x\end{align}',
+        r'\begin{gather}a&b\end{gather}',
+        r'\begin{split}a&b&c\end{split}',
+      ]) {
+        expect(() => parse(source), throwsA(isA<ParseException>()));
+      }
+    });
+  });
+
+  group('explicit equation labels', () {
+    test('tag is placed after the equation regardless of source position', () {
+      expect(symbols(parse(r'\tag{A}x+y')), 'x+y(A)');
+      expect(symbols(parse(r'x+y\tag{A}')), 'x+y(A)');
+      expect(symbols(parse(r'x+y\tag*{A}')), 'x+yA');
+    });
+
+    test('tag contents retain text formatting and inline math', () {
+      expect(symbols(parse(r'x\tag{\textbf{A} $n+1$}')), 'x(A n+1)');
+    });
+
+    test('each alignment row owns its tag', () {
+      for (final name in ['align', 'align*', 'alignat', 'alignat*', 'gather']) {
+        final columns = name.startsWith('alignat') ? '{1}' : '';
+        final result = parse(r'\begin{' +
+            name +
+            '}' +
+            columns +
+            r'a=b\tag{A}\\c=d\tag*{B}\\e=f\end{' +
+            name +
+            '}');
+        final array = descendants(result).whereType<EquationArrayNode>().single;
+        expect(array.body.map(symbols), ['a=b(A)', 'c=dB', 'e=f']);
+      }
+    });
+
+    test('rejects inline and duplicate labels', () {
+      expect(() => parse(r'x\tag{1}', displayMode: false),
+          throwsA(isA<ParseException>()));
+      for (final source in [
+        r'x\tag{1}\tag{2}',
+        r'\begin{align}a\tag{1}\tag{2}\\b\end{align}',
+      ]) {
+        expect(() => parse(source), throwsA(isA<ParseException>()));
+      }
+    });
+  });
+
+  group('operator names', () {
+    test('allows whitespace before the optional star', () {
+      final result = parse(r'\operatorname *{arg\,max}_x f(x)');
+      expect(symbols(result), 'argmaxxf(x)');
+      expect(descendants(result).whereType<UnderNode>(), hasLength(1));
+    });
+
+    test('leaves right delimiters and environment endings for their owner', () {
+      for (final source in [
+        r'\left(\operatorname{Var}\right)',
+        r'\begin{equation}\operatorname{Var}\end{equation}',
+        r'\begin{aligned}\operatorname{Var}&=x\\y&=\operatorname{Var}\end{aligned}',
+      ]) {
+        expect(() => parse(source), returnsNormally);
+      }
+    });
+
+    test('starred names put limits below in display mode only', () {
+      const source = r'\operatorname*{arg\,max}_{x}f(x)';
+      expect(descendants(parse(source)).whereType<UnderNode>(), hasLength(1));
+      expect(
+          descendants(parse(source, displayMode: false)).whereType<UnderNode>(),
+          isEmpty);
+      expect(
+          descendants(parse(source, displayMode: false))
+              .whereType<MultiscriptsNode>(),
+          hasLength(1));
+      expect(
+          descendants(parse(r'\operatorname*{arg\,max}\nolimits_x f(x)'))
+              .whereType<UnderNode>(),
+          isEmpty);
+    });
+  });
+
+  testWidgets(
+      'renders environments, labels and nested operators without fallback',
+      (tester) async {
+    for (final source in [
+      r'\begin{equation}a^2+b^2=c^2\tag{1}\end{equation}',
+      r'\begin{align}a&=b\tag{A}\\c&=d\tag*{B}\end{align}',
+      r'\begin{gather}a=b\\c=d\end{gather}',
+      r'\operatorname{Var}\left(\frac{1}{n}\sum_{i=1}^n a_i X_i\right)',
+      r'\operatorname*{arg\,max}_{x}\left(f(x)\right)',
+    ]) {
+      await tester.pumpWidget(MaterialApp(
+        home: Center(
+          child: Math.tex(source,
+              settings: const TexParserSettings(displayMode: true),
+              onErrorFallback: (error) => throw error),
+        ),
+      ));
+      expect(tester.takeException(), isNull, reason: source);
+    }
+  });
+}

--- a/dependencies/flutter_math_fork/test/ams_environments_test.dart
+++ b/dependencies/flutter_math_fork/test/ams_environments_test.dart
@@ -108,7 +108,7 @@ void main() {
       expect(symbols(parse(r'x\tag{\textbf{A} $n+1$}')), 'x(A n+1)');
     });
 
-    test('encoding retains equation bodies and visible labels', () {
+    test('encoding retains tag commands and their environments', () {
       final regular = parse(r'x\tag{A}').encodeTeX(
         conf: TexEncodeConf.mathParamConf,
       );
@@ -119,16 +119,12 @@ void main() {
         r'\begin{align}a=b\tag{A}\\c=d\tag*{B}\end{align}',
       ).encodeTeX(conf: TexEncodeConf.mathParamConf);
 
-      expect(regular, contains('x'));
-      expect(regular, contains('(A)'));
-      expect(literal, contains('x'));
-      expect(literal, contains('A'));
-      expect(literal, isNot(contains('(A)')));
-      expect(multiline, contains('a=b'));
-      expect(multiline, contains('(A)'));
-      expect(multiline, contains(r'\\'));
-      expect(multiline, contains('c=d'));
-      expect(multiline, contains('B'));
+      expect(regular, r'x\tag{A}');
+      expect(literal, r'x\tag*{A}');
+      expect(
+        multiline,
+        r'\begin{align}a=b\tag{A}\\c=d\tag*{B}\end{align}',
+      );
     });
 
     test('each alignment row owns its tag', () {

--- a/dependencies/flutter_math_fork/test/equation_tag_encoding_test.dart
+++ b/dependencies/flutter_math_fork/test/equation_tag_encoding_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_math_fork/ast.dart';
+import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/encoder/tex/encoder.dart';
+import 'package:flutter_math_fork/src/parser/tex/parser.dart';
+import 'package:flutter_math_fork/src/widgets/controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+EquationRowNode _parse(String source) => TexParser(
+      source,
+      const TexParserSettings(displayMode: true),
+    ).parse();
+
+Iterable<GreenNode> _descendants(GreenNode node) sync* {
+  yield node;
+  for (final child in node.children) {
+    if (child != null) yield* _descendants(child);
+  }
+}
+
+String _symbols(GreenNode node) => _descendants(node)
+    .whereType<SymbolNode>()
+    .map((symbol) => symbol.symbol)
+    .join();
+
+Object? _nodeSemantics(GreenNode node) {
+  if (node is SymbolNode) {
+    return {
+      'type': node.runtimeType,
+      'symbol': node.symbol,
+      'mode': node.mode,
+      'atomType': node.overrideAtomType,
+      'font': node.overrideFont,
+    };
+  }
+  if (node is StyleNode) {
+    final diff = node.optionsDiff;
+    return {
+      'type': node.runtimeType,
+      'style': diff.style,
+      'size': diff.size,
+      'color': diff.color,
+      'textFont': diff.textFontOptions,
+      'mathFont': diff.mathFontOptions,
+      'children': node.children.map(_nodeSemantics).toList(),
+    };
+  }
+  return {
+    'type': node.runtimeType,
+    'children':
+        node.children.whereType<GreenNode>().map(_nodeSemantics).toList(),
+  };
+}
+
+List<Object?> _arraySemantics(GreenNode root) => _descendants(root)
+    .whereType<EquationArrayNode>()
+    .map<Object?>((array) => {
+          'environment': array.environment,
+          'alignmentColumns': array.alignmentColumns,
+          'displayLayout': array.displayLayout,
+          'body': array.body.map(_symbols).toList(),
+          'tags': array.tags.map((tag) {
+            if (tag == null) return null;
+            expect(tag, isA<EquationTagNode>());
+            final semanticTag = tag as EquationTagNode;
+            return {
+              'literal': semanticTag.literal,
+              'body': _nodeSemantics(semanticTag.body),
+              'display': _nodeSemantics(semanticTag),
+            };
+          }).toList(),
+        })
+    .toList();
+
+String _encode(GreenNode node) =>
+    node.encodeTeX(conf: TexEncodeConf.mathParamConf);
+
+void main() {
+  test('encodes tags and their equation environments exactly', () {
+    const sources = [
+      r'x\tag{A}',
+      r'x\tag*{A}',
+      r'\begin{equation}x+y\tag{1}\end{equation}',
+      r'\begin{equation}\begin{aligned}a&=b\\c&=d\end{aligned}'
+          r'\tag{A}\end{equation}',
+      r'\begin{align}a&=b\tag{A}\\c&=d\tag*{B}\end{align}',
+      r'\begin{gather}a=b\\c=d\tag*{B}\end{gather}',
+      r'\begin{alignat}{1}a&=b\tag{A}\\c&=d\end{alignat}',
+    ];
+
+    for (final source in sources) {
+      expect(_encode(_parse(source)), source, reason: source);
+    }
+  });
+
+  test('encoded tags parse back to equivalent semantic arrays', () {
+    const sources = [
+      r'x\tag{A}',
+      r'x\tag*{A}',
+      r'\begin{equation}\begin{aligned}a&=b\\c&=d\end{aligned}'
+          r'\tag{A}\end{equation}',
+      r'\begin{align}a&=b\tag{A}\\c&=d\tag*{B}\end{align}',
+      r'\begin{gather}a=b\\c=d\tag*{B}\end{gather}',
+      r'x\tag{\textbf{A} $n+1$}',
+      r'x\tag{\textbf{$n+1$}}',
+      r'x\tag{\textit{a $n+1$ b}}',
+      r'x\tag{\textcolor{red}{$n$}}',
+    ];
+
+    for (final source in sources) {
+      final parsed = _parse(source);
+      final encoded = _encode(parsed);
+      final reparsed = _parse(encoded);
+      expect(
+        _arraySemantics(reparsed),
+        _arraySemantics(parsed),
+        reason: '$source -> $encoded',
+      );
+    }
+  });
+
+  test('recursively restores nested text and math mode boundaries', () {
+    const cases = {
+      r'x\tag{\textbf{$n+1$}}': r'x\tag{\textbf{\(n+1\)}}',
+      r'x\tag{\textit{a $n+1$ b}}': r'x\tag{\textit{a \(n+1\) b}}',
+      r'x\tag{\textcolor{red}{$n$}}': r'x\tag{\textcolor{#ff0000}{\(n\)}}',
+    };
+
+    for (final entry in cases.entries) {
+      expect(_encode(_parse(entry.key)), entry.value, reason: entry.key);
+    }
+  });
+
+  test('select-all copy retains tag commands and alignment semantics', () {
+    const source = r'\begin{align}a&=b\tag{A}\\c&=d\tag*{B}\end{align}';
+    final root = _parse(source);
+    final controller = MathController(
+      ast: SyntaxTree(greenRoot: root),
+      selection: TextSelection(
+        baseOffset: 0,
+        extentOffset: root.capturedCursor - 1,
+      ),
+    );
+    addTearDown(controller.dispose);
+
+    final copied = controller.selectedNodes.encodeTex();
+    expect(copied, source);
+    expect(
+      _arraySemantics(_parse(copied)),
+      _arraySemantics(root),
+    );
+  });
+
+  test('structural tag updates change the encoded semantic body', () {
+    final root = _parse(r'x\tag{A}');
+    final array = _descendants(root).whereType<EquationArrayNode>().single;
+    final tag = array.tags.single! as EquationTagNode;
+    final outerStyle = tag.children.single as StyleNode;
+    final updatedStyle = outerStyle.copyWith(
+      children: outerStyle.children
+          .map(
+            (child) => child is SymbolNode && child.symbol == 'A'
+                ? SymbolNode(symbol: 'B', mode: Mode.text)
+                : child,
+          )
+          .toList(growable: false),
+    );
+    final updatedTag = tag.updateChildren([updatedStyle]);
+    final updatedArray = array.updateChildren([
+      array.body.single,
+      updatedTag,
+    ]);
+
+    expect(_symbols(updatedTag.body), 'B');
+    expect(updatedTag.toJson()['body'], updatedTag.body.toJson());
+    expect(_encode(updatedArray), r'x\tag{B}');
+
+    final copiedTag = tag.copyWith(children: [updatedStyle]);
+    expect(copiedTag, isA<EquationTagNode>());
+    expect(copiedTag.literal, isFalse);
+    expect(_encode(copiedTag), r'\tag{B}');
+
+    final manuallyUpdatedTag = updatedTag.updateChildren([
+      SymbolNode(symbol: 'C', mode: Mode.text),
+    ]);
+    final manuallyUpdatedArray = array.updateChildren([
+      array.body.single,
+      manuallyUpdatedTag,
+    ]);
+    expect(_symbols(manuallyUpdatedTag.body), 'C');
+    expect(_encode(manuallyUpdatedArray), r'x\tag{C}');
+
+    final customStyle = StyleNode(
+      optionsDiff: const OptionsDiff(
+        textFontOptions: PartialFontOptions(fontWeight: FontWeight.bold),
+      ),
+      children: [SymbolNode(symbol: 'D', mode: Mode.text)],
+    );
+    final styledLiteralTag = EquationTagNode(
+      literal: true,
+      displayBody: EquationRowNode(children: [customStyle]),
+    );
+    expect(styledLiteralTag.body.children, [customStyle]);
+    expect(_encode(styledLiteralTag), r'\tag*{\textbf{D}}');
+  });
+}

--- a/dependencies/flutter_math_fork/test/equation_tag_layout_test.dart
+++ b/dependencies/flutter_math_fork/test/equation_tag_layout_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_math_fork/ast.dart';
+import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/render/layout/eqn_array.dart';
+import 'package:flutter_math_fork/src/render/layout/line.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EquationRowNode _row(String text, {Mode mode = Mode.math}) => EquationRowNode(
+      children: [
+        for (final rune in text.runes)
+          SymbolNode(symbol: String.fromCharCode(rune), mode: mode),
+      ],
+    );
+
+Widget _arrayHarness({
+  required double width,
+  required List<Widget> rows,
+  required List<Widget?> tags,
+  TextDirection textDirection = TextDirection.ltr,
+}) =>
+    MaterialApp(
+      home: Directionality(
+        textDirection: textDirection,
+        child: Center(
+          child: SizedBox(
+            key: const ValueKey('display'),
+            width: width,
+            child: DefaultTextStyle(
+              style: const TextStyle(fontSize: 16, color: Colors.black),
+              child: EqnArray(
+                ruleThickness: 1,
+                jotSize: 0,
+                arrayskip: 12,
+                tagGap: 16,
+                expandToMaxWidth: true,
+                hlines: List.filled(
+                  rows.length + 1,
+                  MatrixSeparatorStyle.none,
+                ),
+                rowSpacings: List.filled(rows.length, 0),
+                rows: rows,
+                tags: tags,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+Rect _rect(WidgetTester tester, Finder finder) => tester.getRect(finder);
+
+Line _alignedRow({
+  required String left,
+  required String right,
+  required Key leftKey,
+  required Key rightKey,
+}) =>
+    Line(
+      children: [
+        Text(left, key: leftKey),
+        const LineElement(
+          alignerOrSpacer: true,
+          child: SizedBox.shrink(),
+        ),
+        Text(right, key: rightKey),
+      ],
+    );
+
+void main() {
+  test('equation arrays retain parallel body and tag slots', () {
+    final firstBody = _row('a');
+    final firstTag = _row('(A)', mode: Mode.text);
+    final secondBody = _row('b');
+    final array = EquationArrayNode(
+      body: [firstBody, secondBody],
+      tags: [firstTag, null],
+      displayLayout: true,
+    );
+
+    expect(array.children, [firstBody, firstTag, secondBody, null]);
+    expect(array.toJson()['tags'], isNotNull);
+    expect(array.copyWith().tags, [firstTag, null]);
+
+    final replacementTag = _row('B', mode: Mode.text);
+    final updated = array.updateChildren([
+      firstBody,
+      replacementTag,
+      secondBody,
+      null,
+    ]);
+    expect(updated.body, [firstBody, secondBody]);
+    expect(updated.tags, [replacementTag, null]);
+  });
+
+  for (final direction in TextDirection.values) {
+    testWidgets(
+        'centers a single body and keeps its tag at the physical right in $direction',
+        (tester) async {
+      const bodyKey = ValueKey('body');
+      const tagKey = ValueKey('tag');
+      await tester.pumpWidget(_arrayHarness(
+        width: 360,
+        textDirection: direction,
+        rows: const [Text('x + y', key: bodyKey)],
+        tags: const [Text('(A)', key: tagKey)],
+      ));
+
+      final display = _rect(tester, find.byKey(const ValueKey('display')));
+      final body = _rect(tester, find.byKey(bodyKey));
+      final tag = _rect(tester, find.byKey(tagKey));
+
+      expect(body.center.dx, closeTo(display.center.dx, 0.01));
+      expect(tag.right, closeTo(display.right, 0.01));
+      expect(body.top, closeTo(tag.top, 0.01));
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('shares body alignment columns without including row tags',
+      (tester) async {
+    const leftOneKey = ValueKey('left-one');
+    const rightOneKey = ValueKey('right-one');
+    const leftTwoKey = ValueKey('left-two');
+    const rightTwoKey = ValueKey('right-two');
+    const tagOneKey = ValueKey('tag-one');
+    const tagTwoKey = ValueKey('tag-two');
+    await tester.pumpWidget(_arrayHarness(
+      width: 420,
+      rows: [
+        _alignedRow(
+          left: 'LLLL',
+          right: 'r',
+          leftKey: leftOneKey,
+          rightKey: rightOneKey,
+        ),
+        _alignedRow(
+          left: 'l',
+          right: 'RRRR',
+          leftKey: leftTwoKey,
+          rightKey: rightTwoKey,
+        ),
+      ],
+      tags: const [
+        Text('(A)', key: tagOneKey),
+        Text('LONG', key: tagTwoKey),
+      ],
+    ));
+
+    final display = _rect(tester, find.byKey(const ValueKey('display')));
+    final bodyLeft = _rect(tester, find.byKey(leftOneKey)).left;
+    final bodyRight = _rect(tester, find.byKey(rightTwoKey)).right;
+    expect((bodyLeft + bodyRight) / 2, closeTo(display.center.dx, 0.01));
+    expect(
+      _rect(tester, find.byKey(rightOneKey)).left,
+      closeTo(_rect(tester, find.byKey(rightTwoKey)).left, 0.01),
+    );
+    expect(
+      _rect(tester, find.byKey(tagOneKey)).right,
+      closeTo(display.right, 0.01),
+    );
+    expect(
+      _rect(tester, find.byKey(tagTwoKey)).right,
+      closeTo(display.right, 0.01),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('moves a colliding tag below a centered body at tight widths',
+      (tester) async {
+    const bodyKey = ValueKey('body');
+    const tagKey = ValueKey('tag');
+    await tester.pumpWidget(_arrayHarness(
+      width: 80,
+      rows: const [Text('a very wide equation', key: bodyKey)],
+      tags: const [Text('(wide tag)', key: tagKey)],
+    ));
+
+    final display = _rect(tester, find.byKey(const ValueKey('display')));
+    final body = _rect(tester, find.byKey(bodyKey));
+    final tag = _rect(tester, find.byKey(tagKey));
+    expect(body.center.dx, closeTo(display.center.dx, 0.01));
+    expect(tag.right, closeTo(display.right, 0.01));
+    expect(tag.top, greaterThanOrEqualTo(body.bottom));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('root equation rows pass display constraints through',
+      (tester) async {
+    final array = EquationArrayNode(
+      body: [_row('x+y')],
+      tags: [_row('(1)', mode: Mode.text)],
+      displayLayout: true,
+    );
+    final ast = SyntaxTree(
+      greenRoot: EquationRowNode(children: [array]),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Center(
+        child: SizedBox(
+          width: 320,
+          child: Math(ast: ast),
+        ),
+      ),
+    ));
+
+    expect(tester.getSize(find.byType(EqnArray)).width, closeTo(320, 0.01));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('selectable display arrays retain the root editable line',
+      (tester) async {
+    final array = EquationArrayNode(
+      body: [_row('x')],
+      tags: [_row('(1)', mode: Mode.text)],
+      displayLayout: true,
+    );
+    final ast = SyntaxTree(
+      greenRoot: EquationRowNode(children: [array]),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Center(child: SelectableMath(ast: ast)),
+    ));
+    await tester.tap(find.byType(SelectableMath));
+    await tester.pump();
+
+    expect(ast.greenRoot.key, isNotNull);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/dependencies/flutter_math_fork/test/equation_tag_layout_test.dart
+++ b/dependencies/flutter_math_fork/test/equation_tag_layout_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_math_fork/ast.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/parser/tex/parser.dart';
 import 'package:flutter_math_fork/src/render/layout/eqn_array.dart';
 import 'package:flutter_math_fork/src/render/layout/line.dart';
+import 'package:flutter_math_fork/src/render/layout/line_editable.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 EquationRowNode _row(String text, {Mode mode = Mode.math}) => EquationRowNode(
@@ -208,24 +210,52 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('selectable display arrays retain the root editable line',
+  testWidgets('selectable display arrays use the parent display width',
       (tester) async {
-    final array = EquationArrayNode(
-      body: [_row('x')],
-      tags: [_row('(1)', mode: Mode.text)],
-      displayLayout: true,
-    );
     final ast = SyntaxTree(
-      greenRoot: EquationRowNode(children: [array]),
+      greenRoot: TexParser(
+        r'x\tag{1}',
+        const TexParserSettings(displayMode: true),
+      ).parse(),
     );
 
     await tester.pumpWidget(MaterialApp(
-      home: Center(child: SelectableMath(ast: ast)),
+      home: Center(
+        child: SizedBox(
+          width: 320,
+          child: SelectableMath(ast: ast),
+        ),
+      ),
     ));
     await tester.tap(find.byType(SelectableMath));
     await tester.pump();
 
     expect(ast.greenRoot.key, isNotNull);
+    final arrayRenderObject =
+        tester.renderObject<RenderEqnArray>(find.byType(EqnArray));
+    final body = arrayRenderObject.firstChild!;
+    final bodyParentData = body.parentData! as EqnArrayParentData;
+    final tag = bodyParentData.nextSibling!;
+    final tagParentData = tag.parentData! as EqnArrayParentData;
+    final editableLine = ast.greenRoot.key!.currentContext!.findRenderObject()!
+        as RenderEditableLine;
+
+    expect(arrayRenderObject.constraints.minWidth, closeTo(320, 0.01));
+    expect(arrayRenderObject.constraints.maxWidth, closeTo(320, 0.01));
+    expect(arrayRenderObject.size.width, closeTo(320, 0.01));
+    expect(
+      bodyParentData.offset.dx + body.size.width / 2,
+      closeTo(arrayRenderObject.size.width / 2, 0.01),
+    );
+    expect(
+      tagParentData.offset.dx + tag.size.width,
+      closeTo(arrayRenderObject.size.width, 0.01),
+    );
+    expect(
+      ast.greenRoot.key!.currentContext!.findRenderObject(),
+      same(editableLine),
+    );
+    expect(editableLine.toStringShort(), isNot(contains('OVERFLOWING')));
     expect(tester.takeException(), isNull);
   });
 }

--- a/dependencies/flutter_math_fork/test/operator_name_layout_test.dart
+++ b/dependencies/flutter_math_fork/test/operator_name_layout_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_math_fork/ast.dart';
+import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/encoder/tex/encoder.dart';
+import 'package:flutter_math_fork/src/parser/tex/parser.dart';
+import 'package:flutter_math_fork/src/render/layout/multiscripts.dart';
+import 'package:flutter_math_fork/src/render/layout/vlist.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EquationRowNode _parse(
+  String source, {
+  bool displayMode = false,
+}) =>
+    TexParser(
+      source,
+      TexParserSettings(displayMode: displayMode),
+    ).parse();
+
+Iterable<GreenNode> _descendants(GreenNode node) sync* {
+  yield node;
+  for (final child in node.children) {
+    if (child != null) yield* _descendants(child);
+  }
+}
+
+Future<void> _pumpOperator(
+  WidgetTester tester,
+  String source, {
+  MathStyle style = MathStyle.display,
+  bool parserDisplayMode = false,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Center(
+        child: Math.tex(
+          source,
+          mathStyle: style,
+          settings: TexParserSettings(displayMode: parserDisplayMode),
+          onErrorFallback: (error) => throw error,
+        ),
+      ),
+    ),
+  );
+  expect(tester.takeException(), isNull);
+}
+
+void _expectLimitsLayout() {
+  expect(find.byType(VList), findsOneWidget);
+  expect(find.byType(Multiscripts), findsNothing);
+}
+
+void _expectScriptsLayout() {
+  expect(find.byType(Multiscripts), findsOneWidget);
+  expect(find.byType(VList), findsNothing);
+}
+
+void main() {
+  test(r'operator argument lookahead leaves \middle for enclosing \left', () {
+    final result = _parse(
+      r'\left\{\operatorname{dom}\middle|x\right\}',
+      displayMode: true,
+    );
+    final leftRight = _descendants(result).whereType<LeftRightNode>().single;
+
+    expect(leftRight.middle, ['|']);
+    expect(leftRight.body, hasLength(2));
+  });
+
+  group(r'\operatorname* script layout', () {
+    const source = r'\operatorname*{argmax}_{x}';
+
+    testWidgets('uses the widget MathStyle instead of parser displayMode',
+        (tester) async {
+      await _pumpOperator(tester, source);
+      _expectLimitsLayout();
+
+      await _pumpOperator(
+        tester,
+        source,
+        style: MathStyle.text,
+        parserDisplayMode: true,
+      );
+      _expectScriptsLayout();
+    });
+
+    testWidgets('honors local style overrides', (tester) async {
+      await _pumpOperator(
+        tester,
+        r'\textstyle\operatorname*{argmax}_{x}',
+      );
+      _expectScriptsLayout();
+
+      await _pumpOperator(
+        tester,
+        r'\displaystyle\operatorname*{argmax}_{x}',
+        style: MathStyle.text,
+      );
+      _expectLimitsLayout();
+    });
+
+    testWidgets(r'explicit \limits and \nolimits take precedence',
+        (tester) async {
+      await _pumpOperator(
+        tester,
+        r'\operatorname*{argmax}\limits_{x}',
+        style: MathStyle.text,
+      );
+      _expectLimitsLayout();
+
+      await _pumpOperator(
+        tester,
+        r'\operatorname*{argmax}\nolimits_{x}',
+      );
+      _expectScriptsLayout();
+    });
+  });
+
+  test('TeX encoding preserves starred operator scripts and limit controls',
+      () {
+    const source = r'\operatorname*{argmax}\nolimits_{x}f';
+    final encoded = _parse(source).encodeTeX(
+      conf: TexEncodeConf.mathParamConf,
+    );
+
+    expect(encoded, r'\operatorname*{argmax}\nolimits_{x}{f}');
+    final operator =
+        _descendants(_parse(encoded)).whereType<OperatorNameNode>().single;
+    expect(operator.limitsInDisplayStyle, isTrue);
+    expect(operator.limits, isFalse);
+    expect(operator.lowerLimit, isNotNull);
+  });
+}

--- a/lib/shared/widgets/markdown_line_lexer.dart
+++ b/lib/shared/widgets/markdown_line_lexer.dart
@@ -908,6 +908,195 @@ final class _MathEnvironmentCloser {
   final int spanEnd;
 }
 
+enum _TexVerbProbeStatus { none, pending, complete }
+
+final class _TexVerbProbe {
+  const _TexVerbProbe._none()
+    : status = _TexVerbProbeStatus.none,
+      end = null,
+      delimiter = null,
+      searchedTo = 0;
+
+  static const none = _TexVerbProbe._none();
+
+  const _TexVerbProbe.pending({this.delimiter, required this.searchedTo})
+    : status = _TexVerbProbeStatus.pending,
+      end = null;
+
+  const _TexVerbProbe.complete(this.end)
+    : status = _TexVerbProbeStatus.complete,
+      delimiter = null,
+      searchedTo = 0;
+
+  final _TexVerbProbeStatus status;
+  final int? end;
+  final int? delimiter;
+  final int searchedTo;
+}
+
+final class _DisplayMathLineState {
+  const _DisplayMathLineState({
+    required this.lineLeading,
+    required this.environmentLineLeading,
+    required this.environmentIndentColumns,
+    required this.environmentComment,
+    required this.pendingEnvironmentName,
+    required this.pendingEnvironmentStart,
+    required this.pendingEnvironmentTokenAt,
+    required this.pendingEnvironmentDepth,
+    required this.commentMatchedEnvironmentName,
+    required this.commentMatchedEnvironmentStart,
+    required this.commentMatchedEnvironmentCloseStart,
+    required this.commentMatchedEnvironmentCloseAt,
+  });
+
+  final bool lineLeading;
+  final bool environmentLineLeading;
+  final int environmentIndentColumns;
+  final bool environmentComment;
+  final String? pendingEnvironmentName;
+  final int? pendingEnvironmentStart;
+  final int pendingEnvironmentTokenAt;
+  final int pendingEnvironmentDepth;
+  final String? commentMatchedEnvironmentName;
+  final int? commentMatchedEnvironmentStart;
+  final int? commentMatchedEnvironmentCloseStart;
+  final int? commentMatchedEnvironmentCloseAt;
+}
+
+final class _IncrementalBacktickResult {
+  _IncrementalBacktickResult({
+    required this.start,
+    required this.end,
+    required this.length,
+    required this.paired,
+    this.state,
+  });
+
+  final int start;
+  final int end;
+  final int length;
+  final bool paired;
+  final _DisplayMathLineState? state;
+  late final int index;
+}
+
+/// Resolves current-line backtick runs with the same greedy rule as
+/// [_LineBackticks], while allowing the final run to grow across appends.
+final class _IncrementalLineBackticks {
+  final _results = <_IncrementalBacktickResult>[];
+  final _standaloneByLength = <int, _IncrementalBacktickResult>{};
+  int? _trailingStart;
+  var _trailingLength = 0;
+  _DisplayMathLineState? _trailingState;
+
+  void reset() {
+    _results.clear();
+    _standaloneByLength.clear();
+    _trailingStart = null;
+    _trailingLength = 0;
+    _trailingState = null;
+  }
+
+  void consume(int offset, _DisplayMathLineState state) {
+    if (_trailingStart == null) {
+      _trailingStart = offset;
+      _trailingLength = 1;
+      _trailingState = state;
+    } else {
+      _trailingLength++;
+    }
+  }
+
+  _DisplayMathLineState? finishRun() {
+    final start = _trailingStart;
+    if (start == null) return null;
+    final length = _trailingLength;
+    final end = start + length;
+    final opener = _standaloneByLength[length];
+    _DisplayMathLineState? restored;
+    if (opener == null) {
+      restored = _trailingState;
+      _append(
+        _IncrementalBacktickResult(
+          start: start,
+          end: end,
+          length: length,
+          paired: false,
+          state: _trailingState,
+        ),
+      );
+    } else {
+      restored = opener.state;
+      while (_results.length > opener.index) {
+        final removed = _results.removeLast();
+        if (!removed.paired) {
+          _standaloneByLength.remove(removed.length);
+        }
+      }
+      _append(
+        _IncrementalBacktickResult(
+          start: opener.start,
+          end: end,
+          length: length,
+          paired: true,
+        ),
+      );
+    }
+    _trailingStart = null;
+    _trailingLength = 0;
+    _trailingState = null;
+    return restored;
+  }
+
+  _DisplayMathLineState? get provisionalState =>
+      _standaloneByLength[_trailingLength]?.state;
+
+  bool get hasTrailingRun => _trailingStart != null;
+
+  bool get hasStandaloneRuns => _standaloneByLength.isNotEmpty;
+
+  bool hasStandaloneRun(int length) => _standaloneByLength.containsKey(length);
+
+  _DisplayMathLineState? get pairingState {
+    if (_trailingStart == null) return null;
+    return _standaloneByLength[_trailingLength]?.state ?? _trailingState;
+  }
+
+  bool contains(int offset) => hiddenSpanEnd(offset) != null;
+
+  int? hiddenSpanEnd(int offset) {
+    final provisionalOpener = _standaloneByLength[_trailingLength];
+    if (provisionalOpener != null &&
+        offset >= provisionalOpener.start &&
+        offset < _trailingStart! + _trailingLength) {
+      return _trailingStart! + _trailingLength;
+    }
+    final resultLimit = provisionalOpener?.index ?? _results.length;
+    if (resultLimit == 0 || offset < _results.first.start) return null;
+    var low = 0;
+    var high = resultLimit;
+    while (low < high) {
+      _noteScanVisit();
+      final middle = (low + high) >> 1;
+      if (_results[middle].start <= offset) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    if (low == 0) return null;
+    final result = _results[low - 1];
+    return result.paired && offset < result.end ? result.end : null;
+  }
+
+  void _append(_IncrementalBacktickResult result) {
+    result.index = _results.length;
+    _results.add(result);
+    if (!result.paired) _standaloneByLength[result.length] = result;
+  }
+}
+
 /// A successful display-math span under the shared pairing rules.
 final class MarkdownDisplayMathSpan {
   const MarkdownDisplayMathSpan({required this.start, required this.end});
@@ -953,6 +1142,10 @@ final class MarkdownDisplayMathScanner {
   var _environmentLineLeading = true;
   var _environmentIndentColumns = 0;
   var _environmentComment = false;
+  var _precedingBackslashes = 0;
+  final _currentLineBackticks = _IncrementalLineBackticks();
+  var _currentLineBackticksChanged = false;
+  _DisplayMathLineState? _lineStartPairState;
   final _dollarOpens = <int>[];
   final _dollarCloses = <int>[];
   final _bracketOpens = <int>[];
@@ -991,6 +1184,13 @@ final class MarkdownDisplayMathScanner {
   int? _commentMatchedEnvironmentStart;
   int? _commentMatchedEnvironmentCloseStart;
   int? _commentMatchedEnvironmentCloseAt;
+  int? _pendingTexVerbStart;
+  int? _pendingTexVerbDelimiter;
+  int? _pendingTexVerbCompleteEnd;
+  var _pendingTexVerbSearchedTo = 0;
+  var _pendingTexVerbBacktickSearchedTo = 0;
+  int? _pendingTexVerbBacktickRunStart;
+  var _pendingTexVerbBacktickRunLength = 0;
 
   void reset() {
     _text = '';
@@ -1000,6 +1200,10 @@ final class MarkdownDisplayMathScanner {
     _environmentLineLeading = true;
     _environmentIndentColumns = 0;
     _environmentComment = false;
+    _precedingBackslashes = 0;
+    _currentLineBackticks.reset();
+    _currentLineBackticksChanged = false;
+    _lineStartPairState = null;
     _dollarOpens.clear();
     _dollarCloses.clear();
     _bracketOpens.clear();
@@ -1032,6 +1236,7 @@ final class MarkdownDisplayMathScanner {
     _frozenFenceCloseAt = 0;
     _clearPendingEnvironment();
     _clearCommentMatchedEnvironment();
+    _clearPendingTexVerb();
   }
 
   MarkdownDisplayMathScan synchronize(
@@ -1052,14 +1257,107 @@ final class MarkdownDisplayMathScanner {
             ))) {
       reset();
     }
+    final pendingTexVerbValidatedTo =
+        _pendingTexVerbBacktickSearchedTo > _pendingTexVerbSearchedTo
+        ? _pendingTexVerbBacktickSearchedTo
+        : _pendingTexVerbSearchedTo;
+    if (_pendingTexVerbStart != null &&
+        (pendingTexVerbValidatedTo > limit ||
+            pendingTexVerbValidatedTo > text.length ||
+            !text.startsWith(
+              _text.substring(
+                0,
+                pendingTexVerbValidatedTo.clamp(0, _text.length),
+              ),
+            ))) {
+      _clearPendingTexVerb();
+    }
     _text = text;
     _feed(limit);
+    if (_currentLineBackticksChanged) {
+      final state = _currentLineBackticks.pairingState;
+      if (state != null) _restorePairState(state);
+      _currentLineBackticksChanged = false;
+    }
     return _pair(limit);
   }
 
   void _feed(int limit) {
     while (_scannedTo < limit) {
       final unit = _text.codeUnitAt(_scannedTo);
+      if (unit != 0x60) {
+        final restored = _currentLineBackticks.finishRun();
+        if (restored != null) _restoreLineState(restored);
+      }
+      if (!_environmentComment &&
+          unit == 0x5C &&
+          _precedingBackslashes.isEven) {
+        final resumesVerb = _pendingTexVerbStart == _scannedTo;
+        final verb = resumesVerb && _pendingTexVerbCompleteEnd != null
+            ? _TexVerbProbe.complete(_pendingTexVerbCompleteEnd!)
+            : _probeTexVerb(
+                _text,
+                _scannedTo,
+                limit,
+                knownDelimiter: resumesVerb ? _pendingTexVerbDelimiter : null,
+                searchFrom: resumesVerb ? _pendingTexVerbSearchedTo : null,
+              );
+        final interruptedByCode = _verbClosingBacktickRun(
+          verb,
+          limit,
+          resumesVerb: resumesVerb,
+        );
+        if (interruptedByCode != null) {
+          if (interruptedByCode.provisional) {
+            _pendingTexVerbStart = _scannedTo;
+            _pendingTexVerbDelimiter = verb.delimiter;
+            _pendingTexVerbCompleteEnd =
+                verb.status == _TexVerbProbeStatus.complete ? verb.end : null;
+            _pendingTexVerbSearchedTo =
+                verb.status == _TexVerbProbeStatus.complete
+                ? verb.end!
+                : verb.searchedTo;
+            _revokeEnvironmentClosersThrough(_scannedTo);
+            return;
+          }
+          _clearPendingTexVerb();
+          _pair(interruptedByCode.start);
+          _lineLeading = false;
+          _environmentLineLeading = false;
+          for (
+            var i = interruptedByCode.start;
+            i < interruptedByCode.end;
+            i++
+          ) {
+            _currentLineBackticks.consume(i, _lineState());
+          }
+          _currentLineBackticksChanged = true;
+          _scannedTo = interruptedByCode.end;
+          _precedingBackslashes = 0;
+          continue;
+        }
+        if (verb.status == _TexVerbProbeStatus.pending) {
+          _pendingTexVerbStart = _scannedTo;
+          _pendingTexVerbDelimiter = verb.delimiter;
+          _pendingTexVerbCompleteEnd = null;
+          _pendingTexVerbSearchedTo = verb.searchedTo;
+          _revokeEnvironmentClosersThrough(_scannedTo);
+          return;
+        }
+        if (verb.status == _TexVerbProbeStatus.complete) {
+          final skipEnd = _pendingTexVerbBacktickSearchedTo > verb.end!
+              ? _pendingTexVerbBacktickSearchedTo
+              : verb.end!;
+          _clearPendingTexVerb();
+          _revokeClosersThrough(_scannedTo);
+          _lineLeading = false;
+          _environmentLineLeading = false;
+          _scannedTo = skipEnd;
+          _precedingBackslashes = 0;
+          continue;
+        }
+        _clearPendingTexVerb();
+      }
       if (!markdownIsLogicalLineBreak(unit) &&
           _scannedTo + 1 >= limit &&
           (unit == 0x24 || unit == 0x5C)) {
@@ -1070,14 +1368,29 @@ final class MarkdownDisplayMathScanner {
       }
       if (!_environmentComment &&
           unit == 0x5C &&
+          _precedingBackslashes.isEven &&
           _hasIncompleteEnvironmentToken(_scannedTo, limit)) {
         _revokeEnvironmentClosersThrough(_scannedTo);
         return;
       }
       _noteScanVisit();
       if (markdownIsLogicalLineBreak(unit)) {
+        final lineStartPairState = _lineStartPairState;
+        if (lineStartPairState == null) {
+          _clearPendingEnvironment();
+          _clearCommentMatchedEnvironment();
+        } else {
+          _restorePairState(lineStartPairState);
+        }
         _rollbackCurrentLine();
         _collectCompleteLine(_lineStart, _scannedTo);
+        // Complete-line collection has already applied the authoritative
+        // backtick walk. Do not filter those exact candidates through the
+        // provisional current-line resolver again.
+        _currentLineBackticks.reset();
+        _currentLineBackticksChanged = false;
+        _environmentComment = false;
+        _pair(_scannedTo);
         _clearCommentMatchedEnvironment();
         _scannedTo = _skipLogicalLineBreak(_text, _scannedTo, limit);
         _lineStart = _scannedTo;
@@ -1085,6 +1398,8 @@ final class MarkdownDisplayMathScanner {
         _environmentLineLeading = true;
         _environmentIndentColumns = 0;
         _environmentComment = false;
+        _precedingBackslashes = 0;
+        _lineStartPairState = _lineState();
         _checkpointCurrentLine();
         continue;
       }
@@ -1126,12 +1441,14 @@ final class MarkdownDisplayMathScanner {
 
   void _consumeAt(int i, int limit) {
     final unit = _text.codeUnitAt(i);
+    if (unit == 0x60) {
+      if (!_currentLineBackticks.hasTrailingRun) _pair(i);
+      _currentLineBackticksChanged = true;
+    }
     final environmentCanOpen =
         _environmentLineLeading && _environmentIndentColumns < 4;
     final beginsEnvironmentComment =
-        !_environmentComment &&
-        unit == 0x25 &&
-        !_texCharacterIsEscaped(_text, i);
+        !_environmentComment && unit == 0x25 && _precedingBackslashes.isEven;
     if (!_environmentComment &&
         !beginsEnvironmentComment &&
         !markdownIsWhitespace(unit)) {
@@ -1140,7 +1457,7 @@ final class MarkdownDisplayMathScanner {
     if (beginsEnvironmentComment) {
       _environmentComment = true;
     }
-    if (!_environmentComment && unit == 0x5C) {
+    if (!_environmentComment && unit == 0x5C && _precedingBackslashes.isEven) {
       final token = _mathEnvironmentToken.matchAsPrefix(_text, i);
       if (token != null && token.end <= limit) {
         final name = token.group(2)!;
@@ -1161,6 +1478,7 @@ final class MarkdownDisplayMathScanner {
         _lineLeading = false;
         _environmentLineLeading = false;
         _scannedTo = token.end;
+        _precedingBackslashes = 0;
         return;
       }
     }
@@ -1170,20 +1488,27 @@ final class MarkdownDisplayMathScanner {
       _lineLeading = false;
       _environmentLineLeading = false;
       _scannedTo = i + 2;
+      _precedingBackslashes = 0;
       return;
     }
-    if (i + 1 < limit && _atEscaped(_text, i, 0x5B)) {
+    if (i + 1 < limit &&
+        _precedingBackslashes.isEven &&
+        _atEscaped(_text, i, 0x5B)) {
       if (_lineLeading) _bracketOpens.add(i);
       _lineLeading = false;
       _environmentLineLeading = false;
       _scannedTo = i + 2;
+      _precedingBackslashes = 0;
       return;
     }
-    if (i + 1 < limit && _atEscaped(_text, i, 0x5D)) {
+    if (i + 1 < limit &&
+        _precedingBackslashes.isEven &&
+        _atEscaped(_text, i, 0x5D)) {
       _bracketCloses.add(i);
       _lineLeading = false;
       _environmentLineLeading = false;
       _scannedTo = i + 2;
+      _precedingBackslashes = 0;
       return;
     }
     if (_environmentLineLeading) {
@@ -1200,6 +1525,106 @@ final class MarkdownDisplayMathScanner {
       _revokeClosersThrough(i, includeEnvironments: !_environmentComment);
     }
     _scannedTo = i + 1;
+    _precedingBackslashes = unit == 0x5C ? _precedingBackslashes + 1 : 0;
+    if (unit == 0x60) {
+      _currentLineBackticks.consume(i, _lineState());
+    }
+  }
+
+  _DisplayMathLineState _lineState() => _DisplayMathLineState(
+    lineLeading: _lineLeading,
+    environmentLineLeading: _environmentLineLeading,
+    environmentIndentColumns: _environmentIndentColumns,
+    environmentComment: _environmentComment,
+    pendingEnvironmentName: _pendingEnvironmentName,
+    pendingEnvironmentStart: _pendingEnvironmentStart,
+    pendingEnvironmentTokenAt: _pendingEnvironmentTokenAt,
+    pendingEnvironmentDepth: _pendingEnvironmentDepth,
+    commentMatchedEnvironmentName: _commentMatchedEnvironmentName,
+    commentMatchedEnvironmentStart: _commentMatchedEnvironmentStart,
+    commentMatchedEnvironmentCloseStart: _commentMatchedEnvironmentCloseStart,
+    commentMatchedEnvironmentCloseAt: _commentMatchedEnvironmentCloseAt,
+  );
+
+  void _restoreLineState(_DisplayMathLineState state) {
+    _lineLeading = state.lineLeading;
+    _environmentLineLeading = state.environmentLineLeading;
+    _environmentIndentColumns = state.environmentIndentColumns;
+    _environmentComment = state.environmentComment;
+    _precedingBackslashes = 0;
+    _clearPendingTexVerb();
+    _restorePairState(state);
+  }
+
+  void _restorePairState(_DisplayMathLineState state) {
+    _pendingEnvironmentName = state.pendingEnvironmentName;
+    _pendingEnvironmentStart = state.pendingEnvironmentStart;
+    _pendingEnvironmentTokenAt = state.pendingEnvironmentTokenAt;
+    _pendingEnvironmentDepth = state.pendingEnvironmentDepth;
+    _commentMatchedEnvironmentName = state.commentMatchedEnvironmentName;
+    _commentMatchedEnvironmentStart = state.commentMatchedEnvironmentStart;
+    _commentMatchedEnvironmentCloseStart =
+        state.commentMatchedEnvironmentCloseStart;
+    _commentMatchedEnvironmentCloseAt = state.commentMatchedEnvironmentCloseAt;
+  }
+
+  ({int start, int end, bool provisional})? _verbClosingBacktickRun(
+    _TexVerbProbe verb,
+    int limit, {
+    required bool resumesVerb,
+  }) {
+    if (!_currentLineBackticks.hasStandaloneRuns ||
+        verb.status == _TexVerbProbeStatus.none) {
+      return null;
+    }
+    final verbEnd = verb.status == _TexVerbProbeStatus.complete
+        ? verb.end!
+        : verb.searchedTo;
+    var i = resumesVerb ? _pendingTexVerbBacktickSearchedTo : _scannedTo;
+    var runStart = resumesVerb ? _pendingTexVerbBacktickRunStart : null;
+    var runLength = resumesVerb ? _pendingTexVerbBacktickRunLength : 0;
+    while (i < verbEnd) {
+      _noteScanVisit();
+      if (_text.codeUnitAt(i) == 0x60) {
+        runStart ??= i;
+        runLength++;
+        i++;
+        continue;
+      }
+      if (runStart != null &&
+          _currentLineBackticks.hasStandaloneRun(runLength)) {
+        return (start: runStart, end: i, provisional: false);
+      }
+      runStart = null;
+      runLength = 0;
+      i++;
+    }
+    if (runStart != null && verb.status == _TexVerbProbeStatus.complete) {
+      while (i < limit && _text.codeUnitAt(i) == 0x60) {
+        _noteScanVisit();
+        runLength++;
+        i++;
+      }
+      if (i < limit) {
+        if (_currentLineBackticks.hasStandaloneRun(runLength)) {
+          return (start: runStart, end: i, provisional: false);
+        }
+        runStart = null;
+        runLength = 0;
+      }
+    }
+    _pendingTexVerbBacktickSearchedTo = i;
+    _pendingTexVerbBacktickRunStart = runStart;
+    _pendingTexVerbBacktickRunLength = runLength;
+    if (runStart != null) {
+      return (start: runStart, end: i, provisional: true);
+    }
+    if (verb.status == _TexVerbProbeStatus.pending) {
+      _pendingTexVerbBacktickSearchedTo = verbEnd;
+      _pendingTexVerbBacktickRunStart = runStart;
+      _pendingTexVerbBacktickRunLength = runLength;
+    }
+    return null;
   }
 
   void _revokeClosersThrough(int nonWsAt, {bool includeEnvironments = true}) {
@@ -1251,6 +1676,7 @@ final class MarkdownDisplayMathScanner {
     var environmentLineLeading = true;
     var environmentIndentColumns = 0;
     var environmentComment = false;
+    var precedingBackslashes = 0;
     var j = 0;
     while (j < rawLine.length) {
       _noteScanVisit();
@@ -1258,42 +1684,55 @@ final class MarkdownDisplayMathScanner {
         j = ticks.advance(j);
         lineLeading = false;
         environmentLineLeading = false;
+        precedingBackslashes = 0;
         continue;
       }
-      if (rawLine.codeUnitAt(j) == 0x25 &&
-          !_texCharacterIsEscaped(rawLine, j)) {
+      if (rawLine.codeUnitAt(j) == 0x25 && precedingBackslashes.isEven) {
         environmentComment = true;
       }
       if (!environmentComment && rawLine.codeUnitAt(j) == 0x5C) {
-        final token = _mathEnvironmentToken.matchAsPrefix(rawLine, j);
-        if (token != null) {
-          final name = token.group(2)!;
-          final opening = token.group(1) == 'begin';
-          (_environmentTokens[name] ??= []).add(
-            _MathEnvironmentToken(start + j, start + token.end, opening),
-          );
-          if (opening) {
-            if (environmentLineLeading && environmentIndentColumns < 4) {
-              _environmentOpens.add(
-                _MathEnvironmentMark(name, start + j, start + token.end),
-              );
-            }
-          } else {
-            final closerEnd = _environmentCloserEnd(rawLine, token.end);
-            if (closerEnd != null) {
-              (_environmentCloses[name] ??= []).add(
-                _MathEnvironmentCloser(
-                  start + j,
-                  start + token.end,
-                  start + closerEnd,
-                ),
-              );
-            }
+        if (precedingBackslashes.isEven) {
+          final verb = _probeTexVerb(rawLine, j, rawLine.length);
+          if (verb.status == _TexVerbProbeStatus.complete) {
+            lineLeading = false;
+            environmentLineLeading = false;
+            j = verb.end!;
+            precedingBackslashes = 0;
+            continue;
           }
-          lineLeading = false;
-          environmentLineLeading = false;
-          j = token.end;
-          continue;
+        }
+        if (precedingBackslashes.isEven) {
+          final token = _mathEnvironmentToken.matchAsPrefix(rawLine, j);
+          if (token != null) {
+            final name = token.group(2)!;
+            final opening = token.group(1) == 'begin';
+            (_environmentTokens[name] ??= []).add(
+              _MathEnvironmentToken(start + j, start + token.end, opening),
+            );
+            if (opening) {
+              if (environmentLineLeading && environmentIndentColumns < 4) {
+                _environmentOpens.add(
+                  _MathEnvironmentMark(name, start + j, start + token.end),
+                );
+              }
+            } else {
+              final closerEnd = _environmentCloserEnd(rawLine, token.end);
+              if (closerEnd != null) {
+                (_environmentCloses[name] ??= []).add(
+                  _MathEnvironmentCloser(
+                    start + j,
+                    start + token.end,
+                    start + closerEnd,
+                  ),
+                );
+              }
+            }
+            lineLeading = false;
+            environmentLineLeading = false;
+            j = token.end;
+            precedingBackslashes = 0;
+            continue;
+          }
         }
       }
       if (_atDoubleDollar(rawLine, j)) {
@@ -1303,22 +1742,25 @@ final class MarkdownDisplayMathScanner {
         lineLeading = false;
         environmentLineLeading = false;
         j += 2;
+        precedingBackslashes = 0;
         continue;
       }
-      if (_atEscaped(rawLine, j, 0x5B)) {
+      if (precedingBackslashes.isEven && _atEscaped(rawLine, j, 0x5B)) {
         if (lineLeading) _bracketOpens.add(start + j);
         lineLeading = false;
         environmentLineLeading = false;
         j += 2;
+        precedingBackslashes = 0;
         continue;
       }
-      if (_atEscaped(rawLine, j, 0x5D)) {
+      if (precedingBackslashes.isEven && _atEscaped(rawLine, j, 0x5D)) {
         if (_onlyWhitespaceAfter(rawLine, j + 2)) {
           _bracketCloses.add(start + j);
         }
         lineLeading = false;
         environmentLineLeading = false;
         j += 2;
+        precedingBackslashes = 0;
         continue;
       }
       if (environmentLineLeading) {
@@ -1331,7 +1773,9 @@ final class MarkdownDisplayMathScanner {
           environmentLineLeading = false;
         }
       }
-      if (!markdownIsWhitespace(rawLine.codeUnitAt(j))) lineLeading = false;
+      final unit = rawLine.codeUnitAt(j);
+      if (!markdownIsWhitespace(unit)) lineLeading = false;
+      precedingBackslashes = unit == 0x5C ? precedingBackslashes + 1 : 0;
       j++;
     }
   }
@@ -1351,9 +1795,16 @@ final class MarkdownDisplayMathScanner {
     int? unclosedStart;
     int? earliestUnresolved;
     final peeked = _peekIncompleteFence(limit);
+    final currentEnvironmentComment =
+        _currentLineBackticks.provisionalState?.environmentComment ??
+        _environmentComment;
+
+    bool hiddenByInlineCode(int offset) =>
+        offset >= _lineStart && _currentLineBackticks.contains(offset);
 
     int advanceInt(List<int> values, int index, int min) {
-      while (index < values.length && values[index] < min) {
+      while (index < values.length &&
+          (values[index] < min || hiddenByInlineCode(values[index]))) {
         _noteScanVisit();
         index++;
       }
@@ -1365,7 +1816,9 @@ final class MarkdownDisplayMathScanner {
       int index,
       int min,
     ) {
-      while (index < values.length && values[index].start < min) {
+      while (index < values.length &&
+          (values[index].start < min ||
+              hiddenByInlineCode(values[index].start))) {
         _noteScanVisit();
         index++;
       }
@@ -1414,7 +1867,8 @@ final class MarkdownDisplayMathScanner {
       dollarOpenAt = advanceInt(_dollarOpens, dollarOpenAt, pos);
       bracketOpenAt = advanceInt(_bracketOpens, bracketOpenAt, pos);
       while (environmentOpenAt < _environmentOpens.length &&
-          _environmentOpens[environmentOpenAt].start < pos) {
+          (_environmentOpens[environmentOpenAt].start < pos ||
+              hiddenByInlineCode(_environmentOpens[environmentOpenAt].start))) {
         _noteScanVisit();
         environmentOpenAt++;
       }
@@ -1452,7 +1906,7 @@ final class MarkdownDisplayMathScanner {
             _environmentCloses[environment.name] ??
             const <_MathEnvironmentCloser>[];
         final resumesCommentMatch =
-            _environmentComment &&
+            currentEnvironmentComment &&
             _commentMatchedEnvironmentStart == environment.start &&
             _commentMatchedEnvironmentName == environment.name;
         if (resumesCommentMatch) {
@@ -1493,11 +1947,27 @@ final class MarkdownDisplayMathScanner {
         for (var i = tokenAt; i < tokens.length; i++) {
           _noteScanVisit();
           final token = tokens[i];
-          depth += token.opening ? 1 : -1;
-          if (token.end <= _lineStart) {
-            stableTokenAt = i + 1;
+          final hiddenEnd = _currentLineBackticks.hiddenSpanEnd(token.start);
+          if (hiddenEnd != null) {
+            var low = i + 1;
+            var high = tokens.length;
+            while (low < high) {
+              _noteScanVisit();
+              final middle = (low + high) >> 1;
+              if (tokens[middle].start < hiddenEnd) {
+                low = middle + 1;
+              } else {
+                high = middle;
+              }
+            }
+            stableTokenAt = low;
             stableDepth = depth;
+            i = low - 1;
+            continue;
           }
+          stableTokenAt = i + 1;
+          depth += token.opening ? 1 : -1;
+          stableDepth = depth;
           if (depth == 0) {
             closingToken = token;
             break;
@@ -1516,7 +1986,7 @@ final class MarkdownDisplayMathScanner {
           _clearPendingEnvironmentFor(environment);
           final close = closes[closeAt];
           final commentExtendsCurrentLine =
-              _environmentComment && close.start >= _lineStart;
+              currentEnvironmentComment && close.start >= _lineStart;
           if (commentExtendsCurrentLine) {
             _commentMatchedEnvironmentName = environment.name;
             _commentMatchedEnvironmentStart = environment.start;
@@ -1564,7 +2034,9 @@ final class MarkdownDisplayMathScanner {
         final openAt = mathAt;
         final closes = useDollar ? _dollarCloses : _bracketCloses;
         var closeAt = useDollar ? dollarCloseAt : bracketCloseAt;
-        while (closeAt < closes.length && closes[closeAt] < openAt + 2) {
+        while (closeAt < closes.length &&
+            (closes[closeAt] < openAt + 2 ||
+                hiddenByInlineCode(closes[closeAt]))) {
           _noteScanVisit();
           closeAt++;
         }
@@ -1684,6 +2156,16 @@ final class MarkdownDisplayMathScanner {
     _commentMatchedEnvironmentCloseAt = null;
   }
 
+  void _clearPendingTexVerb() {
+    _pendingTexVerbStart = null;
+    _pendingTexVerbDelimiter = null;
+    _pendingTexVerbCompleteEnd = null;
+    _pendingTexVerbSearchedTo = 0;
+    _pendingTexVerbBacktickSearchedTo = 0;
+    _pendingTexVerbBacktickRunStart = null;
+    _pendingTexVerbBacktickRunLength = 0;
+  }
+
   _FenceMark? _peekIncompleteFence(int limit) {
     var i = _lineStart;
     while (i < limit) {
@@ -1742,6 +2224,60 @@ bool _atEscaped(String line, int i, int unit) {
       line.codeUnitAt(i) == 0x5C &&
       line.codeUnitAt(i + 1) == unit;
 }
+
+_TexVerbProbe _probeTexVerb(
+  String text,
+  int start,
+  int limit, {
+  int? knownDelimiter,
+  int? searchFrom,
+}) {
+  const prefix = r'\verb';
+  var prefixAt = 0;
+  while (prefixAt < prefix.length && start + prefixAt < limit) {
+    _noteScanVisit();
+    if (text.codeUnitAt(start + prefixAt) != prefix.codeUnitAt(prefixAt)) {
+      return _TexVerbProbe.none;
+    }
+    prefixAt++;
+  }
+  if (prefixAt < prefix.length) {
+    return _TexVerbProbe.pending(searchedTo: limit);
+  }
+
+  var delimiterAt = start + prefix.length;
+  if (delimiterAt >= limit) {
+    return _TexVerbProbe.pending(searchedTo: limit);
+  }
+  var delimiter = text.codeUnitAt(delimiterAt);
+  if (delimiter == 0x2A) {
+    delimiterAt++;
+    if (delimiterAt >= limit) {
+      return _TexVerbProbe.pending(searchedTo: limit);
+    }
+    delimiter = text.codeUnitAt(delimiterAt);
+  } else if (_isAsciiLetter(delimiter)) {
+    return _TexVerbProbe.none;
+  }
+  if (markdownIsLogicalLineBreak(delimiter)) return _TexVerbProbe.none;
+
+  final payloadStart = delimiterAt + 1;
+  var i = knownDelimiter == delimiter && searchFrom != null
+      ? searchFrom
+      : payloadStart;
+  if (i < payloadStart) i = payloadStart;
+  while (i < limit) {
+    _noteScanVisit();
+    final unit = text.codeUnitAt(i);
+    if (markdownIsLogicalLineBreak(unit)) return _TexVerbProbe.none;
+    if (unit == delimiter) return _TexVerbProbe.complete(i + 1);
+    i++;
+  }
+  return _TexVerbProbe.pending(delimiter: delimiter, searchedTo: i);
+}
+
+bool _isAsciiLetter(int unit) =>
+    (unit >= 0x41 && unit <= 0x5A) || (unit >= 0x61 && unit <= 0x7A);
 
 bool _texCharacterIsEscaped(String text, int index) {
   var backslashes = 0;

--- a/lib/shared/widgets/markdown_line_lexer.dart
+++ b/lib/shared/widgets/markdown_line_lexer.dart
@@ -900,6 +900,14 @@ final class _MathEnvironmentToken {
   final bool opening;
 }
 
+final class _MathEnvironmentCloser {
+  const _MathEnvironmentCloser(this.start, this.tokenEnd, this.spanEnd);
+
+  final int start;
+  final int tokenEnd;
+  final int spanEnd;
+}
+
 /// A successful display-math span under the shared pairing rules.
 final class MarkdownDisplayMathSpan {
   const MarkdownDisplayMathSpan({required this.start, required this.end});
@@ -942,13 +950,15 @@ final class MarkdownDisplayMathScanner {
   var _scannedTo = 0;
   var _lineStart = 0;
   var _lineLeading = true;
+  var _environmentLineLeading = true;
+  var _environmentIndentColumns = 0;
   var _environmentComment = false;
   final _dollarOpens = <int>[];
   final _dollarCloses = <int>[];
   final _bracketOpens = <int>[];
   final _bracketCloses = <int>[];
   final _environmentOpens = <_MathEnvironmentMark>[];
-  final _environmentCloses = <String, List<int>>{};
+  final _environmentCloses = <String, List<_MathEnvironmentCloser>>{};
   final _environmentTokens = <String, List<_MathEnvironmentToken>>{};
   final _fenceOpens = <_FenceMark>[];
   final _fenceCloses = <_FenceMark>[];
@@ -973,12 +983,22 @@ final class MarkdownDisplayMathScanner {
   final _frozenEnvironmentTokenAt = <String, int>{};
   var _frozenFenceOpenAt = 0;
   var _frozenFenceCloseAt = 0;
+  String? _pendingEnvironmentName;
+  int? _pendingEnvironmentStart;
+  var _pendingEnvironmentTokenAt = 0;
+  var _pendingEnvironmentDepth = 0;
+  String? _commentMatchedEnvironmentName;
+  int? _commentMatchedEnvironmentStart;
+  int? _commentMatchedEnvironmentCloseStart;
+  int? _commentMatchedEnvironmentCloseAt;
 
   void reset() {
     _text = '';
     _scannedTo = 0;
     _lineStart = 0;
     _lineLeading = true;
+    _environmentLineLeading = true;
+    _environmentIndentColumns = 0;
     _environmentComment = false;
     _dollarOpens.clear();
     _dollarCloses.clear();
@@ -1010,6 +1030,8 @@ final class MarkdownDisplayMathScanner {
     _frozenEnvironmentTokenAt.clear();
     _frozenFenceOpenAt = 0;
     _frozenFenceCloseAt = 0;
+    _clearPendingEnvironment();
+    _clearCommentMatchedEnvironment();
   }
 
   MarkdownDisplayMathScan synchronize(
@@ -1041,10 +1063,14 @@ final class MarkdownDisplayMathScanner {
       if (!markdownIsLogicalLineBreak(unit) &&
           _scannedTo + 1 >= limit &&
           (unit == 0x24 || unit == 0x5C)) {
-        _revokeEnvironmentClosersThrough(_scannedTo);
+        if (!_environmentComment) {
+          _revokeEnvironmentClosersThrough(_scannedTo);
+        }
         return;
       }
-      if (unit == 0x5C && _hasIncompleteEnvironmentToken(_scannedTo, limit)) {
+      if (!_environmentComment &&
+          unit == 0x5C &&
+          _hasIncompleteEnvironmentToken(_scannedTo, limit)) {
         _revokeEnvironmentClosersThrough(_scannedTo);
         return;
       }
@@ -1052,9 +1078,12 @@ final class MarkdownDisplayMathScanner {
       if (markdownIsLogicalLineBreak(unit)) {
         _rollbackCurrentLine();
         _collectCompleteLine(_lineStart, _scannedTo);
+        _clearCommentMatchedEnvironment();
         _scannedTo = _skipLogicalLineBreak(_text, _scannedTo, limit);
         _lineStart = _scannedTo;
         _lineLeading = true;
+        _environmentLineLeading = true;
+        _environmentIndentColumns = 0;
         _environmentComment = false;
         _checkpointCurrentLine();
         continue;
@@ -1096,13 +1125,22 @@ final class MarkdownDisplayMathScanner {
   }
 
   void _consumeAt(int i, int limit) {
-    if (!markdownIsWhitespace(_text.codeUnitAt(i))) {
+    final unit = _text.codeUnitAt(i);
+    final environmentCanOpen =
+        _environmentLineLeading && _environmentIndentColumns < 4;
+    final beginsEnvironmentComment =
+        !_environmentComment &&
+        unit == 0x25 &&
+        !_texCharacterIsEscaped(_text, i);
+    if (!_environmentComment &&
+        !beginsEnvironmentComment &&
+        !markdownIsWhitespace(unit)) {
       _revokeEnvironmentClosersThrough(i);
     }
-    if (_text.codeUnitAt(i) == 0x25 && !_texCharacterIsEscaped(_text, i)) {
+    if (beginsEnvironmentComment) {
       _environmentComment = true;
     }
-    if (!_environmentComment && _text.codeUnitAt(i) == 0x5C) {
+    if (!_environmentComment && unit == 0x5C) {
       final token = _mathEnvironmentToken.matchAsPrefix(_text, i);
       if (token != null && token.end <= limit) {
         final name = token.group(2)!;
@@ -1112,13 +1150,16 @@ final class MarkdownDisplayMathScanner {
         );
         _revokeClosersThrough(i);
         if (opening) {
-          if (_lineLeading) {
+          if (environmentCanOpen) {
             _environmentOpens.add(_MathEnvironmentMark(name, i, token.end));
           }
         } else {
-          (_environmentCloses[name] ??= []).add(i);
+          (_environmentCloses[name] ??= []).add(
+            _MathEnvironmentCloser(i, token.end, token.end),
+          );
         }
         _lineLeading = false;
+        _environmentLineLeading = false;
         _scannedTo = token.end;
         return;
       }
@@ -1127,29 +1168,41 @@ final class MarkdownDisplayMathScanner {
       if (_lineLeading) _dollarOpens.add(i);
       _dollarCloses.add(i);
       _lineLeading = false;
+      _environmentLineLeading = false;
       _scannedTo = i + 2;
       return;
     }
     if (i + 1 < limit && _atEscaped(_text, i, 0x5B)) {
       if (_lineLeading) _bracketOpens.add(i);
       _lineLeading = false;
+      _environmentLineLeading = false;
       _scannedTo = i + 2;
       return;
     }
     if (i + 1 < limit && _atEscaped(_text, i, 0x5D)) {
       _bracketCloses.add(i);
       _lineLeading = false;
+      _environmentLineLeading = false;
       _scannedTo = i + 2;
       return;
     }
-    if (!markdownIsWhitespace(_text.codeUnitAt(i))) {
+    if (_environmentLineLeading) {
+      if (unit == 0x20) {
+        _environmentIndentColumns++;
+      } else if (unit == 0x09) {
+        _environmentIndentColumns += 4 - (_environmentIndentColumns % 4);
+      } else {
+        _environmentLineLeading = false;
+      }
+    }
+    if (!markdownIsWhitespace(unit)) {
       _lineLeading = false;
-      _revokeClosersThrough(i);
+      _revokeClosersThrough(i, includeEnvironments: !_environmentComment);
     }
     _scannedTo = i + 1;
   }
 
-  void _revokeClosersThrough(int nonWsAt) {
+  void _revokeClosersThrough(int nonWsAt, {bool includeEnvironments = true}) {
     while (_dollarCloses.length > _chkDollarCloses) {
       _noteScanVisit();
       final closer = _dollarCloses.last;
@@ -1162,7 +1215,7 @@ final class MarkdownDisplayMathScanner {
       if (closer + 2 > nonWsAt) break;
       _bracketCloses.removeLast();
     }
-    _revokeEnvironmentClosersThrough(nonWsAt);
+    if (includeEnvironments) _revokeEnvironmentClosersThrough(nonWsAt);
   }
 
   void _revokeEnvironmentClosersThrough(int nonWsAt) {
@@ -1171,7 +1224,7 @@ final class MarkdownDisplayMathScanner {
       final checkpoint = _chkEnvironmentCloses[entry.key] ?? 0;
       while (closes.length > checkpoint) {
         _noteScanVisit();
-        if (closes.last + entry.key.length + 6 > nonWsAt) break;
+        if (closes.last.tokenEnd > nonWsAt) break;
         closes.removeLast();
       }
     }
@@ -1195,6 +1248,8 @@ final class MarkdownDisplayMathScanner {
     }
     final ticks = _LineBackticks.of(rawLine);
     var lineLeading = true;
+    var environmentLineLeading = true;
+    var environmentIndentColumns = 0;
     var environmentComment = false;
     var j = 0;
     while (j < rawLine.length) {
@@ -1202,6 +1257,7 @@ final class MarkdownDisplayMathScanner {
       if (rawLine.codeUnitAt(j) == 0x60) {
         j = ticks.advance(j);
         lineLeading = false;
+        environmentLineLeading = false;
         continue;
       }
       if (rawLine.codeUnitAt(j) == 0x25 &&
@@ -1217,15 +1273,25 @@ final class MarkdownDisplayMathScanner {
             _MathEnvironmentToken(start + j, start + token.end, opening),
           );
           if (opening) {
-            if (lineLeading) {
+            if (environmentLineLeading && environmentIndentColumns < 4) {
               _environmentOpens.add(
                 _MathEnvironmentMark(name, start + j, start + token.end),
               );
             }
-          } else if (_onlyWhitespaceAfter(rawLine, token.end)) {
-            (_environmentCloses[name] ??= []).add(start + j);
+          } else {
+            final closerEnd = _environmentCloserEnd(rawLine, token.end);
+            if (closerEnd != null) {
+              (_environmentCloses[name] ??= []).add(
+                _MathEnvironmentCloser(
+                  start + j,
+                  start + token.end,
+                  start + closerEnd,
+                ),
+              );
+            }
           }
           lineLeading = false;
+          environmentLineLeading = false;
           j = token.end;
           continue;
         }
@@ -1235,12 +1301,14 @@ final class MarkdownDisplayMathScanner {
         if (lineLeading) _dollarOpens.add(at);
         if (_onlyWhitespaceAfter(rawLine, j + 2)) _dollarCloses.add(at);
         lineLeading = false;
+        environmentLineLeading = false;
         j += 2;
         continue;
       }
       if (_atEscaped(rawLine, j, 0x5B)) {
         if (lineLeading) _bracketOpens.add(start + j);
         lineLeading = false;
+        environmentLineLeading = false;
         j += 2;
         continue;
       }
@@ -1249,8 +1317,19 @@ final class MarkdownDisplayMathScanner {
           _bracketCloses.add(start + j);
         }
         lineLeading = false;
+        environmentLineLeading = false;
         j += 2;
         continue;
+      }
+      if (environmentLineLeading) {
+        final unit = rawLine.codeUnitAt(j);
+        if (unit == 0x20) {
+          environmentIndentColumns++;
+        } else if (unit == 0x09) {
+          environmentIndentColumns += 4 - (environmentIndentColumns % 4);
+        } else {
+          environmentLineLeading = false;
+        }
       }
       if (!markdownIsWhitespace(rawLine.codeUnitAt(j))) lineLeading = false;
       j++;
@@ -1275,6 +1354,18 @@ final class MarkdownDisplayMathScanner {
 
     int advanceInt(List<int> values, int index, int min) {
       while (index < values.length && values[index] < min) {
+        _noteScanVisit();
+        index++;
+      }
+      return index;
+    }
+
+    int advanceEnvironmentClose(
+      List<_MathEnvironmentCloser> values,
+      int index,
+      int min,
+    ) {
+      while (index < values.length && values[index].start < min) {
         _noteScanVisit();
         index++;
       }
@@ -1357,27 +1448,62 @@ final class MarkdownDisplayMathScanner {
       final mathFirst =
           mathAt != null && (fenceAt == null || mathAt <= fenceAt.start);
       if (mathFirst && useEnvironment) {
-        final closes = _environmentCloses[environment.name] ?? const <int>[];
+        final closes =
+            _environmentCloses[environment.name] ??
+            const <_MathEnvironmentCloser>[];
+        final resumesCommentMatch =
+            _environmentComment &&
+            _commentMatchedEnvironmentStart == environment.start &&
+            _commentMatchedEnvironmentName == environment.name;
+        if (resumesCommentMatch) {
+          final cachedCloseStart = _commentMatchedEnvironmentCloseStart!;
+          final closeAt = _commentMatchedEnvironmentCloseAt!;
+          environmentCloseAt[environment.name] = closeAt;
+          if (closeAt < closes.length &&
+              closes[closeAt].start == cachedCloseStart) {
+            environmentOpenAt++;
+            pos = limit;
+            _spans.add(
+              MarkdownDisplayMathSpan(start: environment.start, end: pos),
+            );
+            unclosedStart = null;
+            break;
+          }
+          _clearCommentMatchedEnvironmentFor(environment);
+        }
         final tokens = _environmentTokens[environment.name]!;
-        var tokenAt = environmentTokenAt[environment.name] ?? 0;
-        while (tokenAt < tokens.length &&
-            tokens[tokenAt].start < environment.start) {
-          _noteScanVisit();
-          tokenAt++;
+        final resumesPending =
+            _pendingEnvironmentStart == environment.start &&
+            _pendingEnvironmentName == environment.name;
+        var tokenAt = resumesPending
+            ? _pendingEnvironmentTokenAt
+            : environmentTokenAt[environment.name] ?? 0;
+        var depth = resumesPending ? _pendingEnvironmentDepth : 0;
+        if (!resumesPending) {
+          while (tokenAt < tokens.length &&
+              tokens[tokenAt].start < environment.start) {
+            _noteScanVisit();
+            tokenAt++;
+          }
         }
         environmentTokenAt[environment.name] = tokenAt;
-        var depth = 0;
+        var stableTokenAt = tokenAt;
+        var stableDepth = depth;
         _MathEnvironmentToken? closingToken;
         for (var i = tokenAt; i < tokens.length; i++) {
           _noteScanVisit();
           final token = tokens[i];
           depth += token.opening ? 1 : -1;
+          if (token.end <= _lineStart) {
+            stableTokenAt = i + 1;
+            stableDepth = depth;
+          }
           if (depth == 0) {
             closingToken = token;
             break;
           }
         }
-        final closeAt = advanceInt(
+        final closeAt = advanceEnvironmentClose(
           closes,
           environmentCloseAt[environment.name] ?? 0,
           closingToken?.start ?? environment.end,
@@ -1386,8 +1512,20 @@ final class MarkdownDisplayMathScanner {
         environmentOpenAt++;
         if (closingToken != null &&
             closeAt < closes.length &&
-            closes[closeAt] == closingToken.start) {
-          pos = closingToken.end;
+            closes[closeAt].start == closingToken.start) {
+          _clearPendingEnvironmentFor(environment);
+          final close = closes[closeAt];
+          final commentExtendsCurrentLine =
+              _environmentComment && close.start >= _lineStart;
+          if (commentExtendsCurrentLine) {
+            _commentMatchedEnvironmentName = environment.name;
+            _commentMatchedEnvironmentStart = environment.start;
+            _commentMatchedEnvironmentCloseStart = close.start;
+            _commentMatchedEnvironmentCloseAt = closeAt;
+          } else {
+            _clearCommentMatchedEnvironmentFor(environment);
+          }
+          pos = commentExtendsCurrentLine ? limit : close.spanEnd;
           _spans.add(
             MarkdownDisplayMathSpan(start: environment.start, end: pos),
           );
@@ -1401,13 +1539,21 @@ final class MarkdownDisplayMathScanner {
             fenceOpenAt,
             fenceCloseAt,
           );
+          if (commentExtendsCurrentLine) break;
         } else if (closingToken == null) {
+          _clearCommentMatchedEnvironmentFor(environment);
+          _pendingEnvironmentName = environment.name;
+          _pendingEnvironmentStart = environment.start;
+          _pendingEnvironmentTokenAt = stableTokenAt;
+          _pendingEnvironmentDepth = stableDepth;
           unclosedStart ??= environment.start;
           earliestUnresolved ??= environment.start;
           // A later environment may be a nested matrix or alignment whose
           // outer end has not streamed in yet. Keep the outer body together.
           break;
         } else {
+          _clearPendingEnvironmentFor(environment);
+          _clearCommentMatchedEnvironmentFor(environment);
           // The balanced environment ends mid-line, so it is ordinary text
           // rather than a standalone display block.
           pos = closingToken.end;
@@ -1510,6 +1656,34 @@ final class MarkdownDisplayMathScanner {
     return MarkdownDisplayMathScan(spans: _spans, unclosedStart: unclosedStart);
   }
 
+  void _clearPendingEnvironmentFor(_MathEnvironmentMark environment) {
+    if (_pendingEnvironmentStart == environment.start &&
+        _pendingEnvironmentName == environment.name) {
+      _clearPendingEnvironment();
+    }
+  }
+
+  void _clearPendingEnvironment() {
+    _pendingEnvironmentName = null;
+    _pendingEnvironmentStart = null;
+    _pendingEnvironmentTokenAt = 0;
+    _pendingEnvironmentDepth = 0;
+  }
+
+  void _clearCommentMatchedEnvironmentFor(_MathEnvironmentMark environment) {
+    if (_commentMatchedEnvironmentStart == environment.start &&
+        _commentMatchedEnvironmentName == environment.name) {
+      _clearCommentMatchedEnvironment();
+    }
+  }
+
+  void _clearCommentMatchedEnvironment() {
+    _commentMatchedEnvironmentName = null;
+    _commentMatchedEnvironmentStart = null;
+    _commentMatchedEnvironmentCloseStart = null;
+    _commentMatchedEnvironmentCloseAt = null;
+  }
+
   _FenceMark? _peekIncompleteFence(int limit) {
     var i = _lineStart;
     while (i < limit) {
@@ -1576,6 +1750,19 @@ bool _texCharacterIsEscaped(String text, int index) {
     backslashes++;
   }
   return backslashes.isOdd;
+}
+
+int? _environmentCloserEnd(String line, int tokenEnd) {
+  var i = tokenEnd;
+  while (i < line.length && markdownIsWhitespace(line.codeUnitAt(i))) {
+    _noteScanVisit();
+    i++;
+  }
+  if (i == line.length) return tokenEnd;
+  if (line.codeUnitAt(i) == 0x25 && !_texCharacterIsEscaped(line, i)) {
+    return line.length;
+  }
+  return null;
 }
 
 bool _onlyWhitespaceAfter(String line, int start) {

--- a/lib/shared/widgets/markdown_line_lexer.dart
+++ b/lib/shared/widgets/markdown_line_lexer.dart
@@ -837,7 +837,70 @@ _FenceMark? _fenceMarkOf(String rawLine, int lineStart) {
   );
 }
 
-/// A successful `$$…$$` or `\[…\]` span under the shared pairing rules.
+/// Math environments understood by the bundled TeX parser.
+const markdownMathEnvironments = <String>[
+  'array',
+  'darray',
+  'matrix',
+  'pmatrix',
+  'bmatrix',
+  'Bmatrix',
+  'vmatrix',
+  'Vmatrix',
+  'smallmatrix',
+  'subarray',
+  'cases',
+  'dcases',
+  'rcases',
+  'drcases',
+  'aligned',
+  'alignedat',
+  'equation',
+  'equation*',
+  'align',
+  'align*',
+  'alignat',
+  'alignat*',
+  'gather',
+  'gather*',
+  'gathered',
+  'split',
+];
+
+final _mathEnvironmentToken = RegExp(
+  r'\\(begin|end)\{('
+  '${markdownMathEnvironments.map(RegExp.escape).join('|')}'
+  r')\}',
+);
+
+final _mathEnvironmentTokenTexts = <String>[
+  for (final name in markdownMathEnvironments) ...[
+    '\\begin{$name}',
+    '\\end{$name}',
+  ],
+];
+final _maxMathEnvironmentTokenLength = _mathEnvironmentTokenTexts.fold<int>(
+  0,
+  (longest, token) => token.length > longest ? token.length : longest,
+);
+
+final class _MathEnvironmentMark {
+  const _MathEnvironmentMark(this.name, this.start, this.end);
+
+  final String name;
+  final int start;
+  final int end;
+}
+
+final class _MathEnvironmentToken {
+  const _MathEnvironmentToken(this.start, this.end, this.opening);
+
+  final int start;
+  final int end;
+  final bool opening;
+}
+
+/// A successful display-math span under the shared pairing rules.
 final class MarkdownDisplayMathSpan {
   const MarkdownDisplayMathSpan({required this.start, required this.end});
 
@@ -850,6 +913,8 @@ final class MarkdownDisplayMathSpan {
 /// [contains] is the extractor/classifier view: only successful spans occupy
 /// later content. [covers] is the splitter view: an unclosed opener holds a
 /// later blank until a closer arrives or a later successful span abandons it.
+/// Raw environments retain their unfinished outer body, including completed
+/// nested environments, until their matching outer end arrives.
 final class MarkdownDisplayMathScan {
   const MarkdownDisplayMathScan({this.spans = const [], this.unclosedStart});
 
@@ -877,16 +942,23 @@ final class MarkdownDisplayMathScanner {
   var _scannedTo = 0;
   var _lineStart = 0;
   var _lineLeading = true;
+  var _environmentComment = false;
   final _dollarOpens = <int>[];
   final _dollarCloses = <int>[];
   final _bracketOpens = <int>[];
   final _bracketCloses = <int>[];
+  final _environmentOpens = <_MathEnvironmentMark>[];
+  final _environmentCloses = <String, List<int>>{};
+  final _environmentTokens = <String, List<_MathEnvironmentToken>>{};
   final _fenceOpens = <_FenceMark>[];
   final _fenceCloses = <_FenceMark>[];
   var _chkDollarOpens = 0;
   var _chkDollarCloses = 0;
   var _chkBracketOpens = 0;
   var _chkBracketCloses = 0;
+  var _chkEnvironmentOpens = 0;
+  final _chkEnvironmentCloses = <String, int>{};
+  final _chkEnvironmentTokens = <String, int>{};
   var _chkFenceOpens = 0;
   var _chkFenceCloses = 0;
   final _spans = <MarkdownDisplayMathSpan>[];
@@ -896,6 +968,9 @@ final class MarkdownDisplayMathScanner {
   var _frozenBracketOpenAt = 0;
   var _frozenDollarCloseAt = 0;
   var _frozenBracketCloseAt = 0;
+  var _frozenEnvironmentOpenAt = 0;
+  final _frozenEnvironmentCloseAt = <String, int>{};
+  final _frozenEnvironmentTokenAt = <String, int>{};
   var _frozenFenceOpenAt = 0;
   var _frozenFenceCloseAt = 0;
 
@@ -904,16 +979,23 @@ final class MarkdownDisplayMathScanner {
     _scannedTo = 0;
     _lineStart = 0;
     _lineLeading = true;
+    _environmentComment = false;
     _dollarOpens.clear();
     _dollarCloses.clear();
     _bracketOpens.clear();
     _bracketCloses.clear();
+    _environmentOpens.clear();
+    _environmentCloses.clear();
+    _environmentTokens.clear();
     _fenceOpens.clear();
     _fenceCloses.clear();
     _chkDollarOpens = 0;
     _chkDollarCloses = 0;
     _chkBracketOpens = 0;
     _chkBracketCloses = 0;
+    _chkEnvironmentOpens = 0;
+    _chkEnvironmentCloses.clear();
+    _chkEnvironmentTokens.clear();
     _chkFenceOpens = 0;
     _chkFenceCloses = 0;
     _spans.clear();
@@ -923,6 +1005,9 @@ final class MarkdownDisplayMathScanner {
     _frozenBracketOpenAt = 0;
     _frozenDollarCloseAt = 0;
     _frozenBracketCloseAt = 0;
+    _frozenEnvironmentOpenAt = 0;
+    _frozenEnvironmentCloseAt.clear();
+    _frozenEnvironmentTokenAt.clear();
     _frozenFenceOpenAt = 0;
     _frozenFenceCloseAt = 0;
   }
@@ -956,6 +1041,11 @@ final class MarkdownDisplayMathScanner {
       if (!markdownIsLogicalLineBreak(unit) &&
           _scannedTo + 1 >= limit &&
           (unit == 0x24 || unit == 0x5C)) {
+        _revokeEnvironmentClosersThrough(_scannedTo);
+        return;
+      }
+      if (unit == 0x5C && _hasIncompleteEnvironmentToken(_scannedTo, limit)) {
+        _revokeEnvironmentClosersThrough(_scannedTo);
         return;
       }
       _noteScanVisit();
@@ -965,6 +1055,7 @@ final class MarkdownDisplayMathScanner {
         _scannedTo = _skipLogicalLineBreak(_text, _scannedTo, limit);
         _lineStart = _scannedTo;
         _lineLeading = true;
+        _environmentComment = false;
         _checkpointCurrentLine();
         continue;
       }
@@ -977,6 +1068,13 @@ final class MarkdownDisplayMathScanner {
     _chkDollarCloses = _dollarCloses.length;
     _chkBracketOpens = _bracketOpens.length;
     _chkBracketCloses = _bracketCloses.length;
+    _chkEnvironmentOpens = _environmentOpens.length;
+    for (final entry in _environmentCloses.entries) {
+      _chkEnvironmentCloses[entry.key] = entry.value.length;
+    }
+    for (final entry in _environmentTokens.entries) {
+      _chkEnvironmentTokens[entry.key] = entry.value.length;
+    }
     _chkFenceOpens = _fenceOpens.length;
     _chkFenceCloses = _fenceCloses.length;
   }
@@ -986,11 +1084,45 @@ final class MarkdownDisplayMathScanner {
     _dollarCloses.length = _chkDollarCloses;
     _bracketOpens.length = _chkBracketOpens;
     _bracketCloses.length = _chkBracketCloses;
+    _environmentOpens.length = _chkEnvironmentOpens;
+    for (final entry in _environmentCloses.entries) {
+      entry.value.length = _chkEnvironmentCloses[entry.key] ?? 0;
+    }
+    for (final entry in _environmentTokens.entries) {
+      entry.value.length = _chkEnvironmentTokens[entry.key] ?? 0;
+    }
     _fenceOpens.length = _chkFenceOpens;
     _fenceCloses.length = _chkFenceCloses;
   }
 
   void _consumeAt(int i, int limit) {
+    if (!markdownIsWhitespace(_text.codeUnitAt(i))) {
+      _revokeEnvironmentClosersThrough(i);
+    }
+    if (_text.codeUnitAt(i) == 0x25 && !_texCharacterIsEscaped(_text, i)) {
+      _environmentComment = true;
+    }
+    if (!_environmentComment && _text.codeUnitAt(i) == 0x5C) {
+      final token = _mathEnvironmentToken.matchAsPrefix(_text, i);
+      if (token != null && token.end <= limit) {
+        final name = token.group(2)!;
+        final opening = token.group(1) == 'begin';
+        (_environmentTokens[name] ??= []).add(
+          _MathEnvironmentToken(i, token.end, opening),
+        );
+        _revokeClosersThrough(i);
+        if (opening) {
+          if (_lineLeading) {
+            _environmentOpens.add(_MathEnvironmentMark(name, i, token.end));
+          }
+        } else {
+          (_environmentCloses[name] ??= []).add(i);
+        }
+        _lineLeading = false;
+        _scannedTo = token.end;
+        return;
+      }
+    }
     if (i + 1 < limit && _atDoubleDollar(_text, i)) {
       if (_lineLeading) _dollarOpens.add(i);
       _dollarCloses.add(i);
@@ -1030,6 +1162,28 @@ final class MarkdownDisplayMathScanner {
       if (closer + 2 > nonWsAt) break;
       _bracketCloses.removeLast();
     }
+    _revokeEnvironmentClosersThrough(nonWsAt);
+  }
+
+  void _revokeEnvironmentClosersThrough(int nonWsAt) {
+    for (final entry in _environmentCloses.entries) {
+      final closes = entry.value;
+      final checkpoint = _chkEnvironmentCloses[entry.key] ?? 0;
+      while (closes.length > checkpoint) {
+        _noteScanVisit();
+        if (closes.last + entry.key.length + 6 > nonWsAt) break;
+        closes.removeLast();
+      }
+    }
+  }
+
+  bool _hasIncompleteEnvironmentToken(int start, int limit) {
+    // Every supported token is short; avoid copying a potentially large tail.
+    if (limit - start > _maxMathEnvironmentTokenLength) return false;
+    final tail = _text.substring(start, limit);
+    return _mathEnvironmentTokenTexts.any(
+      (token) => token.length > tail.length && token.startsWith(tail),
+    );
   }
 
   void _collectCompleteLine(int start, int end) {
@@ -1041,6 +1195,7 @@ final class MarkdownDisplayMathScanner {
     }
     final ticks = _LineBackticks.of(rawLine);
     var lineLeading = true;
+    var environmentComment = false;
     var j = 0;
     while (j < rawLine.length) {
       _noteScanVisit();
@@ -1048,6 +1203,32 @@ final class MarkdownDisplayMathScanner {
         j = ticks.advance(j);
         lineLeading = false;
         continue;
+      }
+      if (rawLine.codeUnitAt(j) == 0x25 &&
+          !_texCharacterIsEscaped(rawLine, j)) {
+        environmentComment = true;
+      }
+      if (!environmentComment && rawLine.codeUnitAt(j) == 0x5C) {
+        final token = _mathEnvironmentToken.matchAsPrefix(rawLine, j);
+        if (token != null) {
+          final name = token.group(2)!;
+          final opening = token.group(1) == 'begin';
+          (_environmentTokens[name] ??= []).add(
+            _MathEnvironmentToken(start + j, start + token.end, opening),
+          );
+          if (opening) {
+            if (lineLeading) {
+              _environmentOpens.add(
+                _MathEnvironmentMark(name, start + j, start + token.end),
+              );
+            }
+          } else if (_onlyWhitespaceAfter(rawLine, token.end)) {
+            (_environmentCloses[name] ??= []).add(start + j);
+          }
+          lineLeading = false;
+          j = token.end;
+          continue;
+        }
       }
       if (_atDoubleDollar(rawLine, j)) {
         final at = start + j;
@@ -1083,6 +1264,9 @@ final class MarkdownDisplayMathScanner {
     var bracketOpenAt = _frozenBracketOpenAt;
     var dollarCloseAt = _frozenDollarCloseAt;
     var bracketCloseAt = _frozenBracketCloseAt;
+    var environmentOpenAt = _frozenEnvironmentOpenAt;
+    final environmentCloseAt = Map<String, int>.of(_frozenEnvironmentCloseAt);
+    final environmentTokenAt = Map<String, int>.of(_frozenEnvironmentTokenAt);
     var fenceOpenAt = _frozenFenceOpenAt;
     var fenceCloseAt = _frozenFenceCloseAt;
     int? unclosedStart;
@@ -1122,6 +1306,13 @@ final class MarkdownDisplayMathScanner {
       _frozenBracketOpenAt = nextBracketOpen;
       _frozenDollarCloseAt = nextDollarClose;
       _frozenBracketCloseAt = nextBracketClose;
+      _frozenEnvironmentOpenAt = environmentOpenAt;
+      _frozenEnvironmentCloseAt
+        ..clear()
+        ..addAll(environmentCloseAt);
+      _frozenEnvironmentTokenAt
+        ..clear()
+        ..addAll(environmentTokenAt);
       _frozenFenceOpenAt = nextFenceOpen;
       _frozenFenceCloseAt = nextFenceClose;
     }
@@ -1131,6 +1322,11 @@ final class MarkdownDisplayMathScanner {
       fenceOpenAt = advanceFence(fenceOpenAt, pos);
       dollarOpenAt = advanceInt(_dollarOpens, dollarOpenAt, pos);
       bracketOpenAt = advanceInt(_bracketOpens, bracketOpenAt, pos);
+      while (environmentOpenAt < _environmentOpens.length &&
+          _environmentOpens[environmentOpenAt].start < pos) {
+        _noteScanVisit();
+        environmentOpenAt++;
+      }
       final dollarAt = dollarOpenAt < _dollarOpens.length
           ? _dollarOpens[dollarOpenAt]
           : null;
@@ -1148,11 +1344,76 @@ final class MarkdownDisplayMathScanner {
       }
       final useDollar =
           dollarAt != null && (bracketAt == null || dollarAt <= bracketAt);
-      final mathAt = useDollar ? dollarAt : bracketAt;
+      final delimitedMathAt = useDollar ? dollarAt : bracketAt;
+      final environment = environmentOpenAt < _environmentOpens.length
+          ? _environmentOpens[environmentOpenAt]
+          : null;
+      final useEnvironment =
+          environment != null &&
+          (delimitedMathAt == null || environment.start < delimitedMathAt);
+      final mathAt = useEnvironment ? environment.start : delimitedMathAt;
       if (mathAt == null && fenceAt == null) break;
 
       final mathFirst =
           mathAt != null && (fenceAt == null || mathAt <= fenceAt.start);
+      if (mathFirst && useEnvironment) {
+        final closes = _environmentCloses[environment.name] ?? const <int>[];
+        final tokens = _environmentTokens[environment.name]!;
+        var tokenAt = environmentTokenAt[environment.name] ?? 0;
+        while (tokenAt < tokens.length &&
+            tokens[tokenAt].start < environment.start) {
+          _noteScanVisit();
+          tokenAt++;
+        }
+        environmentTokenAt[environment.name] = tokenAt;
+        var depth = 0;
+        _MathEnvironmentToken? closingToken;
+        for (var i = tokenAt; i < tokens.length; i++) {
+          _noteScanVisit();
+          final token = tokens[i];
+          depth += token.opening ? 1 : -1;
+          if (depth == 0) {
+            closingToken = token;
+            break;
+          }
+        }
+        final closeAt = advanceInt(
+          closes,
+          environmentCloseAt[environment.name] ?? 0,
+          closingToken?.start ?? environment.end,
+        );
+        environmentCloseAt[environment.name] = closeAt;
+        environmentOpenAt++;
+        if (closingToken != null &&
+            closeAt < closes.length &&
+            closes[closeAt] == closingToken.start) {
+          pos = closingToken.end;
+          _spans.add(
+            MarkdownDisplayMathSpan(start: environment.start, end: pos),
+          );
+          unclosedStart = null;
+          freeze(
+            pos,
+            dollarOpenAt,
+            bracketOpenAt,
+            dollarCloseAt,
+            bracketCloseAt,
+            fenceOpenAt,
+            fenceCloseAt,
+          );
+        } else if (closingToken == null) {
+          unclosedStart ??= environment.start;
+          earliestUnresolved ??= environment.start;
+          // A later environment may be a nested matrix or alignment whose
+          // outer end has not streamed in yet. Keep the outer body together.
+          break;
+        } else {
+          // The balanced environment ends mid-line, so it is ordinary text
+          // rather than a standalone display block.
+          pos = closingToken.end;
+        }
+        continue;
+      }
       if (mathFirst) {
         final openAt = mathAt;
         final closes = useDollar ? _dollarCloses : _bracketCloses;
@@ -1265,11 +1526,13 @@ final class MarkdownDisplayMathScanner {
   }
 }
 
-/// Successful display-math spans in [text] using the same pairing as
-/// [LatexBlockScrollableMd]: a closer may be followed only by whitespace on
+/// Successful display-math spans in [text] for Markdown rendering: a closer
+/// may be followed only by whitespace on
 /// its line; an unclosed opener does not occupy later content; a candidate
 /// that starts inside a successful outer span is discarded; leftmost
 /// successful dollar wins over bracket at the same site.
+/// Named environments balance nested instances of the same name, and an
+/// unfinished outer environment protects its body from paragraph splitting.
 ///
 /// Fence and math candidates are merged by start: a successful earlier
 /// fence hides inner math, and a successful earlier math span treats inner
@@ -1288,7 +1551,7 @@ MarkdownDisplayMathScan markdownScanDisplayMath(
 }
 
 /// Whether [content] ends (at [end]) with a successful display-math span
-/// that [LatexBlockScrollableMd] would match.
+/// that the renderer recognizes after normalizing raw environments.
 bool markdownEndsWithDisplayMath(String content, int end) {
   final spans = markdownScanDisplayMath(content, end: end).spans;
   return spans.isNotEmpty && spans.last.end == end;
@@ -1304,6 +1567,15 @@ bool _atEscaped(String line, int i, int unit) {
   return i + 1 < line.length &&
       line.codeUnitAt(i) == 0x5C &&
       line.codeUnitAt(i + 1) == unit;
+}
+
+bool _texCharacterIsEscaped(String text, int index) {
+  var backslashes = 0;
+  for (var i = index - 1; i >= 0 && text.codeUnitAt(i) == 0x5C; i--) {
+    _noteScanVisit();
+    backslashes++;
+  }
+  return backslashes.isOdd;
 }
 
 bool _onlyWhitespaceAfter(String line, int start) {

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -33,6 +33,8 @@ import 'package:Kelivo/l10n/app_localizations.dart';
 import 'package:Kelivo/theme/app_font_weights.dart';
 import 'package:Kelivo/theme/theme_factory.dart' show getPlatformFontFallback;
 import 'package:provider/provider.dart';
+import 'package:flutter_math_fork/ast.dart'
+    show EquationArrayNode, GreenNode, TransparentNode;
 import 'package:flutter_math_fork/flutter_math.dart';
 import '../../core/providers/settings_provider.dart';
 import 'package:Kelivo/desktop/html_preview_dialog.dart';
@@ -1576,6 +1578,30 @@ Widget _renderMath(String tex, {TextStyle? style, bool displayMode = false}) {
   } catch (_) {
     return Text(normalizedTex, style: resolved);
   }
+}
+
+bool _usesFullWidthEquationLayout(Widget math) {
+  if (math is! Math) return false;
+  final root = math.ast?.greenRoot;
+  if (root == null) return false;
+
+  final flattened = <GreenNode>[];
+  void collect(GreenNode node) {
+    if (node is TransparentNode) {
+      for (final child in node.children) {
+        collect(child);
+      }
+    } else {
+      flattened.add(node);
+    }
+  }
+
+  for (final child in root.children) {
+    collect(child);
+    if (flattened.length > 1) return false;
+  }
+  final child = flattened.length == 1 ? flattened.single : null;
+  return child is EquationArrayNode && child.displayLayout;
 }
 
 TextStyle _inlineMathTextStyle(TextStyle? style) {
@@ -5089,6 +5115,7 @@ class LatexBlockScrollableMd extends BlockMd {
     if (body.isEmpty) return const SizedBox.shrink();
 
     final math = _renderMath(body, style: config.style, displayMode: true);
+    final usesFullWidthLayout = _usesFullWidthEquationLayout(math);
     // Wrap in horizontal scroll to avoid overflow and center within available width
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -5100,7 +5127,7 @@ class LatexBlockScrollableMd extends BlockMd {
               primary: false,
               child: ConstrainedBox(
                 constraints: BoxConstraints(minWidth: constraints.maxWidth),
-                child: Center(child: math),
+                child: usesFullWidthLayout ? math : Center(child: math),
               ),
             ),
           );

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -1023,25 +1023,7 @@ String _preprocessFences(
 
   // STEP 2: PROCESSING (on masked string, code is now protected)
   if (enableMath && out.contains(r'\begin{')) {
-    // Let the shared scanner pair nested environments before handing display
-    // math to the regex-based renderer. Preserve the TeX environment itself.
-    final environments = markdownScanDisplayMath(
-      out,
-    ).spans.where((span) => out.startsWith(r'\begin{', span.start));
-    final wrapped = StringBuffer();
-    var cursor = 0;
-    for (final span in environments) {
-      wrapped
-        ..write(out.substring(cursor, span.start))
-        ..write('\\[\n')
-        ..write(out.substring(span.start, span.end))
-        ..write('\n\\]');
-      cursor = span.end;
-    }
-    if (cursor > 0) {
-      wrapped.write(out.substring(cursor));
-      out = wrapped.toString();
-    }
+    out = _wrapBareMathEnvironments(out);
   }
 
   if (streaming) {
@@ -1179,6 +1161,28 @@ String _preprocessFences(
   });
 
   return out;
+}
+
+String _wrapBareMathEnvironments(String input) {
+  if (!input.contains(r'\begin{')) return input;
+  // Let the shared scanner pair nested environments before handing display
+  // math to the regex-based renderer. Preserve the TeX environment itself.
+  final environments = markdownScanDisplayMath(
+    input,
+  ).spans.where((span) => input.startsWith(r'\begin{', span.start));
+  final wrapped = StringBuffer();
+  var cursor = 0;
+  for (final span in environments) {
+    wrapped
+      ..write(input.substring(cursor, span.start))
+      ..write('\\[\n')
+      ..write(input.substring(span.start, span.end))
+      ..write('\n\\]');
+    cursor = span.end;
+  }
+  if (cursor == 0) return input;
+  wrapped.write(input.substring(cursor));
+  return wrapped.toString();
 }
 
 String _maskHtmlTagStartsInsideFencedCode(String input) {
@@ -5437,7 +5441,7 @@ class ModernBlockQuote extends InlineMd {
         sb.writeln(line);
       }
     }
-    final data = _unmaskBlockquoteFenceMarkers(sb.toString().trim());
+    final data = _unmaskBlockquoteFenceMarkers(sb.toString().trimRight());
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
@@ -5458,6 +5462,9 @@ class ModernBlockQuote extends InlineMd {
       data: data,
       config: config,
       components: innerComponents,
+      enableBareMath: innerComponents.any(
+        (component) => component is LatexBlockScrollableMd,
+      ),
     );
     final child = Directionality(
       textDirection: config.textDirection,
@@ -5505,35 +5512,73 @@ class _BlockquoteMarkdownContent extends StatelessWidget {
     required this.data,
     required this.config,
     required this.components,
+    required this.enableBareMath,
   });
 
   final String data;
   final GptMarkdownConfig config;
   final List<MarkdownComponent> components;
+  final bool enableBareMath;
 
   @override
   Widget build(BuildContext context) {
     final children = <Widget>[];
     final textBuffer = StringBuffer();
     final lines = data.split('\n');
+    final lineStarts = <int>[];
+    var nextLineStart = 0;
+    for (final line in lines) {
+      lineStarts.add(nextLineStart);
+      nextLineStart += line.length + 1;
+    }
+    final mathScan = enableBareMath
+        ? markdownScanDisplayMath(data)
+        : const MarkdownDisplayMathScan();
+    var atBlockBoundary = true;
 
     void flushText() {
-      final text = textBuffer.toString().trim();
-      if (text.isEmpty) {
+      final rawText = textBuffer.toString();
+      if (rawText.trim().isEmpty) {
         textBuffer.clear();
         return;
       }
-      children.add(_buildMarkdown(text));
+      final text = enableBareMath
+          ? _wrapBareMathEnvironments(rawText)
+          : rawText;
+      children.add(_buildMarkdown(text.trimRight()));
       textBuffer.clear();
     }
 
     for (var i = 0; i < lines.length; i++) {
       final line = lines[i];
-      final open = RegExp(
-        r'^[ \t]*(([`~])\2{2,})[ \t]*([^\n]*)$',
-      ).firstMatch(line);
+      final coveredByMath = mathScan.covers(lineStarts[i]);
+      final indentedCode = _blockquoteIndentedCodeLine(line);
+      if (indentedCode != null && atBlockBoundary && !coveredByMath) {
+        flushText();
+        final codeBuffer = StringBuffer()..writeln(indentedCode);
+        while (i + 1 < lines.length) {
+          final next = _blockquoteIndentedCodeLine(lines[i + 1]);
+          if (next == null) break;
+          i++;
+          codeBuffer.writeln(next);
+        }
+        children.add(
+          _CollapsibleCodeBlock(
+            language: '',
+            code: codeBuffer.toString(),
+            streaming: false,
+            closed: true,
+          ),
+        );
+        atBlockBoundary = true;
+        continue;
+      }
+      final open = coveredByMath
+          ? null
+          : RegExp(r'^[ \t]*(([`~])\2{2,})[ \t]*([^\n]*)$').firstMatch(line);
       if (open == null) {
         textBuffer.writeln(line);
+        atBlockBoundary = line.trim().isEmpty;
         continue;
       }
 
@@ -5566,6 +5611,7 @@ class _BlockquoteMarkdownContent extends StatelessWidget {
           closed: closed,
         ),
       );
+      atBlockBoundary = true;
     }
 
     flushText();
@@ -5596,7 +5642,12 @@ class _BlockquoteMarkdownContent extends StatelessWidget {
       orderedListBuilder: config.orderedListBuilder,
       unOrderedListBuilder: config.unOrderedListBuilder,
       tableBuilder: config.tableBuilder,
-      components: components,
+      // Fences outside math were already extracted above. Keeping the block
+      // matcher here would reinterpret a TeX spacing line inside a wrapped
+      // environment as the start of a code fence.
+      components: components
+          .where((component) => component is! FencedCodeBlockMd)
+          .toList(growable: false),
       inlineComponents: config.inlineComponents,
       followLinkColor: config.followLinkColor,
       useDollarSignsForLatex: false,
@@ -5604,6 +5655,23 @@ class _BlockquoteMarkdownContent extends StatelessWidget {
       generation: config.generation,
     );
   }
+}
+
+String? _blockquoteIndentedCodeLine(String line) {
+  var columns = 0;
+  var i = 0;
+  while (i < line.length && columns < 4) {
+    final unit = line.codeUnitAt(i);
+    if (unit == 0x20) {
+      columns++;
+    } else if (unit == 0x09) {
+      columns += 4 - (columns % 4);
+    } else {
+      return null;
+    }
+    i++;
+  }
+  return columns >= 4 ? line.substring(i) : null;
 }
 
 // Modern task checkbox: square with subtle border, primary check on done

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -1020,6 +1020,28 @@ String _preprocessFences(
   });
 
   // STEP 2: PROCESSING (on masked string, code is now protected)
+  if (enableMath && out.contains(r'\begin{')) {
+    // Let the shared scanner pair nested environments before handing display
+    // math to the regex-based renderer. Preserve the TeX environment itself.
+    final environments = markdownScanDisplayMath(
+      out,
+    ).spans.where((span) => out.startsWith(r'\begin{', span.start));
+    final wrapped = StringBuffer();
+    var cursor = 0;
+    for (final span in environments) {
+      wrapped
+        ..write(out.substring(cursor, span.start))
+        ..write('\\[\n')
+        ..write(out.substring(span.start, span.end))
+        ..write('\n\\]');
+      cursor = span.end;
+    }
+    if (cursor > 0) {
+      wrapped.write(out.substring(cursor));
+      out = wrapped.toString();
+    }
+  }
+
   if (streaming) {
     out = _stabilizeStreamingTables(out);
     if (enableMath && enableDollarLatex) {
@@ -1547,6 +1569,7 @@ Widget _renderMath(String tex, {TextStyle? style, bool displayMode = false}) {
     return Math.tex(
       normalizedTex,
       mathStyle: displayMode ? MathStyle.display : MathStyle.text,
+      settings: TexParserSettings(displayMode: displayMode),
       textStyle: resolved,
       onErrorFallback: (_) => Text(normalizedTex, style: resolved),
     );
@@ -2155,6 +2178,11 @@ bool _looksLikeLiteralMathBraceGroup(String tex, int open, int close) {
 bool _isCommandArgumentBrace(String tex, int open) {
   final prev = _previousNonWhitespaceIndex(tex, open - 1);
   if (prev == -1) return false;
+
+  if (tex.codeUnitAt(prev) == 0x2A &&
+      _endsControlWordAt(tex, _previousNonWhitespaceIndex(tex, prev - 1))) {
+    return true;
+  }
 
   if (tex.codeUnitAt(prev) == 0x5D) {
     final optionalOpen = _findMatchingOpenBracket(tex, prev);
@@ -5049,7 +5077,7 @@ class FencedCodeBlockMd extends BlockMd {
 /// Scrollable LaTeX block to prevent overflow when equations are very wide
 class LatexBlockScrollableMd extends BlockMd {
   @override
-  // Match either $$...$$ or \[...\] as standalone block
+  // Bare environments are wrapped by _preprocessFences after balanced scanning.
   String get expString =>
       (r"^(?:\s*\$\$([\s\S]*?)\$\$\s*|\s*\\\[([\s\S]*?)\\\]\s*)$");
 
@@ -5057,7 +5085,7 @@ class LatexBlockScrollableMd extends BlockMd {
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {
     final m = exp.firstMatch(text.trim());
     if (m == null) return const SizedBox.shrink();
-    final body = ((m.group(1) ?? m.group(2) ?? '')).trim();
+    final body = (m.group(1) ?? m.group(2) ?? '').trim();
     if (body.isEmpty) return const SizedBox.shrink();
 
     final math = _renderMath(body, style: config.style, displayMode: true);

--- a/test/shared/widgets/incremental_markdown_document_test.dart
+++ b/test/shared/widgets/incremental_markdown_document_test.dart
@@ -95,6 +95,55 @@ void main() {
     expect(blocks[1].text, contains('\$\$'));
   });
 
+  test('bare equation environments preserve blanks and the next paragraph', () {
+    for (final name in const ['equation', 'equation*', 'align', 'gather']) {
+      final equation = '\\begin{$name}\na + b\n\nc + d\n\\end{$name}';
+      final blocks = IncrementalMarkdownDocument().update(
+        'before\n\n$equation\n\nafter',
+      );
+      expect(blocks, hasLength(3), reason: name);
+      expect(blocks[1].text, equation);
+      expect(blocks.last.text, 'after');
+    }
+  });
+
+  test('streamed bare environments keep blanks until the matching end', () {
+    final document = IncrementalMarkdownDocument();
+    const prefix = '\\begin{equation}\na\n\nb\n';
+    for (var end = 1; end <= prefix.length; end++) {
+      final blocks = document.update(prefix.substring(0, end));
+      expect(blocks, hasLength(1));
+      expect(blocks.single.stable, isFalse);
+    }
+
+    const source = '$prefix\\end{equation}\n\nafter';
+    final blocks = document.update(source);
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, '$prefix\\end{equation}');
+    expect(blocks.first.stable, isTrue);
+    expect(blocks.last.text, 'after');
+  });
+
+  test('inline environment examples do not retain later paragraphs', () {
+    final blocks = IncrementalMarkdownDocument().update(
+      'Use `\\begin{equation}`.\n\nfirst\n\nsecond',
+    );
+    expect(blocks, hasLength(3));
+    expect(blocks.last.text, 'second');
+  });
+
+  test('nested environments stay in one block through the outer closer', () {
+    final document = IncrementalMarkdownDocument();
+    const source = '\\begin{pmatrix}\n\\begin{pmatrix}a\\end{pmatrix}\n\n';
+    final pending = document.update(source);
+    expect(pending, hasLength(1));
+    expect(pending.single.stable, isFalse);
+    final complete = document.update('$source& b\n\\end{pmatrix}\n\nafter');
+    expect(complete, hasLength(2));
+    expect(complete.first.text, contains(source));
+    expect(complete.last.text, 'after');
+  });
+
   test(
     'blank lines inside bracket display math do not split source blocks',
     () {

--- a/test/shared/widgets/incremental_markdown_document_test.dart
+++ b/test/shared/widgets/incremental_markdown_document_test.dart
@@ -107,6 +107,20 @@ void main() {
     }
   });
 
+  test('CommonMark indented code is not retained as a bare environment', () {
+    for (final indent in const ['    ', '\t', ' \t', '   \t']) {
+      final source =
+          '$indent\\begin{equation}\n\n'
+          'outside\n\n'
+          'after';
+      final blocks = IncrementalMarkdownDocument().update(source);
+      expect(blocks, hasLength(3), reason: 'indent ${indent.codeUnits}');
+      expect(blocks.first.text, '$indent\\begin{equation}');
+      expect(blocks[1].text, 'outside');
+      expect(blocks.last.text, 'after');
+    }
+  });
+
   test('streamed bare environments keep blanks until the matching end', () {
     final document = IncrementalMarkdownDocument();
     const prefix = '\\begin{equation}\na\n\nb\n';
@@ -122,6 +136,19 @@ void main() {
     expect(blocks.first.text, '$prefix\\end{equation}');
     expect(blocks.first.stable, isTrue);
     expect(blocks.last.text, 'after');
+  });
+
+  test('a streamed TeX-commented environment closer releases later blocks', () {
+    final document = IncrementalMarkdownDocument();
+    var source = '\\begin{equation}\na\n\nb\n\\end{equation}';
+    for (final chunk in const ['%', ' comment', '\n', '\n', 'after']) {
+      source += chunk;
+      document.update(source);
+    }
+    expect(document.blocks, hasLength(2));
+    expect(document.blocks.first.text, endsWith(r'\end{equation}% comment'));
+    expect(document.blocks.first.stable, isTrue);
+    expect(document.blocks.last.text, 'after');
   });
 
   test('inline environment examples do not retain later paragraphs', () {
@@ -263,6 +290,44 @@ void main() {
 
   test('math-dense splitter scans stay linear one-shot and chunked', () {
     _expectDocumentLinearScan((_) => '\$\$\nx\n\$\$\n\n', chunks: 80);
+  });
+
+  test('splitter resumes an unclosed outer environment pairing linearly', () {
+    final document = IncrementalMarkdownDocument();
+    var source = '\\begin{pmatrix}\n';
+    debugResetMarkdownScanVisits();
+    document.update(source);
+    for (var i = 0; i < 1000; i++) {
+      source += '\\begin{pmatrix}x\\end{pmatrix}\n';
+      document.update(source);
+    }
+    expect(source.length, 30016);
+    expect(document.blocks, hasLength(1));
+    expect(document.blocks.single.stable, isFalse);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+    source += '\\end{pmatrix}%';
+    final comment = List.filled(
+      40,
+      r'\begin{pmatrix}\end{pmatrix}$$\[\]',
+    ).join().substring(0, 1000);
+    for (final unit in comment.codeUnits) {
+      source += String.fromCharCode(unit);
+      final scan = document.update(source);
+      expect(scan, hasLength(1));
+      expect(scan.single.text, source);
+    }
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+    source += '\n\nafter';
+    final complete = document.update(source);
+    expect(complete, hasLength(2));
+    expect(complete.first.stable, isTrue);
+    expect(complete.last.text, 'after');
   });
 
   test('fence-dense splitter scans stay linear one-shot and chunked', () {

--- a/test/shared/widgets/markdown_line_lexer_test.dart
+++ b/test/shared/widgets/markdown_line_lexer_test.dart
@@ -171,6 +171,222 @@ void main() {
     expect(_normalizedSpans(escaped), [(0, escaped.length)]);
   });
 
+  test('TeX verb payloads do not contribute environment tokens', () {
+    for (final source in const [
+      '\\begin{equation}\n'
+          '\\verb|\\begin{equation}|\n'
+          'x=1\n'
+          '\\end{equation}',
+      '\\begin{equation}\n'
+          '\\verb*+\\end{equation}+\n'
+          'x=1\n'
+          '\\end{equation}',
+    ]) {
+      expect(_normalizedSpans(source), [(0, source.length)], reason: source);
+
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final prefix = source.substring(0, end);
+        final streamed = scanner.synchronize(prefix);
+        final oneShot = markdownScanDisplayMath(prefix);
+        expect(
+          [for (final span in streamed.spans) (span.start, span.end)],
+          [for (final span in oneShot.spans) (span.start, span.end)],
+          reason: prefix,
+        );
+        expect(streamed.unclosedStart, oneShot.unclosedStart, reason: prefix);
+      }
+    }
+  });
+
+  test('TeX verb eligibility stays linear on streamed backslash runs', () {
+    final scanner = MarkdownDisplayMathScanner();
+    var source = '';
+    debugResetMarkdownScanVisits();
+    for (var i = 0; i < 2000; i++) {
+      source += String.fromCharCode(0x5C);
+      expect(scanner.synchronize(source).spans, isEmpty);
+    }
+    expect(source.length, 2000);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('pending verb backtick checks resume without rescanning payload', () {
+    final scanner = MarkdownDisplayMathScanner();
+    final backtick = String.fromCharCode(0x60);
+    var source = '${backtick}x\\verb|';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var i = 0; i < 2000; i++) {
+      source += 'a';
+      expect(scanner.synchronize(source).spans, isEmpty);
+    }
+    expect(source.length, 2008);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('a slash-delimited TeX verb does not escape following comments', () {
+    const source =
+        '\\begin{equation}\n'
+        '\\verb\\foo\\% \\begin{equation}\n'
+        'x=1\n'
+        '\\end{equation}';
+    expect(_normalizedSpans(source), [(0, source.length)]);
+
+    final scanner = MarkdownDisplayMathScanner();
+    for (var end = 1; end <= source.length; end++) {
+      final prefix = source.substring(0, end);
+      final streamed = scanner.synchronize(prefix);
+      final oneShot = markdownScanDisplayMath(prefix);
+      expect(
+        [for (final span in streamed.spans) (span.start, span.end)],
+        [for (final span in oneShot.spans) (span.start, span.end)],
+        reason: prefix,
+      );
+      expect(streamed.unclosedStart, oneShot.unclosedStart, reason: prefix);
+    }
+  });
+
+  test('inline code can close inside a TeX verb payload before newline', () {
+    final backtick = String.fromCharCode(0x60);
+    final source =
+        '\\begin{equation}\n'
+        '$backtick\\verb|abc$backtick \\end{equation}%|';
+    final oneShot = markdownScanDisplayMath(source);
+    expect(
+      [for (final span in oneShot.spans) (span.start, span.end)],
+      [(0, source.length)],
+    );
+    expect(oneShot.unclosedStart, isNull);
+
+    final scanner = MarkdownDisplayMathScanner();
+    for (var end = 1; end <= source.length; end++) {
+      final prefix = source.substring(0, end);
+      final streamed = scanner.synchronize(prefix);
+      final fresh = markdownScanDisplayMath(prefix);
+      expect(
+        [for (final span in streamed.spans) (span.start, span.end)],
+        [for (final span in fresh.spans) (span.start, span.end)],
+        reason: prefix,
+      );
+      expect(streamed.unclosedStart, fresh.unclosedStart, reason: prefix);
+    }
+  });
+
+  test('a terminal verb backtick pair can extend before it is finalized', () {
+    final backtick = String.fromCharCode(0x60);
+    final base = '\\begin{equation}\n$backtick\\verb|abc';
+    final pairedAtEnd = '$base$backtick';
+    final extendedAtEnd = '$pairedAtEnd$backtick';
+    for (final source in [pairedAtEnd, extendedAtEnd]) {
+      final scan = markdownScanDisplayMath(source);
+      expect(scan.spans, isEmpty, reason: source);
+      expect(scan.unclosedStart, 0, reason: source);
+    }
+
+    final pairedThenClosed = '$pairedAtEnd \\end{equation}%|';
+    final pairedScanner = MarkdownDisplayMathScanner();
+    pairedScanner.synchronize(pairedAtEnd);
+    final paired = pairedScanner.synchronize(pairedThenClosed);
+    expect(
+      [for (final span in paired.spans) (span.start, span.end)],
+      [(0, pairedThenClosed.length)],
+    );
+
+    final extendedThenClosed = '$extendedAtEnd \\end{equation}|';
+    final extendedScanner = MarkdownDisplayMathScanner();
+    extendedScanner.synchronize(pairedAtEnd);
+    extendedScanner.synchronize(extendedAtEnd);
+    final extended = extendedScanner.synchronize(extendedThenClosed);
+    expect(extended.spans, isEmpty);
+    expect(extended.unclosedStart, 0);
+    expect(
+      [for (final span in extended.spans) (span.start, span.end)],
+      [
+        for (final span in markdownScanDisplayMath(extendedThenClosed).spans)
+          (span.start, span.end),
+      ],
+    );
+  });
+
+  test('a finalized verb code span does not leak pending environments', () {
+    final ticks = String.fromCharCode(0x60) * 2;
+    final source = '\\begin{array}$ticks\\verb$ticks\\end{array}$ticks';
+    expect(source.length, 35);
+
+    final scanner = MarkdownDisplayMathScanner();
+    scanner.synchronize(source.substring(0, 22));
+    final streamed = scanner.synchronize(source);
+    final fresh = markdownScanDisplayMath(source);
+    expect(streamed.spans, isEmpty);
+    expect(streamed.unclosedStart, isNull);
+    expect(fresh.spans, isEmpty);
+    expect(fresh.unclosedStart, isNull);
+  });
+
+  test('complete-line backticks replace provisional verb run state', () {
+    final backtick = String.fromCharCode(0x60);
+    final source =
+        '\\begin{array}\\verb${backtick * 3}'
+        '\\end{array}$backtick\n$backtick\\end{array}$backtick';
+    expect(source.length, 47);
+
+    final scanner = MarkdownDisplayMathScanner();
+    scanner.synchronize(source.substring(0, 46));
+    final streamed = scanner.synchronize(source);
+    final fresh = markdownScanDisplayMath(source);
+    expect(streamed.spans, isEmpty);
+    expect(streamed.unclosedStart, isNull);
+    expect(fresh.spans, isEmpty);
+    expect(fresh.unclosedStart, isNull);
+  });
+
+  test('backslash-led math tokens respect slash-run parity', () {
+    for (final source in const [
+      r'\begin{equation}'
+          '\n'
+          r'\\begin{equation}'
+          '\nx=1\n'
+          r'\end{equation}',
+      r'\begin{equation}'
+          '\n'
+          r'\\end{equation}'
+          '\nx=1\n'
+          r'\end{equation}',
+      r'\['
+          '\n'
+          r'\\['
+          '\nx=1\n'
+          r'\]',
+      r'\['
+          '\n'
+          r'\\]'
+          '\nx=1\n'
+          r'\]',
+    ]) {
+      expect(_normalizedSpans(source), [(0, source.length)], reason: source);
+
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final prefix = source.substring(0, end);
+        final streamed = scanner.synchronize(prefix);
+        final oneShot = markdownScanDisplayMath(prefix);
+        expect(
+          [for (final span in streamed.spans) (span.start, span.end)],
+          [for (final span in oneShot.spans) (span.start, span.end)],
+          reason: prefix,
+        );
+        expect(streamed.unclosedStart, oneShot.unclosedStart, reason: prefix);
+      }
+    }
+  });
+
   test('an unescaped TeX comment may follow an environment closer', () {
     for (final tail in const [
       '% comment',
@@ -305,9 +521,180 @@ void main() {
     );
   });
 
+  test('an unclosed outer environment resumes same-line pairing linearly', () {
+    final scanner = MarkdownDisplayMathScanner();
+    var source = r'\begin{pmatrix}';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var i = 0; i < 1000; i++) {
+      source += r'\begin{pmatrix}x\end{pmatrix}';
+      final scan = scanner.synchronize(source);
+      expect(scan.spans, isEmpty);
+      expect(scan.unclosedStart, 0);
+    }
+    expect(source.length, 29015);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+    source += r'\end{pmatrix}';
+    final complete = scanner.synchronize(source);
+    expect(
+      [for (final span in complete.spans) (span.start, span.end)],
+      [(0, source.length)],
+    );
+  });
+
+  test(
+    'an unmatched backtick does not stall same-line environment pairing',
+    () {
+      final scanner = MarkdownDisplayMathScanner();
+      var source = r'\begin{pmatrix}' + String.fromCharCode(0x60);
+      debugResetMarkdownScanVisits();
+      scanner.synchronize(source);
+      for (var i = 0; i < 1000; i++) {
+        source += r'\begin{pmatrix}x\end{pmatrix}';
+        final scan = scanner.synchronize(source);
+        expect(scan.spans, isEmpty);
+        expect(scan.unclosedStart, 0);
+      }
+      expect(source.length, 29016);
+      expect(
+        debugMarkdownScanVisits,
+        lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+      );
+      source += r'\end{pmatrix}';
+      final complete = scanner.synchronize(source);
+      expect(
+        [for (final span in complete.spans) (span.start, span.end)],
+        [(0, source.length)],
+      );
+    },
+  );
+
+  test('incremental backtick pairing stays linear across many runs', () {
+    final scanner = MarkdownDisplayMathScanner();
+    final backtick = String.fromCharCode(0x60);
+    var source = r'\begin{pmatrix}';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var i = 0; i < 1000; i++) {
+      source += '${backtick}x';
+      final scan = scanner.synchronize(source);
+      expect(scan.spans, isEmpty);
+      expect(scan.unclosedStart, 0);
+    }
+    expect(source.length, 2015);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('many finalized inline-code tokens keep pairing linear', () {
+    final scanner = MarkdownDisplayMathScanner();
+    final backtick = String.fromCharCode(0x60);
+    var source = r'\begin{pmatrix}';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var i = 0; i < 1000; i++) {
+      source += '$backtick\\begin{pmatrix}$backtick ';
+      final scan = scanner.synchronize(source);
+      expect(scan.spans, isEmpty);
+      expect(scan.unclosedStart, 0);
+    }
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('growing terminal runs skip hidden environment suffixes linearly', () {
+    final scanner = MarkdownDisplayMathScanner();
+    final backtick = String.fromCharCode(0x60);
+    var source = r'\begin{pmatrix}';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var length = 1; length <= 300; length++) {
+      source += '${backtick * length}x';
+      expect(scanner.synchronize(source).unclosedStart, 0);
+    }
+    for (var i = 0; i < 3000; i++) {
+      source += r'\begin{pmatrix}x\end{pmatrix}';
+      expect(scanner.synchronize(source).unclosedStart, 0);
+    }
+    for (var length = 1; length <= 300; length++) {
+      source += backtick;
+      expect(scanner.synchronize(source).unclosedStart, 0);
+    }
+    expect(source.length, 132765);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('chunked backtick and partial-token changes stay equivalent', () {
+    final scanner = MarkdownDisplayMathScanner();
+    final backticks = String.fromCharCode(0x60) * 2;
+    final chunks = [
+      r'\[',
+      r'\]',
+      r'\begin{pmatri',
+      backticks,
+      r'$$',
+      r'\%',
+      r'\]',
+      r'\[',
+    ];
+    var source = '';
+    for (final chunk in chunks) {
+      source += chunk;
+      final streamed = scanner.synchronize(source);
+      final oneShot = markdownScanDisplayMath(source);
+      expect(
+        [for (final span in streamed.spans) (span.start, span.end)],
+        [for (final span in oneShot.spans) (span.start, span.end)],
+        reason: source,
+      );
+      expect(streamed.unclosedStart, oneShot.unclosedStart, reason: source);
+    }
+  });
+
+  test('a backtick-paired region rolls pending environment depth back', () {
+    final backtick = String.fromCharCode(0x60);
+    final pending = '\\begin{pmatrix}$backtick\\begin{pmatrix}';
+    final complete = '$pending$backtick\n\\end{pmatrix}';
+    final scanner = MarkdownDisplayMathScanner();
+
+    expect(scanner.synchronize(pending).unclosedStart, 0);
+    final streamed = scanner.synchronize(complete);
+    expect(
+      [for (final span in streamed.spans) (span.start, span.end)],
+      [(0, complete.length)],
+    );
+    expect([
+      for (final span in streamed.spans) (span.start, span.end),
+    ], _normalizedSpans(complete));
+  });
+
   test('unclosed inline code does not hide a later display-math closer', () {
     const content = '`unclosed\n\$\$ `x` \$\$';
     expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('inline code hides a fake environment closer before a newline', () {
+    final backtick = String.fromCharCode(0x60);
+    final source = '\\begin{equation}\n$backtick\\end{equation}$backtick';
+    final scanner = MarkdownDisplayMathScanner();
+
+    final oneShot = markdownScanDisplayMath(source);
+    expect(oneShot.spans, isEmpty);
+    expect(oneShot.unclosedStart, 0);
+    final streamed = scanner.synchronize(source);
+    expect(streamed.spans, isEmpty);
+    expect(streamed.unclosedStart, 0);
+    expect(scanner.synchronize('$source\n').unclosedStart, 0);
   });
 
   test(

--- a/test/shared/widgets/markdown_line_lexer_test.dart
+++ b/test/shared/widgets/markdown_line_lexer_test.dart
@@ -45,6 +45,45 @@ void main() {
     },
   );
 
+  test('bare environments reject CommonMark indented code openers', () {
+    for (final indent in const ['    ', '\t', ' \t', '   \t']) {
+      final source =
+          '$indent\\begin{equation}\n'
+          '${indent}x = 1\n'
+          '$indent\\end{equation}';
+      final scan = markdownScanDisplayMath(source);
+      expect(scan.spans, isEmpty, reason: 'indent ${indent.codeUnits}');
+      expect(scan.unclosedStart, isNull, reason: 'indent ${indent.codeUnits}');
+
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final streamed = scanner.synchronize(source.substring(0, end));
+        expect(
+          streamed.spans,
+          isEmpty,
+          reason: 'indent ${indent.codeUnits}, prefix $end',
+        );
+        expect(
+          streamed.unclosedStart,
+          isNull,
+          reason: 'indent ${indent.codeUnits}, prefix $end',
+        );
+      }
+    }
+  });
+
+  test('bare environments allow up to three leading columns', () {
+    for (final indent in const ['', ' ', '  ', '   ']) {
+      final source =
+          '$indent\\begin{equation}\n'
+          'x = 1\n'
+          '\\end{equation}';
+      expect(_normalizedSpans(source), [
+        (indent.length, source.length),
+      ], reason: 'indent ${indent.codeUnits}');
+    }
+  });
+
   test(
     'outer environments retain nested math and ignore unrelated closers',
     () {
@@ -132,6 +171,81 @@ void main() {
     expect(_normalizedSpans(escaped), [(0, escaped.length)]);
   });
 
+  test('an unescaped TeX comment may follow an environment closer', () {
+    for (final tail in const [
+      '% comment',
+      '  % comment',
+      '% \\end{equation}',
+    ]) {
+      final source = '\\begin{equation}\nx = 1\n\\end{equation}$tail';
+      final oneShot = markdownScanDisplayMath(source);
+      expect(oneShot.spans, hasLength(1), reason: tail);
+      expect(oneShot.spans.single.start, 0, reason: tail);
+      expect(oneShot.spans.single.end, source.length, reason: tail);
+      expect(oneShot.unclosedStart, isNull, reason: tail);
+
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final prefix = source.substring(0, end);
+        final streamed = scanner.synchronize(prefix);
+        final complete = markdownScanDisplayMath(prefix);
+        expect(
+          [for (final span in streamed.spans) (span.start, span.end)],
+          [for (final span in complete.spans) (span.start, span.end)],
+          reason: prefix,
+        );
+        expect(streamed.unclosedStart, complete.unclosedStart, reason: prefix);
+      }
+    }
+  });
+
+  test('an escaped percent after an environment closer remains content', () {
+    const source =
+        '\\begin{equation}\n'
+        'x = 1\n'
+        '\\end{equation}\\% visible';
+    final oneShot = markdownScanDisplayMath(source);
+    expect(oneShot.spans, isEmpty);
+    expect(oneShot.unclosedStart, isNull);
+
+    final scanner = MarkdownDisplayMathScanner();
+    for (var end = 1; end <= source.length; end++) {
+      final prefix = source.substring(0, end);
+      final streamed = scanner.synchronize(prefix);
+      final complete = markdownScanDisplayMath(prefix);
+      expect(
+        [for (final span in streamed.spans) (span.start, span.end)],
+        [for (final span in complete.spans) (span.start, span.end)],
+        reason: prefix,
+      );
+      expect(streamed.unclosedStart, complete.unclosedStart, reason: prefix);
+    }
+  });
+
+  test('math delimiters split inside a TeX-comment line stay equivalent', () {
+    for (final source in const [
+      r'$$'
+          '\n%'
+          r'$$',
+      r'\['
+          '\n%'
+          r'\]',
+    ]) {
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final prefix = source.substring(0, end);
+        final streamed = scanner.synchronize(prefix);
+        final complete = markdownScanDisplayMath(prefix);
+        expect(
+          [for (final span in streamed.spans) (span.start, span.end)],
+          [for (final span in complete.spans) (span.start, span.end)],
+          reason: prefix,
+        );
+        expect(streamed.unclosedStart, complete.unclosedStart, reason: prefix);
+      }
+    }
+  });
+
   test('environment tokens can arrive one character at a time', () {
     for (final source in const [
       'before\n\n\\begin{equation*}\na\n\nb\n\\end{equation*}\n\nafter',
@@ -164,6 +278,30 @@ void main() {
     _expectLinearScan(
       (i) => '\\begin{equation}\nx$i\n\\end{equation}\n\n',
       chunks: 80,
+    );
+  });
+
+  test('an unclosed outer environment resumes same-name pairing linearly', () {
+    final scanner = MarkdownDisplayMathScanner();
+    var source = '\\begin{pmatrix}\n';
+    debugResetMarkdownScanVisits();
+    scanner.synchronize(source);
+    for (var i = 0; i < 1000; i++) {
+      source += '\\begin{pmatrix}x\\end{pmatrix}\n';
+      final scan = scanner.synchronize(source);
+      expect(scan.spans, isEmpty);
+      expect(scan.unclosedStart, 0);
+    }
+    expect(source.length, 30016);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+    source += r'\end{pmatrix}';
+    final complete = scanner.synchronize(source);
+    expect(
+      [for (final span in complete.spans) (span.start, span.end)],
+      [(0, source.length)],
     );
   });
 

--- a/test/shared/widgets/markdown_line_lexer_test.dart
+++ b/test/shared/widgets/markdown_line_lexer_test.dart
@@ -15,6 +15,158 @@ String _unmatchedBacktickRuns({int maxRun = 200}) {
 void main() {
   tearDown(debugDisableMarkdownScanVisits);
 
+  test('supported bare math environments retain their complete source', () {
+    for (final name in markdownMathEnvironments) {
+      final source = '\\begin{$name}\na^2 + b^2 = c^2\n\n\\end{$name}';
+      expect(_normalizedSpans(source), [(0, source.length)], reason: name);
+      expect(markdownEndsWithDisplayMath(source, source.length), isTrue);
+    }
+  });
+
+  test(
+    'bare environments require matching supported names and block bounds',
+    () {
+      for (final source in const [
+        r'\begin{equation}x\end{align}',
+        r'\begin{equation*}x\end{equation}',
+        r'\begin{document}x\end{document}',
+        r'Prose \begin{equation}x\end{equation}',
+        r'\begin{equation}x\end{equation} trailing prose',
+        r'\\begin{equation}x\end{equation}',
+      ]) {
+        expect(markdownScanDisplayMath(source).spans, isEmpty, reason: source);
+      }
+      final disabled = markdownScanDisplayMath(
+        r'\begin{equation}x\end{equation}',
+        enableMath: false,
+      );
+      expect(disabled.spans, isEmpty);
+      expect(disabled.unclosedStart, isNull);
+    },
+  );
+
+  test(
+    'outer environments retain nested math and ignore unrelated closers',
+    () {
+      const source =
+          r'\begin{equation}'
+          '\n'
+          r'\begin{aligned} a &= b \\ c &= d \end{aligned}'
+          '\n'
+          r'\end{equation}';
+      expect(_normalizedSpans(source), [(0, source.length)]);
+
+      final wrapped = '\$\$\n$source\n\$\$';
+      expect(_normalizedSpans(wrapped), [(0, wrapped.length)]);
+
+      const later =
+          r'\begin{equation}'
+          '\n'
+          r'\begin{align}a &= b\end{align}';
+      final scan = markdownScanDisplayMath(later);
+      expect(scan.spans, isEmpty);
+      expect(scan.unclosedStart, 0);
+    },
+  );
+
+  test('nested instances of one environment close at the matching depth', () {
+    for (final source in const [
+      '\\begin{pmatrix}\n\\begin{pmatrix}a\\end{pmatrix}\n'
+          '\n& b\n\\end{pmatrix}',
+      r'\begin{pmatrix}\begin{pmatrix}a\end{pmatrix} & b\end{pmatrix}',
+    ]) {
+      expect(_normalizedSpans(source), [(0, source.length)]);
+      final adjacent = '$source\n\n$source';
+      expect(_normalizedSpans(adjacent), [
+        (0, source.length),
+        (source.length + 2, adjacent.length),
+      ]);
+    }
+    const pending = '\\begin{pmatrix}\n\\begin{pmatrix}a\\end{pmatrix}\n\n';
+    final scan = markdownScanDisplayMath(pending);
+    expect(scan.spans, isEmpty);
+    expect(scan.unclosedStart, 0);
+  });
+
+  test('code fences and inline code keep environment commands literal', () {
+    for (final fence in const ['```', '~~~~']) {
+      final source = '$fence\n\\begin{equation}\nx\n\\end{equation}\n$fence';
+      expect(markdownScanDisplayMath(source).spans, isEmpty);
+    }
+    const inline =
+        r'`\begin{equation}`'
+        '\n\nnext';
+    expect(markdownScanDisplayMath(inline).unclosedStart, isNull);
+
+    const hiddenClose =
+        r'\begin{equation}'
+        '\n'
+        r'`\end{equation}`'
+        '\n';
+    final scan = markdownScanDisplayMath(hiddenClose);
+    expect(scan.spans, isEmpty);
+    expect(scan.unclosedStart, 0);
+  });
+
+  test('bare environments protect details bodies and trailing separators', () {
+    const source =
+        r'\begin{equation}'
+        '\n'
+        '<details><summary>literal</summary>body</details>\n'
+        r'\end{equation}';
+    expect(MarkdownDetailsRegistry(enableMath: true).rewrite(source), source);
+    expect(markdownEndsWithDisplayMath(source, source.length), isTrue);
+  });
+
+  test('TeX comments do not contribute environment begin or end tokens', () {
+    for (final comment in const [
+      r'% \begin{equation}',
+      r'% \end{equation}',
+      r'\\% \begin{equation}',
+    ]) {
+      final source = '\\begin{equation}\nx $comment\n\\end{equation}';
+      expect(_normalizedSpans(source), [(0, source.length)], reason: comment);
+    }
+    const escaped =
+        r'\begin{pmatrix}x\% \begin{pmatrix}y\end{pmatrix}\end{pmatrix}';
+    expect(_normalizedSpans(escaped), [(0, escaped.length)]);
+  });
+
+  test('environment tokens can arrive one character at a time', () {
+    for (final source in const [
+      'before\n\n\\begin{equation*}\na\n\nb\n\\end{equation*}\n\nafter',
+      '\\begin{equation}\n\\begin{aligned}a &= b\\end{aligned}\n'
+          '\\end{equation} trailing\n\\end{equation}\n',
+      '```\n\\begin{equation}\nx\n\\end{equation}\n```\n'
+          '\\begin{gather}a\\end{gather}\n',
+      '\\begin{pmatrix}\n\\begin{pmatrix}a\\end{pmatrix}\n'
+          '\n& b\n\\end{pmatrix}\n',
+      r'\begin{equation}a\end{equation}$$',
+      '\\begin{equation}\nx % \\begin{equation}\n\\end{equation}',
+      '\\begin{equation}\nx % \\end{equation}\n\\end{equation}',
+    ]) {
+      final scanner = MarkdownDisplayMathScanner();
+      for (var end = 1; end <= source.length; end++) {
+        final prefix = source.substring(0, end);
+        final scan = scanner.synchronize(prefix);
+        final oneShot = markdownScanDisplayMath(prefix);
+        expect(
+          [for (final span in scan.spans) (span.start, span.end)],
+          [for (final span in oneShot.spans) (span.start, span.end)],
+          reason: prefix,
+        );
+        expect(scan.unclosedStart, oneShot.unclosedStart, reason: prefix);
+      }
+    }
+  });
+
+  test('environment-dense scans stay linear one-shot and chunked', () {
+    _expectLinearScan(
+      (i) => '\\begin{equation}\nx$i\n\\end{equation}\n\n',
+      chunks: 80,
+    );
+  });
+
   test('unclosed inline code does not hide a later display-math closer', () {
     const content = '`unclosed\n\$\$ `x` \$\$';
     expect(markdownEndsWithDisplayMath(content, content.length), isTrue);

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -2615,6 +2615,223 @@ A-->B
     },
   );
 
+  for (final entry in <String, String>{
+    'equation': r'a^2+b^2=c^2',
+    'equation*': r'a^2+b^2=c^2',
+    'align': r'a&=b\\c&=d',
+    'align*': r'a&=b\\c&=d',
+    'gather': r'a=b\\c=d',
+    'gather*': r'a=b\\c=d',
+    'aligned': r'a&=b\\c&=d',
+    'gathered': r'a=b\\c=d',
+    'split': r'a&=b\\&=c',
+    'pmatrix': r'a&b\\c&d',
+    'cases': r'x&x>0\\0&x=0',
+  }.entries) {
+    testWidgets('renders bare ${entry.key} math environment', (tester) async {
+      final source =
+          '\\begin{${entry.key}}\n${entry.value}\n\\end{${entry.key}}';
+      await tester.pumpWidget(_markdownHarness('Before\n\n$source\n\nAfter'));
+      await tester.pump();
+
+      final widgets = _mathWidgets(tester);
+      expect(widgets, hasLength(1));
+      expect(widgets.single.parseError, isNull);
+      expect(widgets.single.mathStyle, MathStyle.display);
+      expect(find.textContaining(r'\begin'), findsNothing);
+      expect(find.textContaining('Before'), findsOneWidget);
+      expect(find.textContaining('After'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('renders nested environments and visible equation tags', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _markdownHarness(r'''
+\begin{equation}
+\begin{aligned}
+f(x)&=\operatorname{sin} x\\
+g(x)&=\operatorname*{arg\,max}_{y} f(y)
+\end{aligned}
+\tag{Pythagoras}
+\end{equation}
+
+\[
+a^2+b^2=c^2\tag*{Identity}
+\]
+'''),
+    );
+    await tester.pump();
+
+    final widgets = _mathWidgets(tester);
+    expect(widgets, hasLength(2));
+    expect(widgets.map((widget) => widget.parseError), everyElement(isNull));
+    expect(_encodedMathTex(tester)[0], contains('Pythagoras'));
+    expect(_encodedMathTex(tester)[1], contains('Identity'));
+    expect(find.textContaining(r'\tag'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'keeps environment code examples and unknown environments literal',
+    (tester) async {
+      await tester.pumpWidget(
+        _markdownHarness(r'''
+`\begin{equation}x=1\end{equation}`
+
+```latex
+\begin{equation}
+x=1
+\end{equation}
+```
+
+\begin{document}
+Literal document
+\end{document}
+'''),
+      );
+      await tester.pump();
+
+      expect(_findMathWidget(), findsNothing);
+      expect(find.textContaining('Literal document'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('bare environments respect the math rendering setting', (
+    tester,
+  ) async {
+    final harness = await createBusinessTestHarness(
+      initial: const {'display_enable_math_rendering_v1': false},
+    );
+    await tester.pumpWidget(
+      _markdownHarness(
+        r'\begin{equation}a^2+b^2=c^2\end{equation}',
+        businessPreferences: harness.preferences,
+      ),
+    );
+    await tester.pump();
+
+    expect(_findMathWidget(), findsNothing);
+    expect(find.textContaining('a^2+b^2=c^2'), findsOneWidget);
+  });
+
+  testWidgets('bare environments render when dollar math is disabled', (
+    tester,
+  ) async {
+    final harness = await createBusinessTestHarness(
+      initial: const {'display_enable_dollar_latex_v1': false},
+    );
+    await tester.pumpWidget(
+      _markdownHarness(
+        r'\begin{equation}a^2+b^2=c^2\end{equation}',
+        businessPreferences: harness.preferences,
+      ),
+    );
+    await tester.pump();
+
+    expect(_findMathWidget(), findsOneWidget);
+    expect(_mathWidgets(tester).single.parseError, isNull);
+  });
+
+  testWidgets('streaming keeps a bare environment with blank lines intact', (
+    tester,
+  ) async {
+    final prefix = '${List.filled(60, 'Introduction.').join(' ')}\n\n';
+    const body =
+        r'\begin{equation}'
+        '\n\nx^2+y^2=z^2\n\n';
+    await tester.pumpWidget(_markdownHarness('$prefix$body', streaming: true));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+
+    final complete =
+        '$prefix$body'
+        r'\end{equation}'
+        '\n\nAfter';
+    await tester.pumpWidget(_markdownHarness(complete, streaming: true));
+    await tester.pump();
+    expect(_findMathWidget(), findsOneWidget);
+    expect(_mathWidgets(tester).single.parseError, isNull);
+    expect(find.textContaining('After'), findsOneWidget);
+
+    await tester.pumpWidget(_markdownHarness(complete));
+    await tester.pump();
+    expect(_findMathWidget(), findsOneWidget);
+    expect(_mathWidgets(tester).single.parseError, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('preserves spaced starred command arguments', (tester) async {
+    await tester.pumpWidget(
+      _markdownHarness(r'''
+\[x=1\tag *{A,B}\]
+
+\[\operatorname *{arg\,max}_{x} f(x)\]
+'''),
+    );
+    await tester.pump();
+
+    expect(_mathWidgets(tester), hasLength(2));
+    expect(
+      _mathWidgets(tester).map((math) => math.parseError),
+      everyElement(isNull),
+    );
+    final encoded = _encodedMathTex(tester);
+    expect(encoded.first, contains('A,B'));
+    expect(encoded, everyElement(isNot(contains(r'\{'))));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('renders nested matrices with the same environment name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _markdownHarness(r'''
+\begin{pmatrix}
+\begin{pmatrix}1\\2\end{pmatrix}
+\end{pmatrix}
+'''),
+    );
+    await tester.pump();
+
+    expect(_mathWidgets(tester), hasLength(1));
+    expect(_mathWidgets(tester).single.parseError, isNull);
+    expect(find.textContaining(r'\end'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('renders complex operatorname expressions from issue 960', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _markdownHarness(r'''
+$\operatorname{Var}\left( \frac{1}{n}\sum_{i=1}^n a_i X_i \right)$
+
+$\operatorname{Var}\left( \prod_{j=1}^m \exp\left( \beta_j Z_j \right) \right)$
+
+$\operatorname{Var}\left( \hat{\theta}_{\mathrm{MLE}} \right)$
+
+$\operatorname{Var}_{\theta}\left( \frac{\partial}{\partial \theta} \log L(\theta; \mathbf{x}) \right)$
+
+$\operatorname{Var}\left( \sqrt{n}\left( \bar{X} - \mu \right) \right)$
+
+$\operatorname{Var}\left( \frac{1}{N} \sum_{k=1}^{N} \left( f(X_k) - \frac{1}{N}\sum_{j=1}^{N} f(X_j) \right)^2 \right)$
+
+\(\operatorname*{arg\,max}_{x} f(x)\)
+'''),
+    );
+    await tester.pump();
+
+    final widgets = _mathWidgets(tester);
+    expect(widgets, hasLength(7));
+    expect(widgets.map((widget) => widget.parseError), everyElement(isNull));
+    expect(find.textContaining(r'\operatorname'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     r'MarkdownWithCodeHighlight renders nested ovalbox and operatorname expressions',
     (tester) async {

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -2646,6 +2646,80 @@ A-->B
     });
   }
 
+  testWidgets(
+    'renders bare environments in blockquotes but keeps code literal',
+    (tester) async {
+      await tester.pumpWidget(
+        _markdownHarness(r'''
+>     \begin{equation}
+>     indented
+>     \end{equation}
+>
+> ~~~latex
+> \begin{equation}
+> fenced
+> \end{equation}
+> ~~~
+>
+> \begin{equation}
+> \verb|\begin{equation}|
+>
+>     x=1
+> \end{equation}
+'''),
+      );
+      await tester.pump();
+
+      final widgets = _mathWidgets(tester);
+      expect(widgets, hasLength(1));
+      expect(widgets.single.parseError, isNull);
+      expect(find.byKey(const ValueKey('markdown-blockquote')), findsOneWidget);
+      expect(find.textContaining('fenced'), findsOneWidget);
+      expect(find.textContaining('indented'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('keeps quoted fence markers inside bare math', (tester) async {
+    const inner = r'''\begin{equation}
+
+~~~
+x=1
+\end{equation}''';
+    expect(markdownScanDisplayMath(inner).spans, hasLength(1));
+    await tester.pumpWidget(
+      _markdownHarness(r'''> \begin{equation}
+>
+> ~~~
+> x=1
+> \end{equation}'''),
+    );
+    await tester.pump();
+
+    final widgets = _mathWidgets(tester);
+    expect(widgets, hasLength(1));
+    expect(widgets.single.parseError, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('keeps indented blockquote math delimiters literal', (
+    tester,
+  ) async {
+    for (final source in const [
+      r'''>     \[
+>     x=1
+>     \]''',
+      r'''>     \(x=1\)''',
+    ]) {
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+
+      expect(_findMathWidget(), findsNothing, reason: source);
+      expect(find.textContaining('x=1'), findsOneWidget, reason: source);
+      expect(tester.takeException(), isNull, reason: source);
+    }
+  });
+
   testWidgets('renders nested environments and visible equation tags', (
     tester,
   ) async {

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:flutter_math_fork/src/render/layout/eqn_array.dart';
 import 'package:flutter_math_fork/tex.dart' show TexEncoderExt;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gpt_markdown/gpt_markdown.dart' show GptMarkdown, HTag;
@@ -2672,6 +2673,58 @@ a^2+b^2=c^2\tag*{Identity}
     expect(_encodedMathTex(tester)[1], contains('Identity'));
     expect(find.textContaining(r'\tag'), findsNothing);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('centers a tagged formula and puts its label at the block edge', (
+    tester,
+  ) async {
+    for (final source in [
+      r'\[x+y\tag{1}\]',
+      r'\[\displaystyle\begin{align}x&=y\tag{1}\end{align}\]',
+    ]) {
+      await tester.pumpWidget(_markdownHarness(source, width: 360));
+      await tester.pump();
+
+      final arrayFinder = find.byType(EqnArray);
+      final scrollFinder = find
+          .ancestor(
+            of: arrayFinder,
+            matching: find.byType(SingleChildScrollView),
+          )
+          .first;
+      final array = tester.renderObject<RenderEqnArray>(arrayFinder);
+      RenderBox? body;
+      RenderBox? tag;
+      var child = array.firstChild;
+      while (child != null) {
+        final parentData = child.parentData! as EqnArrayParentData;
+        if (parentData.isTag) {
+          tag = child;
+        } else {
+          body = child;
+        }
+        child = parentData.nextSibling;
+      }
+
+      expect(body, isNotNull, reason: source);
+      expect(tag, isNotNull, reason: source);
+      final arrayRect = tester.getRect(arrayFinder);
+      final bodyRect = body!.localToGlobal(Offset.zero) & body.size;
+      final tagRect = tag!.localToGlobal(Offset.zero) & tag.size;
+      expect(
+        arrayRect.width,
+        closeTo(tester.getSize(scrollFinder).width, 0.01),
+        reason: source,
+      );
+      expect(
+        bodyRect.center.dx,
+        closeTo(arrayRect.center.dx, 0.01),
+        reason: source,
+      );
+      expect(tagRect.right, closeTo(arrayRect.right, 0.01), reason: source);
+      expect(tagRect.top, lessThan(bodyRect.bottom), reason: source);
+      expect(tester.takeException(), isNull, reason: source);
+    }
   });
 
   testWidgets(


### PR DESCRIPTION
Bare LaTeX such as `\begin{equation}a^2+b^2=c^2\end{equation}` stayed as text, `\tag` labels were discarded, and complex `\operatorname` expressions could consume their enclosing delimiter and fall back to source text.

This change recognizes supported standalone math environments in the shared Markdown scanner, balances nested environments, and keeps unfinished formulas intact during streaming. Code examples and TeX comments remain protected. The existing display renderer receives the complete environment with display-mode parser settings.

The bundled TeX parser now supports common AMS equation/alignment/gather environments, renders explicit `\tag`/`\tag*` labels (including per-row labels), and preserves operator boundaries and starred limits. Regression coverage includes the reported Pythagorean equation, all six examples from #960, nested matrices, settings, comments, and incremental rendering.

Fixes #960.

Validation (Flutter 3.44.9 / Dart 3.12.2):

- `dart analyze --fatal-infos lib test` — no issues.
- Format check of all 12 changed Dart files — no changes.
- `flutter gen-l10n` — no generated localization diff.
- WSL/Linux: `flutter test --no-pub --timeout 3m` — all 4048 tests passed.
- Vendored parser: `flutter test test/ams_environments_test.dart test/encoder/tex/functions/function_test.dart` — 24 passed.
- Windows: focused Markdown, streaming, scanner and paragraph-splitting suites — 316 passed.

The extended full-suite timeout accommodates WSL's slow refusal of a connection to `127.0.0.1:1`; that same test also passes on unmodified master with the extended timeout. No root tests are excluded.
