### PR TITLE
fix(asr): honor Qwen Audio capture sample rate

### DIFF
--- a/lib/core/providers/asr_provider.dart
+++ b/lib/core/providers/asr_provider.dart
@@ -447,6 +447,7 @@ class AsrProvider extends ChangeNotifier {
     SherpaOnnxAsrOptions() => options.sampleRate,
     OpenAiRealtimeAsrOptions() => options.sampleRate,
     DashScopeAsrOptions() => options.sampleRate,
+    QwenAudioAsrOptions() => options.sampleRate,
     VolcengineAsrOptions() => 16000,
     MimoAsrOptions() => options.sampleRate,
     StepAsrOptions() => options.sampleRate,

--- a/test/core/providers/asr_provider_test.dart
+++ b/test/core/providers/asr_provider_test.dart
@@ -49,6 +49,40 @@ void main() {
     expect(capture.stopped, isTrue);
   });
 
+  for (final sampleRate in [16000, 8000]) {
+    test('Qwen Audio streams and finishes at $sampleRate Hz', () async {
+      final capture = _FakeAudioCapture();
+      final session = _FakeCloudSession(finalTranscript: 'hello world');
+      final options = QwenAudioAsrOptions(
+        apiKey: 'test-key',
+        sampleRate: sampleRate,
+      );
+      final provider = AsrProvider(
+        audioCaptureFactory: () => capture,
+        cloudSessionStarter: (service) async {
+          expect(service, same(options));
+          return session;
+        },
+      );
+      addTearDown(provider.dispose);
+
+      await provider.start(options);
+      expect(provider.state, AsrSessionState.listening);
+      expect(capture.sampleRate, sampleRate);
+
+      final pcm = _pcm16(6000);
+      capture.add(pcm);
+      session.emitPartial('hello');
+      await Future<void>.delayed(Duration.zero);
+      expect(provider.transcript, 'hello');
+
+      expect(await provider.finish(), 'hello world');
+      expect(session.receivedAudio, [pcm]);
+      expect(capture.stopped, isTrue);
+      expect(provider.state, AsrSessionState.idle);
+    });
+  }
+
   test('captures audio at each cloud provider sample rate', () async {
     final captures = <_FakeAudioCapture>[];
     final provider = AsrProvider(


### PR DESCRIPTION
Selecting Qwen Audio and starting voice input fails with `Bad state: Unsupported ASR service: qwen_audio`. The settings and cloud session already support this provider, but `AsrProvider._sampleRateOf()` omits `QwenAudioAsrOptions`, so microphone capture never starts.

Add the missing branch to use the configured sample rate. Add regression coverage at 16 kHz and 8 kHz for recording startup, PCM forwarding, partial transcripts, and successful completion.

Validation (Flutter 3.44.9 / Dart 3.12.2):
- Both new tests reproduced the exact error before the fix.
- All 39 ASR provider, cloud service, and service options tests pass after the fix.
- `dart analyze --fatal-infos lib test`: no issues.
- Changed-file formatting and localization generation checks pass.
- Full Windows suite: 4,079 passed, 6 skipped, 28 failed. Rerunning the affected test files on unmodified `44c84e0` reproduced 27 of the same failures (including path and file-lock failures); one backup-isolate timeout failure did not reproduce. Full-suite validation is therefore not green locally; the repository's Linux CI remains necessary.

Tests use fake microphone and cloud sessions; no live API credentials or device recording are required.
