### PR TITLE
fix(gemini): drop the replayed server tool block, and do not finish on a leading empty candidate

### DIFF
--- a/lib/core/services/api/providers/google/google_decoder.dart
+++ b/lib/core/services/api/providers/google/google_decoder.dart
@@ -107,6 +107,8 @@ class GoogleStreamDecoder implements StreamChunkDecoder {
   bool _imageStarted = false;
   bool _imageEnded = false;
   int _syntheticPartIndex = 0;
+  bool _sawPart = false;
+  bool _finishAfterAnyPart = false;
   bool _closed = false;
 
   bool get emittedImageEvents => _imageStarted;
@@ -121,8 +123,12 @@ class GoogleStreamDecoder implements StreamChunkDecoder {
     return null;
   }
 
+  /// Only a finish reason reached after a part ends the turn: some
+  /// Gemini-compatible endpoints open the stream with an empty candidate
+  /// already carrying `finishReason: STOP`, and closing there would drop the
+  /// whole reply. Such a stream ends when the transport does.
   bool get canFinishNow =>
-      finishReason != null &&
+      _finishAfterAnyPart &&
       !retryMalformedResponse &&
       functionCalls.isEmpty &&
       (!expectImage || receivedImage);
@@ -288,7 +294,10 @@ class GoogleStreamDecoder implements StreamChunkDecoder {
       }
 
       final fr = cand['finishReason'];
-      if (fr is String && fr.isNotEmpty) finishReason = fr;
+      if (fr is String && fr.isNotEmpty) {
+        finishReason = fr;
+        if (_sawPart) _finishAfterAnyPart = true;
+      }
 
       final gm = cand['groundingMetadata'] ?? obj['groundingMetadata'];
       final cite = _parseCitations(gm);
@@ -333,6 +342,7 @@ class GoogleStreamDecoder implements StreamChunkDecoder {
     final thought = p['thought'] as bool? ?? false;
     final fc = p['functionCall'];
     final rawPart = Map<String, dynamic>.from(p);
+    if (rawPart.isNotEmpty) _sawPart = true;
 
     if (isGemini3 && !thought && rawPart.isNotEmpty) {
       roundModelParts.add(rawPart);

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -295,6 +295,11 @@ void _ensureGeminiFunctionCallThoughtSig(List<Map<String, dynamic>> parts) {
   }
 }
 
+/// A server-side tool invocation part (`google_search` and friends), which the
+/// model turn carries as a `toolCall` / `toolResponse` pair.
+bool _isGeminiServerToolPart(Map part) =>
+    part.containsKey('toolCall') || part.containsKey('toolResponse');
+
 Map<String, dynamic> _googleFunctionResponsePartFromToolMessage(
   Map<String, dynamic> message,
 ) {
@@ -1486,7 +1491,16 @@ Stream<StreamChunk> sendGoogleStream(
     append: (executed) {
       if (retryMalformed) return;
       if (isGemini3) {
-        convo.add({'role': 'model', 'parts': lastRoundModelParts});
+        // Replaying a server-side tool block is rejected as soon as the turn
+        // is answered by functionResponse parts — which a tool continuation
+        // always is: "Tool call part is missing thought_signature", pointing
+        // at the toolCall part however the turn is split or signed. Every
+        // other part stays in the order the model produced it.
+        final replayParts = <dynamic>[
+          for (final part in lastRoundModelParts)
+            if (!(part is Map && _isGeminiServerToolPart(part))) part,
+        ];
+        convo.add({'role': 'model', 'parts': replayParts});
         final responseParts = <Map<String, dynamic>>[];
         for (final c in lastRoundCalls) {
           final name = (c['name'] ?? '').toString();

--- a/test/gemini_leading_finish_reason_test.dart
+++ b/test/gemini_leading_finish_reason_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'support/collect_generation.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiLeadingFinishReasonTest',
+    enabled: true,
+    name: 'GeminiLeadingFinishReasonTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+String _chunk(List<Map<String, dynamic>> parts, {String? finishReason}) {
+  return 'data: ${jsonEncode({
+    'candidates': [
+      {
+        'content': {'parts': parts, 'role': 'model'},
+        'index': 0,
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+  })}\n\n';
+}
+
+void main() {
+  test(
+    'keeps streaming past an empty candidate that already says STOP',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        request.response.headers.set('Transfer-Encoding', 'chunked');
+        // Some Gemini-compatible endpoints open the stream this way.
+        request.response.write(_chunk(const [], finishReason: 'STOP'));
+        request.response.write(_chunk(const [], finishReason: 'STOP'));
+        request.response.write(
+          _chunk(const [
+            {'text': 'pro 20x '},
+          ]),
+        );
+        request.response.write(
+          _chunk(const [
+            {'text': 'is four times 5x.'},
+          ]),
+        );
+        request.response.write(_chunk(const [], finishReason: 'STOP'));
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-flash-preview',
+        messages: const [
+          {'role': 'user', 'content': 'How many tasks fit in pro 20x?'},
+        ],
+      ).toList();
+
+      expect(chunks.joinedContent, 'pro 20x is four times 5x.');
+      expect(chunks.isGenerationDone, isTrue);
+    },
+  );
+}

--- a/test/gemini_thought_signature_repro_test.dart
+++ b/test/gemini_thought_signature_repro_test.dart
@@ -60,6 +60,18 @@ Map<String, dynamic> _toolCallPart({
   };
 }
 
+Map<String, dynamic> _toolResponsePart({
+  required String toolType,
+  required Map<String, dynamic> response,
+  required String id,
+  String? thoughtSignature,
+}) {
+  return {
+    'toolResponse': {'toolType': toolType, 'response': response, 'id': id},
+    if (thoughtSignature != null) 'thoughtSignature': thoughtSignature,
+  };
+}
+
 Map<String, dynamic> _textPart({
   required String text,
   String? thoughtSignature,
@@ -562,7 +574,7 @@ void main() {
       expect(chunks.isGenerationDone, isTrue);
     });
 
-    test('preserves signed toolCall and functionCall parts in order', () async {
+    test('drops the server tool block from a replayed tool turn', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
         await server.close(force: true);
@@ -597,17 +609,15 @@ void main() {
           final body = jsonDecode(bodyText) as Map<String, dynamic>;
           final contents = (body['contents'] as List).cast<Map>();
           final modelParts = (contents[1]['parts'] as List).cast<Map>();
-          final toolCallIndex = modelParts.indexWhere(
-            (p) => p.containsKey('toolCall'),
-          );
           final functionCallIndex = modelParts.indexWhere(
             (p) => p.containsKey('functionCall'),
           );
 
-          expect(toolCallIndex, isNonNegative);
+          // Gemini rejects a replayed toolCall part once the turn is answered
+          // by functionResponse parts, so the server tool block cannot travel
+          // with a tool continuation.
+          expect(modelParts.where((p) => p.containsKey('toolCall')), isEmpty);
           expect(functionCallIndex, isNonNegative);
-          expect(toolCallIndex, lessThan(functionCallIndex));
-          expect(_hasThoughtSignature(modelParts[toolCallIndex]), isTrue);
           expect(_hasThoughtSignature(modelParts[functionCallIndex]), isTrue);
 
           request.response.statusCode = HttpStatus.ok;
@@ -874,6 +884,104 @@ void main() {
           _thoughtSignatureOf(replayedCall),
           'context_engineering_is_the_way_to_go',
         );
+      },
+    );
+
+    test(
+      'drops a whole server tool block, keeping the unsigned client call',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        var requestCount = 0;
+        Map<String, dynamic> requestBody = const <String, dynamic>{};
+        server.listen((request) async {
+          requestCount++;
+          final bodyText = await utf8.decoder.bind(request).join();
+
+          if (requestCount == 1) {
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.contentType = ContentType(
+              'text',
+              'event-stream',
+            );
+            request.response.headers.set('Transfer-Encoding', 'chunked');
+            // The shape a live gemini-3 turn produces: only the server tool
+            // parts are signed, and the client call is spliced between them.
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([
+                _toolCallPart(toolType: 'GOOGLE_SEARCH_WEB', args: {
+                  'queries': ['latest Flutter stable release'],
+                }, id: 'call_search', thoughtSignature: 'sig-google-search'),
+                _functionCallPart(name: 'lookup_docs', args: {'query': 'widget X'}),
+                _toolResponsePart(toolType: 'GOOGLE_SEARCH_WEB', response: {'search_suggestions': '<style>.chip {}</style>'}, id: 'call_search', thoughtSignature: 'sig-tool-response'),
+              ]))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          if (requestCount == 2) {
+            requestBody = jsonDecode(bodyText) as Map<String, dynamic>;
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.contentType = ContentType(
+              'text',
+              'event-stream',
+            );
+            request.response.headers.set('Transfer-Encoding', 'chunked');
+            request.response.write(
+              'data: ${jsonEncode(_streamChunk([_textPart(text: 'ok')], finishReason: 'STOP'))}\n\n',
+            );
+            request.response.write('data: [DONE]');
+            await request.response.close();
+            return;
+          }
+
+          fail('Unexpected request count: $requestCount');
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-3.1-pro-preview',
+          messages: const [
+            {
+              'role': 'user',
+              'content':
+                  'Search for the latest Flutter release and look up widget X.',
+            },
+          ],
+          tools: const [
+            {
+              'type': 'function',
+              'function': {
+                'name': 'lookup_docs',
+                'description': 'Look up internal docs',
+                'parameters': {
+                  'type': 'object',
+                  'properties': {
+                    'query': {'type': 'string'},
+                  },
+                  'required': ['query'],
+                },
+              },
+            },
+          ],
+          onToolCall: (name, args, {String? toolCallId}) async => '{}',
+        ).toList();
+
+        expect(chunks.isGenerationDone, isTrue);
+        final contents = (requestBody['contents'] as List).cast<Map>();
+        final modelParts = (contents[1]['parts'] as List).cast<Map>();
+
+        expect(modelParts.where((p) => p.containsKey('toolCall')), isEmpty);
+        expect(modelParts.where((p) => p.containsKey('toolResponse')), isEmpty);
+        expect(modelParts, hasLength(1));
+        expect(modelParts.single['functionCall'], isA<Map>());
       },
     );
   });


### PR DESCRIPTION
## 做了什么

两处 Gemini 3 流式链路的改动，一个提交一个根因：

- **续轮回放丢弃服务端工具块。** 混合回合回传 `toolCall` / `toolResponse` 时上游 400。**此项已撤回**，实为网关剥掉签名，见下方评论。
- **收紧流结束判据。** `finishReason` 在产出任何 part 之前到达时不再终止流，否则整条回复被丢弃。此项与上一项无关，转入 #1003 讨论。

## 测试

新增 `test/gemini_leading_finish_reason_test.dart` 复刻「空 `parts` + `STOP` 开头、随后才是正文」的帧序列；gemini / google 相关测试全绿，`flutter analyze lib` 无问题。
