### PR TITLE
feat(chat): add opt-in runtime context and context inspector

### DIFF
--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -81,6 +81,8 @@ class Assistant {
   final int
   recentChatsSummaryMessageCount; // refresh summary after N new messages
   final bool appendCurrentTimeToUserMessage;
+  final bool includeAppLocaleInContext;
+  final bool includeModelInfoInContext;
   // Preset conversation messages (ordered)
   final List<PresetMessage> presetMessages;
   // Regex replacement rules
@@ -126,6 +128,8 @@ class Assistant {
     this.generateConversationSummary = false,
     this.recentChatsSummaryMessageCount = defaultRecentChatsSummaryMessageCount,
     this.appendCurrentTimeToUserMessage = false,
+    this.includeAppLocaleInContext = false,
+    this.includeModelInfoInContext = false,
     this.presetMessages = const <PresetMessage>[],
     this.regexRules = const <AssistantRegex>[],
   });
@@ -170,6 +174,8 @@ class Assistant {
     bool? generateConversationSummary,
     int? recentChatsSummaryMessageCount,
     bool? appendCurrentTimeToUserMessage,
+    bool? includeAppLocaleInContext,
+    bool? includeModelInfoInContext,
     List<PresetMessage>? presetMessages,
     List<AssistantRegex>? regexRules,
     bool clearChatModel = false,
@@ -238,6 +244,10 @@ class Assistant {
           recentChatsSummaryMessageCount ?? this.recentChatsSummaryMessageCount,
       appendCurrentTimeToUserMessage:
           appendCurrentTimeToUserMessage ?? this.appendCurrentTimeToUserMessage,
+      includeAppLocaleInContext:
+          includeAppLocaleInContext ?? this.includeAppLocaleInContext,
+      includeModelInfoInContext:
+          includeModelInfoInContext ?? this.includeModelInfoInContext,
       presetMessages: presetMessages ?? this.presetMessages,
       regexRules: regexRules ?? this.regexRules,
     );
@@ -283,6 +293,8 @@ class Assistant {
     'generateConversationSummary': generateConversationSummary,
     'recentChatsSummaryMessageCount': recentChatsSummaryMessageCount,
     'appendCurrentTimeToUserMessage': appendCurrentTimeToUserMessage,
+    'includeAppLocaleInContext': includeAppLocaleInContext,
+    'includeModelInfoInContext': includeModelInfoInContext,
     'presetMessages': PresetMessage.encodeList(presetMessages),
     'regexRules': regexRules.map((e) => e.toJson()).toList(),
   };
@@ -401,6 +413,10 @@ class Assistant {
     })(),
     appendCurrentTimeToUserMessage:
         json['appendCurrentTimeToUserMessage'] as bool? ?? false,
+    includeAppLocaleInContext:
+        json['includeAppLocaleInContext'] as bool? ?? false,
+    includeModelInfoInContext:
+        json['includeModelInfoInContext'] as bool? ?? false,
     presetMessages: (() {
       try {
         return PresetMessage.decodeList(json['presetMessages']);

--- a/lib/core/services/api/builtin_tools.dart
+++ b/lib/core/services/api/builtin_tools.dart
@@ -1096,3 +1096,40 @@ class BuiltInToolsState {
   bool get anyGeminiToolActive =>
       codeExecutionActive || urlContextActive || youtubeActive;
 }
+
+List<Map<String, dynamic>> buildGeminiToolsArray({
+  required Set<String> builtIns,
+  required bool allowCoexistence,
+  List<Map<String, dynamic>>? geminiTools,
+}) {
+  final toolsArr = <Map<String, dynamic>>[];
+  if (allowCoexistence) {
+    if (builtIns.contains(BuiltInToolNames.codeExecution)) {
+      toolsArr.add({'code_execution': {}});
+    }
+    if (builtIns.contains(BuiltInToolNames.search)) {
+      toolsArr.add({'google_search': {}});
+    }
+    if (builtIns.contains(BuiltInToolNames.urlContext)) {
+      toolsArr.add({'url_context': {}});
+    }
+    if (geminiTools != null) {
+      toolsArr.addAll(geminiTools);
+    }
+  } else {
+    if (builtIns.contains(BuiltInToolNames.codeExecution)) {
+      toolsArr.add({'code_execution': {}});
+    } else if (builtIns.contains(BuiltInToolNames.search) ||
+        builtIns.contains(BuiltInToolNames.urlContext)) {
+      if (builtIns.contains(BuiltInToolNames.search)) {
+        toolsArr.add({'google_search': {}});
+      }
+      if (builtIns.contains(BuiltInToolNames.urlContext)) {
+        toolsArr.add({'url_context': {}});
+      }
+    } else if (geminiTools != null) {
+      toolsArr.addAll(geminiTools);
+    }
+  }
+  return toolsArr;
+}

--- a/lib/core/services/api/generation/generation_capabilities.dart
+++ b/lib/core/services/api/generation/generation_capabilities.dart
@@ -1,0 +1,106 @@
+import '../../../providers/settings_provider.dart';
+import '../builtin_tools.dart';
+
+/// Mirrors the providers' native-tool selection using the same builders. In
+/// particular, older Gemini native tools displace client function declarations.
+class GenerationCapabilities {
+  GenerationCapabilities({
+    required this.clientTools,
+    required this.nativeTools,
+    this.allowsClientTools = true,
+  });
+
+  factory GenerationCapabilities.resolve({
+    required ProviderConfig config,
+    required String modelId,
+    required List<Map<String, dynamic>> clientTools,
+  }) {
+    final kind = ProviderConfig.classify(
+      config.id,
+      explicitType: config.providerType,
+    );
+    final upstream = BuiltInToolNames.effectiveModelId(
+      cfg: config,
+      modelId: modelId,
+    );
+    final configured = BuiltInToolNames.parseFromOverride(
+      config.modelOverrides[modelId],
+    );
+    final native = <String>[];
+    var clients = clientTools;
+    var allowsClientTools = true;
+    switch (kind) {
+      case ProviderKind.google:
+        final selected = buildGeminiToolsArray(
+          builtIns: configured,
+          allowCoexistence: upstream.toLowerCase().contains('gemini-3'),
+          geminiTools: const [
+            {'function_declarations': <Object>[]},
+          ],
+        );
+        if (!selected.any(
+          (entry) => entry.containsKey('function_declarations'),
+        )) {
+          clients = [];
+          allowsClientTools = false;
+        }
+        native.addAll(
+          selected
+              .expand((entry) => entry.keys)
+              .where((name) => name != 'function_declarations'),
+        );
+      case ProviderKind.claude:
+        if (BuiltInToolsHelper.isBuiltInSearchEnabled(
+          cfg: config,
+          modelId: modelId,
+        )) {
+          native.add('web_search');
+        }
+        native.addAll(
+          BuiltInToolsHelper.claudeServerToolEntries(
+            cfg: config,
+            modelId: modelId,
+            enabled: configured,
+          ).map((entry) => entry['name'].toString()),
+        );
+      case ProviderKind.openai:
+        final payload = config.useResponseApi == true
+            ? BuiltInToolsHelper.buildResponsesTools(
+                cfg: config,
+                modelId: modelId,
+                upstreamModelId: upstream,
+              )
+            : BuiltInToolsHelper.buildChatCompletionsTools(
+                cfg: config,
+                modelId: modelId,
+                upstreamModelId: upstream,
+              );
+        native.addAll(payload.tools.map((entry) => entry['type'].toString()));
+        if (native.isEmpty &&
+            BuiltInToolsHelper.isBuiltInSearchEnabled(
+              cfg: config,
+              modelId: modelId,
+            )) {
+          native.add('web_search');
+        }
+    }
+    if (kind == ProviderKind.claude) {
+      final claimed = clients
+          .map((tool) => (tool['function'] as Map?)?['name'])
+          .toSet();
+      native.removeWhere(claimed.contains);
+    }
+    return GenerationCapabilities(
+      clientTools: List.unmodifiable(clients),
+      nativeTools: List.unmodifiable(native),
+      allowsClientTools: allowsClientTools,
+    );
+  }
+
+  final List<Map<String, dynamic>> clientTools;
+  final List<String> nativeTools;
+  final bool allowsClientTools;
+  Set<String> get toolNames => clientTools
+      .map((tool) => ((tool['function'] as Map?)?['name'] ?? '').toString())
+      .toSet();
+}

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -29,42 +29,6 @@ import 'google_vertex.dart';
 ///
 /// Gemini 3: built-in tools can coexist with function_declarations (MCP).
 /// Gemini 2.x and below: code_execution is exclusive; search/url_context exclude MCP.
-List<Map<String, dynamic>> _buildGeminiToolsArray({
-  required Set<String> builtIns,
-  required bool allowCoexistence,
-  List<Map<String, dynamic>>? geminiTools,
-}) {
-  final toolsArr = <Map<String, dynamic>>[];
-  if (allowCoexistence) {
-    if (builtIns.contains(BuiltInToolNames.codeExecution)) {
-      toolsArr.add({'code_execution': {}});
-    }
-    if (builtIns.contains(BuiltInToolNames.search)) {
-      toolsArr.add({'google_search': {}});
-    }
-    if (builtIns.contains(BuiltInToolNames.urlContext)) {
-      toolsArr.add({'url_context': {}});
-    }
-    if (geminiTools != null) {
-      toolsArr.addAll(geminiTools);
-    }
-  } else {
-    if (builtIns.contains(BuiltInToolNames.codeExecution)) {
-      toolsArr.add({'code_execution': {}});
-    } else if (builtIns.contains(BuiltInToolNames.search) ||
-        builtIns.contains(BuiltInToolNames.urlContext)) {
-      if (builtIns.contains(BuiltInToolNames.search)) {
-        toolsArr.add({'google_search': {}});
-      }
-      if (builtIns.contains(BuiltInToolNames.urlContext)) {
-        toolsArr.add({'url_context': {}});
-      }
-    } else if (geminiTools != null) {
-      toolsArr.addAll(geminiTools);
-    }
-  }
-  return toolsArr;
-}
 
 bool _isGemma4Model(String modelId) {
   return RegExp(
@@ -707,7 +671,7 @@ Stream<StreamChunk> sendGoogleStream(
       assistantHeaders: extraHeaders,
     );
 
-    final toolsArr = _buildGeminiToolsArray(
+    final toolsArr = buildGeminiToolsArray(
       builtIns: builtIns,
       allowCoexistence: isGemini3,
       geminiTools: geminiTools,
@@ -1170,7 +1134,7 @@ Stream<StreamChunk> sendGoogleStream(
       ];
     }
   }
-  final toolsArr = _buildGeminiToolsArray(
+  final toolsArr = buildGeminiToolsArray(
     builtIns: builtIns,
     allowCoexistence: isGemini3,
     geminiTools: geminiTools,

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -26,6 +26,7 @@ import '../../models/conversation.dart';
 import '../../models/workspace_binding.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
+import 'prepared_context_store.dart';
 
 final class LoadedTimelineSlot {
   const LoadedTimelineSlot({required this.identity, required this.message});
@@ -63,6 +64,19 @@ final class LoadedTimelinePage {
 typedef AssetContentHash = Future<String> Function(File file);
 
 class ChatService extends ChangeNotifier {
+  final preparedContexts = PreparedContextStore();
+  bool _acceptPreparedContexts = true;
+
+  void recordPreparedContext(PreparedContextSnapshot snapshot) {
+    final id = snapshot.context.conversationId;
+    if (!_acceptPreparedContexts ||
+        _discardedTemporaryConversationIds.contains(id) ||
+        getConversation(id) == null) {
+      return;
+    }
+    preparedContexts.record(snapshot);
+  }
+
   ChatService({
     ChatDatabaseGateway? databaseGateway,
     ChatDatabaseRepository? existingRepository,
@@ -298,6 +312,7 @@ class ChatService extends ChangeNotifier {
       await _resetStaleStreamingFlags();
 
       _initialized = true;
+      _acceptPreparedContexts = true;
       notifyListeners();
       late final Future<void> postStartupMaintenance;
       postStartupMaintenance = _runAssetReferenceMaintenance(appDataDir)
@@ -323,6 +338,8 @@ class ChatService extends ChangeNotifier {
   }
 
   Future<void> close() async {
+    _acceptPreparedContexts = false;
+    preparedContexts.clear();
     final initialization = _initFuture;
     if (initialization != null) {
       try {
@@ -369,6 +386,7 @@ class ChatService extends ChangeNotifier {
     if (_initialized || _initFuture != null) {
       unawaited(close());
     }
+    preparedContexts.dispose();
     super.dispose();
   }
 
@@ -1928,6 +1946,7 @@ class ChatService extends ChangeNotifier {
 
   void _discardTemporaryConversation(String? id) {
     if (id == null || !_temporaryConversationIds.remove(id)) return;
+    preparedContexts.remove(id);
     _rememberDiscardedTemporaryConversation(id);
     final messages = _messagesCache[id] ?? const <ChatMessage>[];
     for (final message in messages) {
@@ -1970,6 +1989,7 @@ class ChatService extends ChangeNotifier {
 
   Future<bool> _deleteDraftConversation(String id) async {
     if (!_draftConversations.containsKey(id)) return false;
+    preparedContexts.remove(id);
 
     _draftConversations.remove(id);
     if (_temporaryConversationIds.remove(id)) {
@@ -1995,6 +2015,7 @@ class ChatService extends ChangeNotifier {
     if (conversation == null) return false;
 
     await _repo.deleteConversation(id);
+    preparedContexts.remove(id);
     _conversationsCache.remove(id);
     // Stop any deferred/in-flight order backfill before clearing caches so a
     // late getMessageIds cannot resurrect order/count for a deleted id.
@@ -2549,6 +2570,7 @@ class ChatService extends ChangeNotifier {
   }
 
   Future<void> _resetAfterOverwriteRestore() async {
+    preparedContexts.clear();
     for (final id in _temporaryConversationIds) {
       _rememberDiscardedTemporaryConversation(id);
     }
@@ -4193,6 +4215,7 @@ class ChatService extends ChangeNotifier {
     if (!_initialized) await init();
 
     await _repo.clearAllData();
+    preparedContexts.clear();
     for (final id in _temporaryConversationIds) {
       _rememberDiscardedTemporaryConversation(id);
     }

--- a/lib/core/services/chat/prepared_context_store.dart
+++ b/lib/core/services/chat/prepared_context_store.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../utils/token_estimator.dart';
+import '../logging/context_log_models.dart';
+
+class ContextPreparationIssue {
+  const ContextPreparationIssue(this.source, this.reason);
+  final ContextSource source;
+
+  /// A safe diagnostic code, never raw exceptions (paths / secrets).
+  final String reason;
+}
+
+class PreparedContextSnapshot {
+  PreparedContextSnapshot({
+    required this.generationId,
+    required this.context,
+    required List<Map<String, dynamic>> tools,
+    List<String> nativeTools = const [],
+    List<ContextPreparationIssue> issues = const [],
+  }) : nativeTools = List.unmodifiable(nativeTools),
+       issues = List.unmodifiable(issues),
+       toolNames = List.unmodifiable(
+         tools
+             .map(
+               (tool) => ((tool['function'] as Map?)?['name'] ?? '').toString(),
+             )
+             .where((name) => name.isNotEmpty),
+       ),
+       toolTokens = tools.isEmpty ? 0 : estimateTokens(jsonEncode(tools));
+
+  final String generationId;
+  final ContextLogSnapshot context;
+  final List<String> toolNames;
+  final int toolTokens;
+  final List<String> nativeTools;
+  final List<ContextPreparationIssue> issues;
+}
+
+/// Session-only, bounded independently of request logging and chat persistence.
+class PreparedContextStore extends ChangeNotifier {
+  static const capacity = 8;
+  final _snapshots = <String, PreparedContextSnapshot>{};
+
+  PreparedContextSnapshot? forConversation(String? id) => _snapshots[id];
+
+  void record(PreparedContextSnapshot snapshot) {
+    final id = snapshot.context.conversationId;
+    if (id.isEmpty) return;
+    final previous = _snapshots[id];
+    if (previous != null &&
+        previous.context.timestamp.isAfter(snapshot.context.timestamp)) {
+      return;
+    }
+    _snapshots.remove(id);
+    _snapshots[id] = snapshot;
+    while (_snapshots.length > capacity) {
+      _snapshots.remove(_snapshots.keys.first);
+    }
+    notifyListeners();
+  }
+
+  void remove(String id) {
+    if (_snapshots.remove(id) != null) notifyListeners();
+  }
+
+  void clear() {
+    if (_snapshots.isEmpty) return;
+    _snapshots.clear();
+    notifyListeners();
+  }
+}

--- a/lib/core/services/chat/runtime_context.dart
+++ b/lib/core/services/chat/runtime_context.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+
+import '../../models/assistant.dart';
+import '../../utils/multimodal_input_utils.dart';
+import '../logging/context_log_models.dart';
+
+/// Request metadata, sampled once after attachment processing. Never frozen
+/// into a message or sampled again by HTTP retries / client tool follow-ups.
+class RuntimeContextSnapshot {
+  const RuntimeContextSnapshot({
+    required this.capturedAt,
+    this.localTime,
+    this.timezoneName,
+    this.utcOffset,
+    this.appLocale,
+    this.modelName,
+    this.modelId,
+  });
+
+  factory RuntimeContextSnapshot.capture({
+    required Assistant? assistant,
+    required DateTime now,
+    required String appLocale,
+    required String modelName,
+    required String modelId,
+    String? timezoneName,
+    Duration? utcOffset,
+  }) {
+    final includeTime = assistant?.appendCurrentTimeToUserMessage ?? false;
+    return RuntimeContextSnapshot(
+      capturedAt: now,
+      localTime: includeTime ? now : null,
+      timezoneName: includeTime ? timezoneName ?? now.timeZoneName : null,
+      utcOffset: includeTime ? utcOffset ?? now.timeZoneOffset : null,
+      appLocale: assistant?.includeAppLocaleInContext == true
+          ? appLocale
+          : null,
+      modelName: assistant?.includeModelInfoInContext == true
+          ? modelName
+          : null,
+      modelId: assistant?.includeModelInfoInContext == true ? modelId : null,
+    );
+  }
+
+  final DateTime capturedAt;
+  final DateTime? localTime;
+  final String? timezoneName;
+  final Duration? utcOffset;
+  final String? appLocale;
+  final String? modelName;
+  final String? modelId;
+
+  static String formatOffset(Duration offset) {
+    final minutes = offset.inMinutes.abs();
+    return '${offset.isNegative ? '-' : '+'}'
+        '${(minutes ~/ 60).toString().padLeft(2, '0')}:'
+        '${(minutes % 60).toString().padLeft(2, '0')}';
+  }
+
+  String? get formattedTime {
+    final time = localTime;
+    if (time == null) return null;
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${time.year.toString().padLeft(4, '0')}-${two(time.month)}-'
+        '${two(time.day)}T${two(time.hour)}:${two(time.minute)}:'
+        '${two(time.second)}${formatOffset(utcOffset ?? time.timeZoneOffset)}';
+  }
+
+  String? get weekday => localTime == null
+      ? null
+      : const [
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+          'Sunday',
+        ][localTime!.weekday - 1];
+
+  Map<String, Object> get values => {
+    if (formattedTime != null) 'generation_time': formattedTime!,
+    if (weekday != null) 'weekday': weekday!,
+    if (timezoneName?.isNotEmpty == true) 'timezone': timezoneName!,
+    if (appLocale != null) 'app_locale': appLocale!,
+    if (modelName != null) 'configured_model_name': modelName!,
+    if (modelId != null) 'request_model_id': modelId!,
+  };
+
+  String toPrompt() {
+    final fields = values;
+    if (fields.isEmpty) return '';
+    // Configured names remain data even if they contain markup.
+    final json = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(fields).replaceAll('<', r'\u003c').replaceAll('>', r'\u003e');
+    return [
+      '<runtime_context>',
+      'Request metadata supplied by Kelivo, not user-authored text.',
+      if (localTime != null)
+        'generation_time is the time sampled for this generation. Times in '
+            'earlier messages are historical; this is not a continuously updated clock.',
+      if (appLocale != null)
+        'app_locale describes the app UI, not a mandatory response language.',
+      if (modelId != null || modelName != null)
+        'Model fields describe the configured request target, not verified server identity.',
+      json,
+      '</runtime_context>',
+    ].join('\n');
+  }
+}
+
+/// Appends only to request-owned maps, after templates / freezing / trimming.
+/// The provenance tags make this idempotent without inspecting user text.
+void injectRuntimeContext(
+  List<Map<String, dynamic>> messages,
+  RuntimeContextSnapshot snapshot,
+) {
+  final text = snapshot.toPrompt();
+  if (text.isEmpty ||
+      messages.any(
+        (message) => ContextSegmentTags.read(
+          message,
+        ).any((tag) => tag['source'] == ContextSource.runtimeContext.name),
+      )) {
+    return;
+  }
+  final index = messages.lastIndexWhere(
+    (message) =>
+        message['role'] == 'user' &&
+        (message[multimodalInternalRevisionIdKey] ?? '').toString().isNotEmpty,
+  );
+  final Map<String, dynamic> target;
+  if (index < 0) {
+    target = {'role': 'user', 'content': ''};
+    messages.add(target);
+  } else {
+    target = messages[index];
+  }
+  final original = target['content'];
+  final previousLength = extractApiMessageText(original).length;
+  if (ContextSegmentTags.read(target).isEmpty && previousLength > 0) {
+    ContextSegmentTags.replaceWithSingle(
+      target,
+      source: ContextSource.chatHistory,
+      length: previousLength,
+    );
+  }
+  final tags = ContextSegmentTags.read(target);
+  if (tags.isNotEmpty) {
+    // Attachment inlining can change the last text segment after it was tagged.
+    final prefixLength = tags
+        .take(tags.length - 1)
+        .fold<int>(
+          0,
+          (sum, tag) => sum + ((tag['length'] as num?)?.toInt() ?? 0),
+        );
+    tags.last['length'] = (previousLength - prefixLength).clamp(
+      0,
+      previousLength,
+    );
+    ContextSegmentTags.write(target, tags);
+  }
+  final suffix = '${previousLength > 0 ? '\n\n' : ''}$text';
+  target['content'] = original is List
+      ? [
+          ...original,
+          {'type': 'text', 'text': suffix},
+        ]
+      : '${original ?? ''}$suffix';
+  ContextSegmentTags.append(
+    target,
+    source: ContextSource.runtimeContext,
+    length: suffix.length,
+  );
+}
+
+/// Only dynamic clock placeholders affect the duplicate-time hint.
+List<String> detectTimeVariablesInSystemPrompt(String prompt) => [
+  for (final token in const ['{cur_date}', '{cur_time}', '{cur_datetime}'])
+    if (prompt.contains(token)) token,
+];

--- a/lib/core/services/logging/context_log_models.dart
+++ b/lib/core/services/logging/context_log_models.dart
@@ -17,6 +17,9 @@ enum ContextSource {
   chatHistory,
   toolCall,
   toolResult,
+  runtimeContext,
+  workspace,
+  skills,
 }
 
 extension ContextSourceWire on ContextSource {
@@ -225,9 +228,8 @@ String extractApiMessageText(dynamic content) {
   return content.toString();
 }
 
-/// Replace inlined `data:...;base64,...` payloads with a short placeholder.
-String truncateBase64DataUris(String text) =>
-    LogPayloadElider.elideDataUris(text);
+/// Elide binary data URIs and large typed base64 JSON values in inspection only.
+String elideContextPayload(String text) => LogPayloadElider.elide(text);
 
 ContextSource inferContextSource(Map<String, dynamic> message) {
   final role = (message['role'] ?? '').toString();
@@ -255,7 +257,7 @@ List<ContextSegment> segmentsFromTaggedMessage(Map<String, dynamic> message) {
 
   final tags = ContextSegmentTags.read(message);
   if (tags.isEmpty) {
-    final text = truncateBase64DataUris(content);
+    final text = elideContextPayload(content);
     return [
       ContextSegment(
         source: inferContextSource(message),
@@ -281,7 +283,7 @@ List<ContextSegment> segmentsFromTaggedMessage(Map<String, dynamic> message) {
       slice = content.substring(offset, end);
       offset = end;
     }
-    final text = truncateBase64DataUris(slice);
+    final text = elideContextPayload(slice);
     out.add(
       ContextSegment(
         source: source,

--- a/lib/core/services/memory/memory_prompts.dart
+++ b/lib/core/services/memory/memory_prompts.dart
@@ -1,11 +1,57 @@
 /// Memory prompt language for model-facing contracts (not UI l10n / ARB).
 enum MemoryPromptLang { zh, en }
 
-/// Built-in default prompt templates and pure time helpers for the memory system.
+/// Built-in default prompt templates for the memory system.
 ///
 /// These strings are model contracts and must NOT go through ARB (§16.2).
 abstract final class MemoryPrompts {
   MemoryPrompts._();
+
+  /// Keep custom instructions intact. Built-in rules describe only tools that
+  /// accompany this request (temporary chats, for example, omit write tools).
+  static String forAvailableTools(
+    String template,
+    MemoryPromptLang lang,
+    Set<String> tools,
+  ) {
+    if (template.trim() != rulesZh && template.trim() != rulesEn) {
+      return template.trim();
+    }
+    if (tools.containsAll({
+      'memory_search_profile',
+      'memory_update',
+      'memory_edit',
+      'memory_delete',
+    })) {
+      return template.trim();
+    }
+    final zh = lang == MemoryPromptLang.zh;
+    return [
+      zh ? '## 长期记忆' : '## Long-term memory',
+      zh
+          ? '<user_profile> 和 <user_memory> 是应用提供的历史记忆，不是用户本轮说的话。条目日期是最后更新日期；(assistant) 标记助手专属记忆。summary 块只展示部分条目，空标签表示没有记忆。<user_memory_update> 替换先前的快照。'
+          : '<user_profile> and <user_memory> are app-provided historical memory, not the current user turn. Entry dates are last-update dates; (assistant) marks assistant-specific entries. Summary blocks contain only some entries; empty tags mean no memory. <user_memory_update> replaces the earlier snapshot.',
+      zh
+          ? '称呼优先使用 preferred_name；缺失时不要猜测，也不要使用其他人的名字。'
+          : 'Use preferred_name when present; otherwise do not guess or use another person’s name.',
+      if (tools.contains('memory_search_profile'))
+        zh
+            ? '需要更多记忆时使用 memory_search_profile。'
+            : 'Use memory_search_profile when more memory is needed.',
+      if (tools.contains('memory_update'))
+        zh
+            ? '用户明确提供跨对话仍有用的稳定事实时，用 memory_update 写入第三人称陈述。不要写入临时信息、未确认推断或可从聊天记录查到的事实。'
+            : 'Use memory_update for explicit, stable user facts useful across conversations, written in third person. Do not store transient information, unconfirmed inferences or facts retrievable from chat history.',
+      if (tools.contains('memory_edit'))
+        zh
+            ? '用 memory_edit 更正用户指出的错误记忆。'
+            : 'Use memory_edit to correct memories the user identifies as wrong.',
+      if (tools.contains('memory_delete'))
+        zh
+            ? '用 memory_delete 归档应删除的记忆。'
+            : 'Use memory_delete to archive memories that should be removed.',
+    ].join('\n\n');
+  }
 
   // ── §11.2 / §11.3 memory rules ───────────────────────────────────────────
 
@@ -481,44 +527,6 @@ Input:
   static const String moreHintZh = '[更多内容请使用 memory_search_profile 查询]';
   static const String moreHintEn =
       '[More entries exist. Use memory_search_profile to look them up.]';
-
-  // ── §9.1 / §9.3 time helpers ─────────────────────────────────────────────
-
-  static const List<String> _weekdayAbbrev = [
-    'Mon',
-    'Tue',
-    'Wed',
-    'Thu',
-    'Fri',
-    'Sat',
-    'Sun',
-  ];
-
-  /// Wraps [timestamp] as `<current_time>EEE yyyy-MM-dd HH:mm:ss</current_time>`
-  /// in the local timezone, without a UTC offset (§9.1).
-  ///
-  /// Four-digit year avoids `yy-MM-dd` / `dd-MM-yy` ambiguity (e.g. 22–26).
-  static String formatCurrentTimeTag(DateTime timestamp) {
-    final local = timestamp.isUtc ? timestamp.toLocal() : timestamp;
-    final eee = _weekdayAbbrev[local.weekday - 1];
-    final yyyy = local.year.toString();
-    final mm = local.month.toString().padLeft(2, '0');
-    final dd = local.day.toString().padLeft(2, '0');
-    final hh = local.hour.toString().padLeft(2, '0');
-    final min = local.minute.toString().padLeft(2, '0');
-    final ss = local.second.toString().padLeft(2, '0');
-    return '<current_time>$eee $yyyy-$mm-$dd $hh:$min:$ss</current_time>';
-  }
-
-  /// Returns which of `{cur_date}`, `{cur_time}`, `{cur_datetime}` occur in
-  /// [systemPrompt], in that fixed order. `{timezone}` etc. are ignored (§9.3).
-  static List<String> detectTimeVariablesInSystemPrompt(String systemPrompt) {
-    const candidates = ['{cur_date}', '{cur_time}', '{cur_datetime}'];
-    return [
-      for (final token in candidates)
-        if (systemPrompt.contains(token)) token,
-    ];
-  }
 
   static String rulesFor(MemoryPromptLang lang) =>
       lang == MemoryPromptLang.zh ? rulesZh : rulesEn;

--- a/lib/core/services/workspace/workspace_tools_service.dart
+++ b/lib/core/services/workspace/workspace_tools_service.dart
@@ -173,16 +173,15 @@ class WorkspaceToolsService {
       ];
     }
     return definitions(
-          vocab: _pathVocab(ctx.paths),
-          outputHint: ctx.paths.sandboxed
-              ? '${WorkspacePaths.guestChat}/outputs/<id>.txt'
-              : '${ctx.paths.sessionHostDir}/outputs/<id>.txt',
-        )
-        .where(
-          (definition) =>
-              _enabled(ctx, (definition['function'] as Map)['name'] as String),
-        )
-        .toList();
+      vocab: _pathVocab(ctx.paths),
+      outputHint: ctx.paths.sandboxed
+          ? '${WorkspacePaths.guestChat}/outputs/<id>.txt'
+          : '${ctx.paths.sessionHostDir}/outputs/<id>.txt',
+    ).where((definition) {
+      final name = (definition['function'] as Map)['name'] as String;
+      return _enabled(ctx, name) &&
+          (name != 'shell' || ctx.runtimeStatus?.ready == true);
+    }).toList();
   }
 
   /// Shared schemas for execution and the ungated description editor.
@@ -336,8 +335,13 @@ class WorkspaceToolsService {
     WorkspaceToolContext ctx, {
     List<AttachmentInfo> attachments = const [],
     Iterable<String> environmentVariableNames = const [],
+    Set<String>? availableToolNames,
   }) {
     if (ctx.skillsOnly) return '';
+    bool enabled(String name) =>
+        availableToolNames?.contains(name) ??
+        (ctx.workspace.isToolEnabled(name) &&
+            (name != 'shell' || ctx.runtimeStatus?.ready == true));
     final paths = ctx.paths;
     final workspace = paths.sandboxed
         ? WorkspacePaths.guestWorkspace
@@ -381,11 +385,9 @@ class WorkspaceToolsService {
     buf
       ..writeln('- $tmp — scratch (writable, ephemeral)')
       ..writeln('cwd: ${ctx.cwd}')
-      ..writeln(
-        'Enabled tools: ${toolNames.where(ctx.workspace.isToolEnabled).join(', ')}',
-      )
+      ..writeln('Enabled tools: ${toolNames.where(enabled).join(', ')}')
       ..writeln();
-    if (ctx.workspace.isToolEnabled('shell')) {
+    if (enabled('shell')) {
       buf.writeln(
         'shell is one-shot: a fresh non-interactive sh -lc each call. '
         'No cd or env persists. Chain with &&. Use non-interactive flags (-y). '
@@ -399,9 +401,8 @@ class WorkspaceToolsService {
         );
       }
     }
-    if (ctx.workspace.isToolEnabled('read_file') &&
-        ctx.workspace.isToolEnabled('edit_file')) {
-      if (ctx.workspace.isToolEnabled('write_file')) {
+    if (enabled('read_file') && enabled('edit_file')) {
+      if (enabled('write_file')) {
         buf.writeln(
           'Prefer read_file, edit_file, and write_file over cat/sed.',
         );

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -13,7 +13,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart';
 import '../../../core/services/chat/prompt_transformer.dart';
-import '../../../core/services/memory/memory_prompts.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
@@ -63,6 +62,7 @@ import '../../../utils/brand_assets.dart';
 import '../../../utils/platform_utils.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../utils/assistant_edit_tab_layout.dart';
+import '../widgets/runtime_context_settings_card.dart';
 import 'assistant_regex_tab.dart';
 import 'assistant_settings_edit_skills_tab.dart';
 import 'assistant_settings_edit_workspace_tab.dart';
@@ -274,7 +274,12 @@ Future<int?> _showContextMessageInputDialog(
 }
 
 class AssistantSettingsEditPage extends StatefulWidget {
-  const AssistantSettingsEditPage({super.key, required this.assistantId});
+  const AssistantSettingsEditPage({
+    super.key,
+    required this.assistantId,
+    this.initialTab,
+  });
+  final String? initialTab;
   final String assistantId;
 
   @override
@@ -285,6 +290,7 @@ class AssistantSettingsEditPage extends StatefulWidget {
 class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
     with TickerProviderStateMixin {
   late TabController _tabController;
+  bool _initialTabApplied = false;
 
   @override
   void initState() {
@@ -306,9 +312,10 @@ class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
     if (mounted) setState(() {});
   }
 
-  void _syncTabController(int length) {
-    if (_tabController.length == length) return;
-    final nextIndex = math.min(_tabController.index, length - 1);
+  void _syncTabController(int length, {int? initialIndex}) {
+    if (_tabController.length == length && initialIndex == null) return;
+    final nextIndex =
+        initialIndex ?? math.min(_tabController.index, length - 1);
     _tabController.removeListener(_handleTabChanged);
     _tabController.dispose();
     _tabController = TabController(
@@ -347,10 +354,24 @@ class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
     }
 
     final allTabs = _assistantEditTabSpecs(context, assistant.id);
-    final visibleTabs = _visibleAssistantEditTabs(allTabs, settings);
-    final useOutline = settings.mobileAssistantDetailOutlineEnabled;
+    final visibleTabs = [..._visibleAssistantEditTabs(allTabs, settings)];
+    final requestedTabs = allTabs.where((tab) => tab.id == widget.initialTab);
+    if (requestedTabs.isNotEmpty &&
+        !visibleTabs.any((tab) => tab.id == widget.initialTab)) {
+      visibleTabs.insert(0, requestedTabs.first);
+    }
+    final useOutline =
+        settings.mobileAssistantDetailOutlineEnabled &&
+        widget.initialTab == null;
     if (!useOutline) {
-      _syncTabController(visibleTabs.length);
+      final initial = !_initialTabApplied
+          ? visibleTabs.indexWhere((tab) => tab.id == widget.initialTab)
+          : -1;
+      _syncTabController(
+        visibleTabs.length,
+        initialIndex: initial >= 0 ? initial : null,
+      );
+      _initialTabApplied = true;
     }
 
     return Scaffold(

--- a/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
@@ -15,6 +15,7 @@ class _PromptTabState extends State<_PromptTab> {
   late final FocusNode _tmplFocus;
   late final TextEditingController _presetCtrl;
   bool _showPresetInput = false;
+  bool _advancedExpanded = false;
   String _presetRole = 'user';
   final GlobalKey _presetHeaderKey = GlobalKey(debugLabel: 'presetHeader');
 
@@ -201,83 +202,12 @@ class _PromptTabState extends State<_PromptTab> {
     await _applySystemPromptChange(next);
   }
 
-  Future<void> _onAppendCurrentTimeChanged(Assistant a, bool enabled) async {
-    if (enabled) {
-      final hits = MemoryPrompts.detectTimeVariablesInSystemPrompt(
-        _sysCtrl.text,
-      );
-      if (hits.isNotEmpty) {
-        final keep = await _showTimeVarEnableDialog(context, hits);
-        if (!mounted) return;
-        if (keep != true) {
-          if (keep == false) {
-            Future.microtask(() => _sysFocus.requestFocus());
-          }
-          return;
-        }
-      }
-    }
-    await context.read<AssistantProvider>().updateAssistant(
-      a.copyWith(appendCurrentTimeToUserMessage: enabled),
-    );
-  }
-
-  Future<bool?> _showTimeVarEnableDialog(
-    BuildContext context,
-    List<String> hits,
-  ) {
-    final l10n = AppLocalizations.of(context)!;
-    final cs = Theme.of(context).colorScheme;
-    final variables = hits.join(', ');
-    return showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l10n.assistantEditPromptTimeVarDialogTitle),
-        content: Text(l10n.assistantEditPromptTimeVarDialogBody(variables)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l10n.assistantEditPromptTimeVarDialogRemove),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              l10n.assistantEditPromptTimeVarDialogKeep,
-              style: TextStyle(color: cs.primary),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _showAppendCurrentTimeInfoDialog(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    const example = '<current_time>Mon 2026-08-08 14:30:05</current_time>';
-    return showDialog<void>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l10n.assistantEditPromptAppendTimeInfoTitle),
-        content: Text(l10n.assistantEditPromptAppendTimeInfoBody(example)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: Text(l10n.assistantEditPromptAppendTimeInfoClose),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final ap = context.watch<AssistantProvider>();
     final a = ap.getById(widget.assistantId)!;
-    final timeVarsInPrompt = MemoryPrompts.detectTimeVariablesInSystemPrompt(
-      _sysCtrl.text,
-    );
 
     // Sample preview for message template
     final now = DateTime.now();
@@ -312,7 +242,7 @@ class _PromptTabState extends State<_PromptTab> {
               children: [
                 Expanded(
                   child: Text(
-                    l10n.assistantEditSystemPromptTitle,
+                    l10n.harnessCustomInstructions,
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: AppFontWeights.emphasis,
@@ -326,12 +256,12 @@ class _PromptTabState extends State<_PromptTab> {
                   minSize: 38,
                   color: cs.primary,
                   onTap: _openSystemPromptEditor,
-                  semanticLabel: l10n.assistantEditSystemPromptTitle,
+                  semanticLabel: l10n.harnessCustomInstructions,
                 ),
                 const SizedBox(width: 4),
                 _IosButton(
                   label: l10n.assistantEditSystemPromptImportButton,
-                  icon: Icons.file_open,
+                  icon: Lucide.Upload,
                   dense: true,
                   neutral: false,
                   onTap: _importSystemPrompt,
@@ -373,95 +303,60 @@ class _PromptTabState extends State<_PromptTab> {
                 contentPadding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.assistantEditAvailableVariables,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: AppFontWeights.semibold,
-              ),
-            ),
-            const SizedBox(height: 4),
-            _VarExplainList(
-              items: [
-                (l10n.assistantEditVariableDate, '{cur_date}'),
-                (l10n.assistantEditVariableTime, '{cur_time}'),
-                (l10n.assistantEditVariableDatetime, '{cur_datetime}'),
-                (l10n.assistantEditVariableModelId, '{model_id}'),
-                (l10n.assistantEditVariableModelName, '{model_name}'),
-                (l10n.assistantEditVariableLocale, '{locale}'),
-                (l10n.assistantEditVariableTimezone, '{timezone}'),
-                (l10n.assistantEditVariableSystemVersion, '{system_version}'),
-                (l10n.assistantEditVariableDeviceInfo, '{device_info}'),
-                (l10n.assistantEditVariableBatteryLevel, '{battery_level}'),
-                (l10n.assistantEditVariableNickname, '{nickname}'),
-                (l10n.assistantEditVariableAssistantName, '{assistant_name}'),
-              ],
-              cacheWarningVars: const {
-                '{cur_date}',
-                '{cur_time}',
-                '{cur_datetime}',
-              },
-              cacheWarningTooltip: l10n.assistantEditPromptTimeVarWarning,
-              onTapVar: (v) {
-                _insertAtCursor(_sysCtrl, v);
-                setState(() {});
-                context.read<AssistantProvider>().updateAssistant(
-                  a.copyWith(systemPrompt: _sysCtrl.text),
-                );
-                // Restore focus to the input to keep cursor active
-                Future.microtask(() => _sysFocus.requestFocus());
-              },
-            ),
-            AnimatedSize(
-              duration: const Duration(milliseconds: 180),
-              curve: Curves.easeOutCubic,
-              alignment: Alignment.topCenter,
-              child: timeVarsInPrompt.isEmpty
-                  ? const SizedBox.shrink()
-                  : Padding(
-                      padding: const EdgeInsets.only(top: 10),
-                      child: Material(
-                        color: cs.errorContainer.withValues(alpha: 0.30),
-                        borderRadius: BorderRadius.circular(12),
-                        child: Padding(
-                          padding: const EdgeInsets.all(12),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Icon(
-                                Lucide.TriangleAlert,
-                                size: 18,
-                                color: cs.error,
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(
-                                  l10n.assistantEditPromptTimeVarWarning,
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    height: 1.35,
-                                    color: cs.onSurface.withValues(alpha: 0.8),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-            ),
           ],
         ),
       ),
     );
 
-    final appendTimeCard = SectionCard(
+    final variablesCard = SectionCard(
       children: [
-        _AppendCurrentTimeRow(
-          value: a.appendCurrentTimeToUserMessage,
-          onChanged: (enabled) => _onAppendCurrentTimeChanged(a, enabled),
-          onInfoTap: () => _showAppendCurrentTimeInfoDialog(context),
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 8),
+              Text(
+                l10n.assistantEditAvailableVariables,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: AppFontWeights.semibold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              _VarExplainList(
+                items: [
+                  (l10n.assistantEditVariableDate, '{cur_date}'),
+                  (l10n.assistantEditVariableTime, '{cur_time}'),
+                  (l10n.assistantEditVariableDatetime, '{cur_datetime}'),
+                  (l10n.assistantEditVariableModelId, '{model_id}'),
+                  (l10n.assistantEditVariableModelName, '{model_name}'),
+                  (l10n.assistantEditVariableLocale, '{locale}'),
+                  (l10n.assistantEditVariableTimezone, '{timezone}'),
+                  (l10n.assistantEditVariableSystemVersion, '{system_version}'),
+                  (l10n.assistantEditVariableDeviceInfo, '{device_info}'),
+                  (l10n.assistantEditVariableBatteryLevel, '{battery_level}'),
+                  (l10n.assistantEditVariableNickname, '{nickname}'),
+                  (l10n.assistantEditVariableAssistantName, '{assistant_name}'),
+                ],
+                cacheWarningVars: const {
+                  '{cur_date}',
+                  '{cur_time}',
+                  '{cur_datetime}',
+                },
+                cacheWarningTooltip: l10n.assistantEditPromptTimeVarWarning,
+                onTapVar: (v) {
+                  _insertAtCursor(_sysCtrl, v);
+                  setState(() {});
+                  context.read<AssistantProvider>().updateAssistant(
+                    a.copyWith(systemPrompt: _sysCtrl.text),
+                  );
+                  // Restore focus to the input to keep cursor active
+                  Future.microtask(() => _sysFocus.requestFocus());
+                },
+              ),
+            ],
+          ),
         ),
       ],
     );
@@ -900,105 +795,28 @@ class _PromptTabState extends State<_PromptTab> {
     return ListView(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
       children: [
+        RuntimeContextSettingsCard(
+          assistant: a,
+          onChanged: (next) => ap.updateAssistant(next),
+        ),
+        const SizedBox(height: 12),
         sysCard,
         const SizedBox(height: 12),
-        appendTimeCard,
-        const SizedBox(height: 12),
-        tmplCard,
-        const SizedBox(height: 12),
-        presetCard(),
-      ],
-    );
-  }
-}
-
-class _AppendCurrentTimeRow extends StatelessWidget {
-  const _AppendCurrentTimeRow({
-    required this.value,
-    required this.onChanged,
-    required this.onInfoTap,
-  });
-
-  final bool value;
-  final ValueChanged<bool> onChanged;
-  final VoidCallback onInfoTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final cs = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            child: _TactileRow(
-              onTap: () => onChanged(!value),
-              builder: (pressed) {
-                final baseColor = cs.onSurface.withValues(alpha: 0.9);
-                return _AnimatedPressColor(
-                  pressed: pressed,
-                  base: baseColor,
-                  builder: (color) {
-                    return Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: 36,
-                          child: Icon(
-                            Lucide.clock,
-                            size: 20,
-                            color: value ? cs.primary : color,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                l10n.assistantEditPromptAppendTimeTitle,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
-                                  fontSize: 15,
-                                  color: color,
-                                  fontWeight: AppFontWeights.semibold,
-                                ),
-                              ),
-                              const SizedBox(height: 3),
-                              Text(
-                                l10n.assistantEditPromptAppendTimeSubtitle,
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  height: 1.25,
-                                  color: cs.onSurface.withValues(alpha: 0.62),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                );
-              },
-            ),
-          ),
-          IosIconButton(
-            icon: Lucide.BadgeInfo,
-            size: 16,
-            padding: const EdgeInsets.all(6),
-            minSize: 32,
-            color: cs.onSurface.withValues(alpha: 0.55),
-            semanticLabel: l10n.assistantEditPromptAppendTimeInfoTitle,
-            onTap: onInfoTap,
-          ),
-          const SizedBox(width: 4),
-          IosSwitch(value: value, onChanged: onChanged),
+        _HoverPillButton(
+          icon: _advancedExpanded ? Lucide.ChevronUp : Lucide.ChevronDown,
+          color: cs.primary,
+          label: l10n.harnessAdvanced,
+          onTap: () => setState(() => _advancedExpanded = !_advancedExpanded),
+        ),
+        if (_advancedExpanded) ...[
+          const SizedBox(height: 12),
+          variablesCard,
+          const SizedBox(height: 12),
+          tmplCard,
+          const SizedBox(height: 12),
+          presetCard(),
         ],
-      ),
+      ],
     );
   }
 }
@@ -1323,7 +1141,7 @@ class _SystemPromptDesktopDialogState
                       children: [
                         Expanded(
                           child: Text(
-                            l10n.assistantEditSystemPromptTitle,
+                            l10n.harnessCustomInstructions,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(

--- a/lib/features/assistant/widgets/runtime_context_settings_card.dart
+++ b/lib/features/assistant/widgets/runtime_context_settings_card.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/assistant.dart';
+import '../../../core/models/conversation.dart';
+import '../../../core/providers/settings_provider.dart';
+import '../../../core/services/api/builtin_tools.dart';
+import '../../../core/services/chat/runtime_context.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_switch.dart';
+import '../../../shared/widgets/section_card.dart';
+import '../../../theme/app_font_weights.dart';
+import '../../home/utils/model_display_helper.dart';
+
+/// Shared by assistant settings and the chat inspector. This preview only
+/// reads configuration; it never runs message preparation or device tools.
+class RuntimeContextSettingsCard extends StatelessWidget {
+  const RuntimeContextSettingsCard({
+    super.key,
+    required this.assistant,
+    required this.onChanged,
+    this.conversation,
+    this.now,
+  });
+
+  final Assistant assistant;
+  final ValueChanged<Assistant> onChanged;
+  final Conversation? conversation;
+  final DateTime? now;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final settings = context.watch<SettingsProvider>();
+    final info = getModelDisplayInfo(
+      settings,
+      assistant: assistant,
+      conversation: conversation,
+    );
+    final preview = RuntimeContextSnapshot.capture(
+      assistant: assistant.copyWith(
+        appendCurrentTimeToUserMessage: true,
+        includeAppLocaleInContext: true,
+        includeModelInfoInContext: true,
+      ),
+      now: now ?? DateTime.now(),
+      appLocale: Localizations.localeOf(context).toLanguageTag(),
+      modelName: info.modelDisplay ?? l10n.harnessNotConfigured,
+      modelId: info.modelId == null
+          ? l10n.harnessNotConfigured
+          : BuiltInToolNames.effectiveModelId(
+              cfg: info.getConfig(settings),
+              modelId: info.modelId,
+            ),
+    );
+    final timeConflict =
+        assistant.appendCurrentTimeToUserMessage &&
+        detectTimeVariablesInSystemPrompt(assistant.systemPrompt).isNotEmpty;
+    return SectionCard(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.harnessBuiltInContext,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: AppFontWeights.emphasis,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  l10n.harnessAssistantScope,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          _ContextOption(
+            id: 'time',
+            title: l10n.harnessTime,
+            description:
+                '${l10n.harnessTimeDescription}\n${preview.formattedTime} · '
+                '${preview.weekday} · ${preview.timezoneName}',
+            value: assistant.appendCurrentTimeToUserMessage,
+            onChanged: (value) => onChanged(
+              assistant.copyWith(appendCurrentTimeToUserMessage: value),
+            ),
+          ),
+          _ContextOption(
+            id: 'locale',
+            title: l10n.harnessLocale,
+            description:
+                '${l10n.harnessLocaleDescription}\n${preview.appLocale}',
+            value: assistant.includeAppLocaleInContext,
+            onChanged: (value) =>
+                onChanged(assistant.copyWith(includeAppLocaleInContext: value)),
+          ),
+          _ContextOption(
+            id: 'model',
+            title: l10n.harnessModel,
+            description:
+                '${l10n.harnessModelDescription}\n${preview.modelName} · ${preview.modelId}',
+            value: assistant.includeModelInfoInContext,
+            onChanged: (value) =>
+                onChanged(assistant.copyWith(includeModelInfoInContext: value)),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              l10n.harnessRequestOnly,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          if (timeConflict)
+            Padding(
+              key: const ValueKey('runtime-context-time-warning'),
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Lucide.BadgeInfo, size: 16),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      l10n.harnessTimeConflict,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContextOption extends StatelessWidget {
+  const _ContextOption({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.value,
+    required this.onChanged,
+  });
+  final String id;
+  final String title;
+  final String description;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.all(12),
+    child: Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: TextStyle(fontWeight: AppFontWeights.semibold),
+              ),
+              const SizedBox(height: 4),
+              Text(description, style: Theme.of(context).textTheme.bodySmall),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Semantics(
+          label: title,
+          child: IosSwitch(
+            key: ValueKey('runtime-context-$id'),
+            value: value,
+            onChanged: onChanged,
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/chat/widgets/chat_context_inspector.dart
+++ b/lib/features/chat/widgets/chat_context_inspector.dart
@@ -1,0 +1,469 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/skills_binding.dart';
+import '../../../core/models/conversation.dart';
+import '../../../core/models/workspace_binding.dart';
+import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/mcp_provider.dart';
+import '../../../core/providers/settings_provider.dart';
+import '../../../core/providers/workspace_provider.dart';
+import '../../../core/services/api/generation/generation_capabilities.dart';
+import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/chat/prepared_context_store.dart';
+import '../../../core/services/logging/context_log_models.dart';
+import '../../../core/services/skills/skills_service.dart';
+import '../../../core/services/workspace/workspace_runtime.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/responsive/screen_type_helper.dart';
+import '../../../shared/widgets/ios_tactile.dart';
+import '../../../shared/widgets/section_card.dart';
+import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
+import '../../../utils/platform_utils.dart';
+import '../../assistant/pages/assistant_settings_edit_page.dart';
+import '../../assistant/widgets/runtime_context_settings_card.dart';
+import '../../home/services/local_tools_service.dart';
+import '../../home/utils/model_display_helper.dart';
+import '../../settings/pages/log_viewer_page.dart';
+
+Future<void> showChatContextInspector(
+  BuildContext context, {
+  required String assistantId,
+  required String? conversationId,
+  required bool Function(String, String) isToolModel,
+  VoidCallback? onManageSearch,
+  VoidCallback? onManageWorkspace,
+  VoidCallback? onManageSkills,
+}) {
+  Widget panel(BuildContext panelContext) => ChatContextInspector(
+    assistantId: assistantId,
+    conversationId: conversationId,
+    isToolModel: isToolModel,
+    onClose: () => Navigator.of(panelContext).pop(),
+    onManage: (section) {
+      Navigator.of(panelContext).pop();
+      if (!context.mounted) return;
+      if (section == 'workspace' && onManageWorkspace != null) {
+        onManageWorkspace();
+      } else if (section == 'skills' && onManageSkills != null) {
+        onManageSkills();
+      } else if (section == 'search' && onManageSearch != null) {
+        onManageSearch();
+      } else {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => AssistantSettingsEditPage(
+              assistantId: assistantId,
+              initialTab: section,
+            ),
+          ),
+        );
+      }
+    },
+  );
+  // Narrow desktop windows still use a dialog, never a bottom sheet.
+  if (PlatformUtils.isDesktopTarget || ResponsiveHelper.isDesktop(context)) {
+    return showDialog<void>(
+      context: context,
+      builder: (ctx) => Dialog(
+        child: SizedBox(
+          width: 720,
+          height: MediaQuery.sizeOf(ctx).height * .85,
+          child: panel(ctx),
+        ),
+      ),
+    );
+  }
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: context.overlaySurface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (ctx) => SizedBox(
+      height: MediaQuery.sizeOf(ctx).height * .85,
+      child: panel(ctx),
+    ),
+  );
+}
+
+class ChatContextInspector extends StatelessWidget {
+  const ChatContextInspector({
+    super.key,
+    required this.assistantId,
+    required this.conversationId,
+    required this.isToolModel,
+    required this.onClose,
+    required this.onManage,
+  });
+  final String assistantId;
+  final String? conversationId;
+  final bool Function(String, String) isToolModel;
+  final VoidCallback onClose;
+  final ValueChanged<String> onManage;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final ap = context.watch<AssistantProvider>();
+    final assistant = ap.getById(assistantId);
+    final chat = context.read<ChatService>();
+    final current = context.select<ChatService, Conversation?>(
+      (chat) => chat.getConversation(conversationId ?? ''),
+    );
+    final settings = context.watch<SettingsProvider>();
+    final mcp = context.watch<McpProvider?>();
+    final skills = context.watch<SkillsService?>();
+    final workspaces = context.watch<WorkspaceProvider?>();
+    final runtime = context.watch<WorkspaceRuntimeProvider?>();
+    if (assistant == null) {
+      return Center(child: Text(l10n.assistantEditPageNotFound));
+    }
+
+    final model = getModelDisplayInfo(
+      settings,
+      assistant: assistant,
+      conversation: current,
+    );
+    final supportsTools =
+        model.isConfigured && isToolModel(model.providerKey!, model.modelId!);
+    final native = model.isConfigured
+        ? GenerationCapabilities.resolve(
+            config: model.getConfig(settings)!,
+            modelId: model.modelId!,
+            clientTools: const [],
+          )
+        : null;
+    final toolsAvailable = supportsTools && (native?.allowsClientTools ?? true);
+    final toolReason = !supportsTools
+        ? l10n.harnessToolsUnsupported
+        : l10n.harnessNativeExclusive;
+    final connected =
+        mcp?.connectedServers
+            .where((server) => server.tools.any((tool) => tool.enabled))
+            .map((server) => server.id)
+            .toSet() ??
+        <String>{};
+    final connectedCount = assistant.mcpServerIds
+        .where(connected.contains)
+        .length;
+    final localCount = assistant.localToolIds
+        .where(LocalToolsService.isAvailableOnThisPlatform)
+        .length;
+    final binding = WorkspaceBinding.fromExtras(current?.extras ?? const {});
+    final workspaceId =
+        binding.workspaceId ??
+        (current == null ? assistant.defaultWorkspaceId : null);
+    final workspace = workspaceId == null
+        ? null
+        : workspaces?.byId(workspaceId);
+    final selectedSkills =
+        skills?.resolveForAssistant(
+          assistant,
+          conversationOverride: SkillsBinding.fromExtras(
+            current?.extras ?? const {},
+          ).skillIds,
+        ) ??
+        const [];
+    final configuredSkills = selectedSkills.length;
+    final canReadSkills =
+        workspace == null || workspace.isToolEnabled('read_file');
+    String availability(bool enabled, bool available, String reason) => !enabled
+        ? l10n.harnessOff
+        : available
+        ? l10n.harnessAvailable
+        : '${l10n.harnessUnavailable} · $reason';
+
+    String countedAvailability(int eligible, int selected, String reason) {
+      final count = toolsAvailable ? eligible : 0;
+      final label = count > 0 && count < selected
+          ? '${l10n.harnessPartial} · $reason'
+          : availability(
+              selected > 0,
+              count > 0,
+              !toolsAvailable ? toolReason : reason,
+            );
+      return '$label · $count/$selected';
+    }
+
+    return SafeArea(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    l10n.harnessTitle,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: AppFontWeights.emphasis,
+                    ),
+                  ),
+                ),
+                IosIconButton(
+                  icon: Lucide.X,
+                  semanticLabel: l10n.harnessClose,
+                  onTap: onClose,
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text(
+                  l10n.harnessCurrentConfiguration,
+                  style: TextStyle(fontWeight: AppFontWeights.emphasis),
+                ),
+                const SizedBox(height: 8),
+                RuntimeContextSettingsCard(
+                  assistant: assistant,
+                  conversation: current,
+                  onChanged: (next) => ap.updateAssistant(next),
+                ),
+                const SizedBox(height: 12),
+                SectionCard(
+                  children: [
+                    _StatusRow(
+                      title: l10n.harnessMemory,
+                      icon: Lucide.Brain,
+                      status:
+                          !assistant.enableMemory &&
+                              !assistant.allowPastConversationRecall
+                          ? l10n.harnessOff
+                          : assistant.enableMemory && !toolsAvailable
+                          ? l10n.harnessMemoryReadOnly
+                          : availability(true, toolsAvailable, toolReason),
+                      onTap: () => onManage('memory'),
+                    ),
+                    _StatusRow(
+                      title: l10n.harnessSearch,
+                      icon: Lucide.Search,
+                      status:
+                          native?.nativeTools.any(
+                                (name) => name.contains('search'),
+                              ) ==
+                              true
+                          ? l10n.harnessNativeTools
+                          : availability(
+                              assistant.searchEnabled,
+                              toolsAvailable,
+                              toolReason,
+                            ),
+                      onTap: () => onManage('search'),
+                    ),
+                    _StatusRow(
+                      title: l10n.harnessLocalTools,
+                      icon: Lucide.ToolCase,
+                      status: countedAvailability(
+                        localCount,
+                        assistant.localToolIds.length,
+                        l10n.harnessPlatformUnavailable,
+                      ),
+                      onTap: () => onManage('localTools'),
+                    ),
+                    _StatusRow(
+                      title: 'MCP',
+                      icon: Lucide.Wrench,
+                      status: countedAvailability(
+                        connectedCount,
+                        assistant.mcpServerIds.length,
+                        l10n.harnessMcpDisconnected,
+                      ),
+                      onTap: () => onManage('mcp'),
+                    ),
+                    _StatusRow(
+                      title: l10n.harnessSkills,
+                      icon: Lucide.WandSparkles,
+                      status:
+                          '${availability(configuredSkills > 0, toolsAvailable && canReadSkills, !toolsAvailable ? toolReason : l10n.harnessSkillReadUnavailable)} · $configuredSkills',
+                      onTap: () => onManage('skills'),
+                    ),
+                    _StatusRow(
+                      title: l10n.harnessWorkspace,
+                      icon: Lucide.Folder,
+                      status: workspaceId == null
+                          ? l10n.harnessOff
+                          : workspace == null
+                          ? l10n.harnessNotConfigured
+                          : '${workspace.name} · '
+                                '${!toolsAvailable
+                                    ? toolReason
+                                    : runtime?.lastStatus?.ready == true
+                                    ? l10n.harnessAvailable
+                                    : runtime?.lastStatus == null
+                                    ? l10n.harnessReadinessPending
+                                    : l10n.harnessWorkspaceUnready}',
+                      onTap: () => onManage('workspace'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                ListenableBuilder(
+                  listenable: chat.preparedContexts,
+                  builder: (context, _) => _LatestRequest(
+                    snapshot: chat.preparedContexts.forConversation(
+                      conversationId,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  const _StatusRow({
+    required this.title,
+    required this.status,
+    required this.icon,
+    required this.onTap,
+  });
+  final String title;
+  final String status;
+  final IconData icon;
+  final VoidCallback onTap;
+  @override
+  Widget build(BuildContext context) => InkWell(
+    onTap: onTap,
+    child: Padding(
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title),
+                const SizedBox(height: 4),
+                Text(status, style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ),
+          const Icon(Lucide.ChevronRight, size: 16),
+        ],
+      ),
+    ),
+  );
+}
+
+class _LatestRequest extends StatefulWidget {
+  const _LatestRequest({this.snapshot});
+  final PreparedContextSnapshot? snapshot;
+  @override
+  State<_LatestRequest> createState() => _LatestRequestState();
+}
+
+class _LatestRequestState extends State<_LatestRequest> {
+  bool expanded = false;
+  @override
+  void didUpdateWidget(covariant _LatestRequest oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.snapshot?.generationId != widget.snapshot?.generationId) {
+      expanded = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final snapshot = widget.snapshot;
+    return SectionCard(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.harnessLatestRequest,
+            style: TextStyle(fontWeight: AppFontWeights.emphasis),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            snapshot == null
+                ? l10n.harnessNoSnapshot
+                : l10n.harnessPreparedOnly,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          if (snapshot != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              '${snapshot.context.model} · ${snapshot.context.timestamp.toLocal()}',
+            ),
+            Text(l10n.contextLogSnapshotTokens(snapshot.context.totalTokens)),
+            Text(
+              '${l10n.harnessClientTools}: ${snapshot.toolNames.length} · '
+              '${l10n.harnessToolsEstimate}: ${snapshot.toolTokens}',
+            ),
+            Text(
+              '${l10n.harnessNativeTools}: ${snapshot.nativeTools.isEmpty ? '—' : snapshot.nativeTools.join(', ')}',
+            ),
+            TextButton.icon(
+              key: const ValueKey('context-inspector-details'),
+              icon: Icon(
+                expanded ? Lucide.ChevronUp : Lucide.ChevronDown,
+                size: 16,
+              ),
+              onPressed: () => setState(() => expanded = !expanded),
+              label: Text(l10n.harnessDetails),
+            ),
+            if (expanded) ...[
+              SelectableText(
+                '${l10n.harnessClientTools}: ${snapshot.toolNames.isEmpty ? '—' : snapshot.toolNames.join(', ')}',
+              ),
+              for (final issue in snapshot.issues)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    '${contextSourceLabel(l10n, issue.source)} · ${l10n.harnessNotInjected} · ${issue.reason}',
+                  ),
+                ),
+              Text(
+                l10n.harnessPreviewHint,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              for (final message in _previewMessages(snapshot))
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: ContextMessageGroup(message: message),
+                ),
+              TextButton.icon(
+                key: const ValueKey('context-inspector-full-request'),
+                icon: const Icon(Lucide.ListTree, size: 16),
+                label: Text(l10n.harnessFullRequest),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) =>
+                        ContextSnapshotDetailPage(snapshot: snapshot.context),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+Iterable<ContextLogMessage> _previewMessages(PreparedContextSnapshot snapshot) {
+  final messages = snapshot.context.messages;
+  if (messages.isEmpty) return const [];
+  final live = messages.where(
+    (message) => message.segments.any(
+      (segment) => segment.source == ContextSource.runtimeContext,
+    ),
+  );
+  return {messages.first, live.isNotEmpty ? live.last : messages.last};
+}

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1,3 +1,5 @@
+import '../../workspace/widgets/skills/conversation_skills_sheet.dart';
+import '../../chat/widgets/chat_context_inspector.dart';
 import 'dart:async';
 import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
@@ -1522,6 +1524,47 @@ class _HomePageState extends State<HomePage>
           anchorKey: _inputBarKey,
           conversationId: id,
           assistant: assistant,
+        );
+      },
+      onOpenContext: () {
+        final assistant = context.read<AssistantProvider>().currentAssistant;
+        if (assistant == null) return;
+        _controller.dismissKeyboard();
+        showChatContextInspector(
+          context,
+          assistantId: assistant.id,
+          conversationId: _controller.currentConversation?.id,
+          isToolModel: _controller.isToolModel,
+          onManageSearch: _openSearchSettings,
+          onManageWorkspace: () {
+            if (PlatformUtils.isDesktop) {
+              showDesktopWorkspaceDialog(
+                context,
+                conversationListenable: _controller,
+                conversationId: () => _controller.currentConversation?.id,
+                assistantId: assistant.id,
+              );
+            } else {
+              showChatToolsSheet(
+                context,
+                assistantId: assistant.id,
+                conversationId: _controller.currentConversation?.id,
+              );
+            }
+          },
+          onManageSkills: () async {
+            final id = await ensureConversationId(
+              context,
+              conversationId: _controller.currentConversation?.id,
+              assistantId: assistant.id,
+            );
+            if (id == null || !context.mounted) return;
+            await showConversationSkillsSheet(
+              context,
+              conversationId: id,
+              assistant: assistant,
+            );
+          },
         );
       },
       onOpenTools: () {

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -23,7 +23,7 @@ import '../../../utils/mcp_structured_image.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../core/services/chat/prompt_transformer.dart';
 import '../../../core/services/logging/context_log_models.dart';
-import '../../../core/services/logging/context_logger.dart';
+import '../../../core/services/chat/prepared_context_store.dart';
 import '../../../core/services/memory/memory_block_builder.dart';
 import '../../../core/services/memory/memory_prompts.dart';
 import '../../../core/models/skills_binding.dart';
@@ -317,7 +317,7 @@ class MessageBuilderService {
               // assistant message as well would replay the same reasoning
               // twice, which OpenRouter/Anthropic reject. Only the final
               // assistant message below carries them.
-              if (ContextLogger.enabled) {
+              {
                 ContextSegmentTags.replaceWithSingle(
                   assistantToolMessage,
                   source: ContextSource.toolCall,
@@ -386,7 +386,7 @@ class MessageBuilderService {
       if (reasoningDetails != null) {
         message['reasoning_details'] = reasoningDetails;
       }
-      if (ContextLogger.enabled) {
+      {
         ContextSegmentTags.replaceWithSingle(
           message,
           source: ContextSource.chatHistory,
@@ -1032,7 +1032,7 @@ class MessageBuilderService {
         final carriesSnapshot =
             existing.carriesMemorySnapshot && sendPayload == existing.payload;
         if (carriesSnapshot) snapshotRevisionIds.add(revisionId);
-        if (ContextLogger.enabled) {
+        {
           _tagFrozenUserPrompt(
             apiMessages[i],
             payload: sendPayload,
@@ -1146,15 +1146,12 @@ class MessageBuilderService {
             ? '{{ message }}'
             : (assistant?.messageTemplate ?? '{{ message }}');
         final now = chatMessage?.timestamp ?? DateTime.now();
-        var content = PromptTransformer.applyMessageTemplate(
+        final content = PromptTransformer.applyMessageTemplate(
           templ,
           role: 'user',
           message: processedBody,
           now: now,
         );
-        if (assistant?.appendCurrentTimeToUserMessage == true) {
-          content = '$content\n\n${MemoryPrompts.formatCurrentTimeTag(now)}';
-        }
         apiMessages[i]['content'] = content;
       }
     }
@@ -1263,7 +1260,7 @@ class MessageBuilderService {
         if (wanted == null || wanted == split.prefix) continue;
         final refreshed = '$wanted${split.rest}';
         message['content'] = refreshed;
-        if (ContextLogger.enabled) {
+        {
           _tagFrozenUserPrompt(
             message,
             payload: refreshed,
@@ -1273,7 +1270,7 @@ class MessageBuilderService {
         continue;
       }
       message['content'] = split.rest;
-      if (ContextLogger.enabled) {
+      {
         ContextSegmentTags.replaceWithSingle(
           message,
           source: ContextSource.chatHistory,
@@ -1368,12 +1365,9 @@ class MessageBuilderService {
       message: processedUserBody,
       now: message.timestamp,
     );
-    final timeSuffix = (assistant?.appendCurrentTimeToUserMessage ?? false)
-        ? '\n\n${MemoryPrompts.formatCurrentTimeTag(message.timestamp)}'
-        : '';
-    final finalContent = '${memory.prefix}$templated$timeSuffix';
+    final finalContent = '${memory.prefix}$templated';
 
-    if (ContextLogger.enabled) {
+    {
       for (final apiMessage in apiMessages) {
         if ((apiMessage[internalRevisionIdKey] ?? '').toString() !=
             message.id) {
@@ -1624,7 +1618,7 @@ class MessageBuilderService {
         vars,
       );
       final sysMessage = <String, dynamic>{'role': 'system', 'content': sys};
-      if (ContextLogger.enabled) {
+      {
         ContextSegmentTags.replaceWithSingle(
           sysMessage,
           source: ContextSource.systemPrompt,
@@ -1648,6 +1642,8 @@ class MessageBuilderService {
     Assistant? assistant, {
     SettingsProvider? settings,
     String? currentConversationId,
+    Set<String>? availableToolNames,
+    List<ContextPreparationIssue>? issues,
   }) async {
     try {
       if (assistant == null) return;
@@ -1657,6 +1653,7 @@ class MessageBuilderService {
           assistant,
           settings: settings,
           currentConversationId: currentConversationId,
+          availableToolNames: availableToolNames,
         );
         return;
       }
@@ -1664,7 +1661,10 @@ class MessageBuilderService {
       // allowPastConversationRecall alone, so its rules cannot ride along with
       // the long-term memory rules or the tool ships without instructions.
       final wantsMemoryRules = assistant.enableMemory;
-      final wantsRecallRules = assistant.allowPastConversationRecall;
+      final wantsRecallRules =
+          assistant.allowPastConversationRecall &&
+          (availableToolNames == null ||
+              availableToolNames.contains('chat_search'));
       if (!wantsMemoryRules && !wantsRecallRules) return;
 
       final resolved = settings ?? contextProvider.read<SettingsProvider>();
@@ -1674,7 +1674,15 @@ class MessageBuilderService {
         final rules = lang == MemoryPromptLang.zh
             ? resolved.memoryRulesPromptZh
             : resolved.memoryRulesPromptEn;
-        buf.write(rules.trim());
+        buf.write(
+          availableToolNames == null
+              ? rules.trim()
+              : MemoryPrompts.forAvailableTools(
+                  rules,
+                  lang,
+                  availableToolNames,
+                ),
+        );
       }
       if (wantsRecallRules) {
         if (buf.isNotEmpty) buf.write('\n\n');
@@ -1685,7 +1693,14 @@ class MessageBuilderService {
         buf.toString(),
         source: ContextSource.memoryRules,
       );
-    } catch (_) {}
+    } catch (error) {
+      issues?.add(
+        ContextPreparationIssue(
+          ContextSource.memoryRules,
+          error.runtimeType.toString(),
+        ),
+      );
+    }
   }
 
   Future<void> _injectLegacyMemoryAndRecentChats(
@@ -1693,6 +1708,7 @@ class MessageBuilderService {
     Assistant assistant, {
     SettingsProvider? settings,
     String? currentConversationId,
+    Set<String>? availableToolNames,
   }) async {
     if (assistant.enableMemory) {
       final resolved = settings ?? contextProvider.read<SettingsProvider>();
@@ -1716,12 +1732,29 @@ class MessageBuilderService {
       final template = resolved.resolvedMemoryPromptLang == MemoryPromptLang.zh
           ? resolved.legacyMemoryPromptZh
           : resolved.legacyMemoryPromptEn;
-      buf.writeln(
-        template.replaceAll(
-          MemoryPrompts.legacyCurrentTimePlaceholder,
-          currentHour,
-        ),
-      );
+      const operations = {'create_memory', 'edit_memory', 'delete_memory'};
+      final builtInTemplate =
+          template.trim() == MemoryPrompts.legacyRulesZh ||
+          template.trim() == MemoryPrompts.legacyRulesEn;
+      if (availableToolNames != null &&
+          builtInTemplate &&
+          !availableToolNames.containsAll(operations)) {
+        final available = operations
+            .where(availableToolNames.contains)
+            .join(', ');
+        buf.writeln(
+          resolved.resolvedMemoryPromptLang == MemoryPromptLang.zh
+              ? '这些记录是应用提供的历史记忆。仅使用工具定义中列出的操作。本轮可用记忆工具：${available.isEmpty ? "无" : available}。'
+              : 'These records are app-provided historical memory. Use only operations in the tool definitions. Memory tools in this request: ${available.isEmpty ? "none" : available}.',
+        );
+      } else {
+        buf.writeln(
+          template.replaceAll(
+            MemoryPrompts.legacyCurrentTimePlaceholder,
+            currentHour,
+          ),
+        );
+      }
       _appendToSystemMessage(
         apiMessages,
         buf.toString(),
@@ -1819,6 +1852,8 @@ class MessageBuilderService {
     String? conversationId,
     WorkspaceToolContext? workspaceContext,
     List<AttachmentInfo> attachments = const [],
+    Set<String>? availableToolNames,
+    List<ContextPreparationIssue>? issues,
   }) async {
     try {
       final environmentProvider = contextProvider.read<EnvironmentProvider?>();
@@ -1837,14 +1872,22 @@ class MessageBuilderService {
         ctx,
         attachments: attachments,
         environmentVariableNames: environment?.variables.keys ?? const [],
+        availableToolNames: availableToolNames,
       );
       if (fragment.trim().isEmpty) return;
       _appendToSystemMessage(
         apiMessages,
         fragment,
-        source: ContextSource.instructionInjection,
+        source: ContextSource.workspace,
       );
-    } catch (_) {}
+    } catch (error) {
+      issues?.add(
+        ContextPreparationIssue(
+          ContextSource.workspace,
+          error.runtimeType.toString(),
+        ),
+      );
+    }
   }
 
   /// Inject the `<available_skills>` list after the workspace prompt.
@@ -1853,6 +1896,8 @@ class MessageBuilderService {
     Assistant? assistant, {
     String? conversationId,
     WorkspaceToolContext? workspaceContext,
+    Set<String>? availableToolNames,
+    List<ContextPreparationIssue>? issues,
   }) async {
     try {
       final skillsService = contextProvider.read<SkillsService>();
@@ -1869,8 +1914,18 @@ class MessageBuilderService {
         conversationOverride: override,
       );
       if (skills.isEmpty) return;
-      final skillsModelRoot =
-          workspaceContext?.paths.modelSkillsDir ?? '/skills';
+      if (workspaceContext == null ||
+          (availableToolNames != null &&
+              !availableToolNames.contains('read_file'))) {
+        issues?.add(
+          const ContextPreparationIssue(
+            ContextSource.skills,
+            'toolUnavailable',
+          ),
+        );
+        return;
+      }
+      final skillsModelRoot = workspaceContext.paths.modelSkillsDir;
       final fragment = buildAvailableSkillsFragment(
         skills,
         skillsModelRoot: skillsModelRoot,
@@ -1879,9 +1934,16 @@ class MessageBuilderService {
       _appendToSystemMessage(
         apiMessages,
         fragment,
-        source: ContextSource.instructionInjection,
+        source: ContextSource.skills,
       );
-    } catch (_) {}
+    } catch (error) {
+      issues?.add(
+        ContextPreparationIssue(
+          ContextSource.skills,
+          error.runtimeType.toString(),
+        ),
+      );
+    }
   }
 
   /// Inject world book (lorebook) entries into apiMessages.
@@ -2011,7 +2073,7 @@ class MessageBuilderService {
                   'role': 'user',
                   'content': wrapSystemTag(merged),
                 };
-          if (ContextLogger.enabled) {
+          {
             ContextSegmentTags.replaceWithSingle(
               message,
               source: ContextSource.worldBook,
@@ -2069,7 +2131,7 @@ class MessageBuilderService {
             sb.write(afterContent);
           }
           apiMessages[systemIndex]['content'] = sb.toString();
-          if (ContextLogger.enabled) {
+          {
             final sysMsg = apiMessages[systemIndex];
             if (beforeContent.isNotEmpty) {
               ContextSegmentTags.prepend(
@@ -2106,7 +2168,7 @@ class MessageBuilderService {
               'role': 'system',
               'content': sb.toString(),
             };
-            if (ContextLogger.enabled) {
+            {
               if (beforeContent.isNotEmpty && afterContent.isNotEmpty) {
                 ContextSegmentTags.write(created, [
                   ContextSegmentTags.item(
@@ -2227,7 +2289,7 @@ class MessageBuilderService {
     if (apiMessages.isNotEmpty && apiMessages.first['role'] == 'system') {
       apiMessages[0]['content'] =
           '${(apiMessages[0]['content'] ?? '') as String}\n\n$content';
-      if (ContextLogger.enabled && source != null) {
+      if (source != null) {
         ContextSegmentTags.append(
           apiMessages[0],
           source: source,
@@ -2236,7 +2298,7 @@ class MessageBuilderService {
       }
     } else {
       final message = <String, dynamic>{'role': 'system', 'content': content};
-      if (ContextLogger.enabled && source != null) {
+      if (source != null) {
         ContextSegmentTags.append(
           message,
           source: source,

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -1,3 +1,4 @@
+import '../../../core/models/workspace_binding.dart';
 import 'package:Kelivo/core/providers/external_mounts_provider.dart';
 import 'dart:async';
 import 'package:flutter/widgets.dart';
@@ -13,6 +14,10 @@ import '../../../core/services/api/builtin_tools.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/providers/workspace_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/chat/runtime_context.dart';
+import '../../../core/services/chat/prepared_context_store.dart';
+import '../../../core/services/logging/context_log_models.dart';
+import '../../../core/services/api/generation/generation_capabilities.dart';
 import '../../../core/services/chat/document_text_extractor.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../core/services/logging/context_logger.dart';
@@ -66,6 +71,7 @@ class PreparedGeneration {
   final ToolCallHandler? onToolCall;
   final bool hasBuiltInSearch;
   final List<String> lastUserImagePaths;
+  final PreparedContextSnapshot? contextSnapshot;
 
   PreparedGeneration({
     required this.apiMessages,
@@ -73,6 +79,7 @@ class PreparedGeneration {
     this.onToolCall,
     required this.hasBuiltInSearch,
     required this.lastUserImagePaths,
+    this.contextSnapshot,
   });
 }
 
@@ -92,13 +99,15 @@ class MessageGenerationService {
     required this.generationController,
     required this.streamController,
     required this.contextProvider,
-  });
+    DateTime Function()? clock,
+  }) : clock = clock ?? DateTime.now;
 
   final ChatService chatService;
   final MessageBuilderService messageBuilderService;
   final GenerationController generationController;
   final stream_ctrl.StreamController streamController;
   final BuildContext contextProvider;
+  final DateTime Function() clock;
 
   // Callbacks for UI updates (set by home_page)
   OnMessagesChanged? onMessagesChanged;
@@ -139,6 +148,9 @@ class MessageGenerationService {
     String? processingMessageId,
     String? requiredAttachmentMessageId,
   }) async {
+    final appLocale = assistant?.includeAppLocaleInContext == true
+        ? Localizations.localeOf(contextProvider).toLanguageTag()
+        : '';
     final cfg = settings.getProviderConfig(providerKey);
     final kind = ProviderConfig.classify(
       providerKey,
@@ -180,37 +192,7 @@ class MessageGenerationService {
       }
     }
 
-    // Inject prompts first so WorldBook can scan the full untrimmed history
-    // (same keyword trigger range as before OCR-after-trim). Document/OCR work
-    // runs only after the single final context trim below.
-    messageBuilderService.injectSystemPrompt(apiMessages, assistant, modelId);
-    await messageBuilderService.injectMemoryAndRecentChats(
-      apiMessages,
-      assistant,
-      settings: settings,
-      currentConversationId: currentConversation?.id,
-    );
-
-    final hasBuiltInSearch = messageBuilderService.hasBuiltInSearch(
-      settings,
-      providerKey,
-      modelId,
-    );
-    messageBuilderService.injectSearchPrompt(
-      apiMessages,
-      settings,
-      assistant,
-      hasBuiltInSearch,
-    );
-    await messageBuilderService.injectInstructionPrompts(
-      apiMessages,
-      assistantId,
-    );
-    await messageBuilderService.injectWorldBookPrompts(
-      apiMessages,
-      assistantId,
-    );
-
+    final issues = <ContextPreparationIssue>[];
     WorkspaceToolContext? workspaceContext;
     var workspaceAttachments = const <AttachmentInfo>[];
     try {
@@ -221,6 +203,17 @@ class MessageGenerationService {
           workspaceProvider: workspaceProvider,
           runtimeProvider: runtimeProvider,
           chatService: chatService,
+        );
+      }
+      if (workspaceContext == null &&
+          WorkspaceBinding.fromExtras(
+            currentConversation?.extras ?? const {},
+          ).isBound) {
+        issues.add(
+          const ContextPreparationIssue(
+            ContextSource.workspace,
+            'workspaceUnavailable',
+          ),
         );
       }
       workspaceContext ??= await _skillsOnlyContext(
@@ -234,28 +227,91 @@ class MessageGenerationService {
           requiredMessageId: requiredAttachmentMessageId,
         );
       }
-      if (workspaceContext != null) {
-        await messageBuilderService.injectWorkspacePrompt(
-          apiMessages,
-          assistant,
-          conversationId: currentConversation?.id,
-          workspaceContext: workspaceContext,
-          attachments: workspaceAttachments,
-        );
-      }
     } catch (e) {
       if (workspaceContext != null && !workspaceContext.skillsOnly) {
         // Let the existing generation error UI offer retry. Continuing here
         // would silently send without the attachments the user selected.
         rethrow;
       }
-      debugPrint('Workspace prompt/attachments failed: $e');
+      issues.add(
+        ContextPreparationIssue(
+          ContextSource.workspace,
+          e.runtimeType.toString(),
+        ),
+      );
+    }
+    final hasBuiltInSearch = messageBuilderService.hasBuiltInSearch(
+      settings,
+      providerKey,
+      modelId,
+    );
+    final mcpRouteSnapshot = generationController.captureMcpToolRoutes(
+      assistant,
+    );
+    final configuredToolDefs = generationController.buildToolDefinitions(
+      settings,
+      assistant,
+      providerKey,
+      modelId,
+      hasBuiltInSearch,
+      mcpRouteSnapshot: mcpRouteSnapshot,
+      workspaceContext: workspaceContext,
+    );
+    final capabilities = GenerationCapabilities.resolve(
+      config: cfg,
+      modelId: modelId,
+      clientTools: configuredToolDefs,
+    );
+    final toolDefs = capabilities.clientTools;
+    final availableToolNames = capabilities.toolNames;
+    // Inject prompts first so WorldBook can scan the full untrimmed history
+    // (same keyword trigger range as before OCR-after-trim). Document/OCR work
+    // runs only after the single final context trim below.
+    messageBuilderService.injectSystemPrompt(apiMessages, assistant, modelId);
+    await messageBuilderService.injectMemoryAndRecentChats(
+      apiMessages,
+      assistant,
+      settings: settings,
+      currentConversationId: currentConversation?.id,
+      availableToolNames: availableToolNames,
+      issues: issues,
+    );
+
+    if (availableToolNames.contains('search_web')) {
+      messageBuilderService.injectSearchPrompt(
+        apiMessages,
+        settings,
+        assistant,
+        hasBuiltInSearch,
+      );
+    }
+    await messageBuilderService.injectInstructionPrompts(
+      apiMessages,
+      assistantId,
+    );
+    await messageBuilderService.injectWorldBookPrompts(
+      apiMessages,
+      assistantId,
+    );
+
+    if (workspaceContext != null) {
+      await messageBuilderService.injectWorkspacePrompt(
+        apiMessages,
+        assistant,
+        conversationId: currentConversation?.id,
+        workspaceContext: workspaceContext,
+        attachments: workspaceAttachments,
+        availableToolNames: availableToolNames,
+        issues: issues,
+      );
     }
     await messageBuilderService.injectSkillsPrompt(
       apiMessages,
       assistant,
       conversationId: currentConversation?.id,
       workspaceContext: workspaceContext,
+      availableToolNames: availableToolNames,
+      issues: issues,
     );
 
     // Single final trim after WorldBook TOP/BOTTOM/AT_DEPTH injections. OCR and
@@ -270,18 +326,6 @@ class MessageGenerationService {
     // reads, memory injection, templating) must never show the bar.
     // Tools are assembled first: whether a data file is read into the prompt
     // or left for the sandbox depends on which tools go with it.
-    final mcpRouteSnapshot = generationController.captureMcpToolRoutes(
-      assistant,
-    );
-    final toolDefs = generationController.buildToolDefinitions(
-      settings,
-      assistant,
-      providerKey,
-      modelId,
-      hasBuiltInSearch,
-      mcpRouteSnapshot: mcpRouteSnapshot,
-      workspaceContext: workspaceContext,
-    );
     final sandboxDataFiles = BuiltInToolsHelper.sendsDataFilesToSandbox(
       cfg: cfg,
       modelId: modelId,
@@ -341,16 +385,33 @@ class MessageGenerationService {
     }
 
     await messageBuilderService.inlineLocalImages(apiMessages);
-    if (ContextLogger.enabled) {
-      final providerName = cfg.name.trim();
-      ContextLogger.logPrepared(
+    final now = clock();
+    final runtimeContext = RuntimeContextSnapshot.capture(
+      assistant: assistant,
+      now: now,
+      appLocale: appLocale,
+      modelName: displayNameForModel(cfg, modelId),
+      modelId: BuiltInToolNames.effectiveModelId(cfg: cfg, modelId: modelId),
+    );
+    injectRuntimeContext(apiMessages, runtimeContext);
+    final snapshot = PreparedContextSnapshot(
+      generationId:
+          processingMessageId ??
+          '${currentConversation?.id}:${now.microsecondsSinceEpoch}',
+      context: ContextLogger.buildSnapshot(
         apiMessages: apiMessages,
         conversationId: currentConversation?.id ?? '',
         assistantName: assistant?.name ?? '',
-        provider: providerName.isNotEmpty ? providerName : providerKey,
+        provider: cfg.name.trim().isNotEmpty ? cfg.name : providerKey,
         model: modelId,
-      );
-    }
+        timestamp: now,
+      ),
+      tools: toolDefs,
+      nativeTools: capabilities.nativeTools,
+      issues: List.unmodifiable(issues),
+    );
+    chatService.recordPreparedContext(snapshot);
+    ContextLogger.logSnapshot(snapshot.context);
     messageBuilderService.stripInternalRevisionIds(apiMessages);
 
     final onToolCall = toolDefs.isNotEmpty
@@ -371,6 +432,7 @@ class MessageGenerationService {
       onToolCall: onToolCall,
       hasBuiltInSearch: hasBuiltInSearch,
       lastUserImagePaths: lastUserImagePaths,
+      contextSnapshot: snapshot,
     );
   }
 

--- a/lib/features/home/utils/model_display_helper.dart
+++ b/lib/features/home/utils/model_display_helper.dart
@@ -84,21 +84,7 @@ ModelDisplayInfo getModelDisplayInfo(
   final cfg = settings.getProviderConfig(providerKey);
   final providerName = cfg.name.isNotEmpty ? cfg.name : providerKey;
 
-  // Extract model display name from overrides or use raw modelId
-  String modelDisplay = modelId;
-  final ov = cfg.modelOverrides[modelId] as Map?;
-  if (ov != null) {
-    // Priority: override name > apiModelId > api_model_id > raw modelId
-    final overrideName = (ov['name'] as String?)?.trim();
-    if (overrideName != null && overrideName.isNotEmpty) {
-      modelDisplay = overrideName;
-    } else {
-      final apiId = (ov['apiModelId'] ?? ov['api_model_id'])?.toString().trim();
-      if (apiId != null && apiId.isNotEmpty) {
-        modelDisplay = apiId;
-      }
-    }
-  }
+  final modelDisplay = displayNameForModel(cfg, modelId);
 
   return ModelDisplayInfo(
     providerName: providerName,
@@ -134,4 +120,25 @@ ProviderConfig? getActiveProviderConfig(
   ).providerKey;
   if (providerKey == null) return null;
   return settings.getProviderConfig(providerKey);
+}
+
+/// Display label for an already-resolved request target; shared by the UI and harness.
+String displayNameForModel(ProviderConfig cfg, String modelId) {
+  // Extract model display name from overrides or use raw modelId
+  String modelDisplay = modelId;
+  final ov = cfg.modelOverrides[modelId] as Map?;
+  if (ov != null) {
+    // Priority: override name > apiModelId > api_model_id > raw modelId
+    final overrideName = (ov['name'] as String?)?.trim();
+    if (overrideName != null && overrideName.isNotEmpty) {
+      modelDisplay = overrideName;
+    } else {
+      final apiId = (ov['apiModelId'] ?? ov['api_model_id'])?.toString().trim();
+      if (apiId != null && apiId.isNotEmpty) {
+        modelDisplay = apiId;
+      }
+    }
+  }
+
+  return modelDisplay;
 }

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -121,6 +121,7 @@ class ChatInputBar extends StatefulWidget {
     this.onSelectModel,
     this.onLongPressSelectModel,
     this.onOpenTools,
+    this.onOpenContext,
     this.onLongPressTools,
     this.onOpenWorkspace,
     this.showWorkspaceButton = false,
@@ -178,6 +179,7 @@ class ChatInputBar extends StatefulWidget {
   final VoidCallback? onSelectModel;
   final VoidCallback? onLongPressSelectModel;
   final VoidCallback? onOpenTools;
+  final VoidCallback? onOpenContext;
   final VoidCallback? onLongPressTools;
   final VoidCallback? onOpenWorkspace;
   final bool showWorkspaceButton;
@@ -1983,6 +1985,24 @@ class _ChatInputBarState extends State<ChatInputBar>
                 icon: Lucide.WandSparkles,
                 label: l10n.workspaceEntrySessionSkills,
                 onTap: lockTap(widget.onOpenSkills),
+              ),
+            ),
+          );
+        }
+
+        if (widget.onOpenContext != null) {
+          actions.add(
+            _OverflowAction(
+              width: normalButtonW,
+              builder: () => _CompactIconButton(
+                tooltip: l10n.harnessTitle,
+                icon: Lucide.Layers,
+                onTap: widget.onOpenContext,
+              ),
+              menu: DesktopContextMenuItem(
+                icon: Lucide.Layers,
+                label: l10n.harnessTitle,
+                onTap: widget.onOpenContext,
               ),
             ),
           );

--- a/lib/features/home/widgets/chat_input_section.dart
+++ b/lib/features/home/widgets/chat_input_section.dart
@@ -55,6 +55,7 @@ class ChatInputSection extends StatelessWidget {
     this.onSelectModel,
     this.onLongPressSelectModel,
     this.onOpenTools,
+    this.onOpenContext,
     this.onLongPressTools,
     this.onOpenWorkspace,
     this.onOpenSkills,
@@ -99,6 +100,7 @@ class ChatInputSection extends StatelessWidget {
   final VoidCallback? onSelectModel;
   final VoidCallback? onLongPressSelectModel;
   final VoidCallback? onOpenTools;
+  final VoidCallback? onOpenContext;
   final VoidCallback? onLongPressTools;
   final VoidCallback? onOpenWorkspace;
   final VoidCallback? onOpenSkills;
@@ -151,9 +153,8 @@ class ChatInputSection extends StatelessWidget {
     final pk = chatModelProviderKey;
     final mid = chatModelId;
 
-    // Enforce model capabilities: disable MCP selection if model doesn't
-    // support tools. Skipped while the conversation overrides the model —
-    // these writes land on the assistant and would leak across conversations.
+    // Reasoning enforcement is skipped for per-conversation model overrides.
+    // Tool selections are retained even when the current model lacks tools.
     if (!chatModelIsConversationOverride) {
       _enforceModelCapabilities(context, settings, ap, a, pk, mid);
     }
@@ -177,6 +178,7 @@ class ChatInputSection extends StatelessWidget {
       onLongPressSelectModel: onLongPressSelectModel,
       conversationId: conversationId,
       onOpenTools: onOpenTools,
+      onOpenContext: onOpenContext,
       onLongPressTools: onLongPressTools,
       onOpenWorkspace: onOpenWorkspace,
       showWorkspaceButton: showWorkspaceButton,
@@ -327,15 +329,8 @@ class ChatInputSection extends StatelessWidget {
   ) {
     if (pk == null || mid == null) return;
 
-    final supportsTools = isToolModel(pk, mid);
-    if (!supportsTools && (a?.mcpServerIds.isNotEmpty ?? false)) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final aa = ap.currentAssistant;
-        if (aa != null && aa.mcpServerIds.isNotEmpty) {
-          ap.updateAssistant(aa.copyWith(mcpServerIds: const <String>[]));
-        }
-      });
-    }
+    // Tool availability is request-scoped. Never erase the assistant's MCP
+    // selections just because one selected model does not support tools.
 
     final supportsReasoning = isReasoningModel(pk, mid);
     if (!supportsReasoning && a != null) {

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -870,7 +870,7 @@ class _ContextLogFilePageState extends State<_ContextLogFilePage> {
                         Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (_) =>
-                                _ContextSnapshotDetailPage(snapshot: snapshot),
+                                ContextSnapshotDetailPage(snapshot: snapshot),
                           ),
                         );
                       },
@@ -1207,7 +1207,7 @@ class _ContextCompositionLegend extends StatelessWidget {
               ),
               const SizedBox(width: 6),
               Text(
-                _contextSourceLabel(l10n, entry.key),
+                contextSourceLabel(l10n, entry.key),
                 style: TextStyle(
                   fontSize: 12,
                   color: cs.onSurface.withValues(alpha: 0.72),
@@ -1228,8 +1228,8 @@ class _ContextCompositionLegend extends StatelessWidget {
   }
 }
 
-class _ContextSnapshotDetailPage extends StatelessWidget {
-  const _ContextSnapshotDetailPage({required this.snapshot});
+class ContextSnapshotDetailPage extends StatelessWidget {
+  const ContextSnapshotDetailPage({super.key, required this.snapshot});
 
   final ContextLogSnapshot snapshot;
 
@@ -1309,7 +1309,7 @@ class _ContextSnapshotDetailPage extends StatelessWidget {
             padding: EdgeInsets.only(
               bottom: index == snapshot.messages.length ? 0 : 14,
             ),
-            child: _ContextMessageGroup(message: message),
+            child: ContextMessageGroup(message: message),
           );
         },
       ),
@@ -1343,8 +1343,8 @@ class _ContextInfoCard extends StatelessWidget {
   }
 }
 
-class _ContextMessageGroup extends StatelessWidget {
-  const _ContextMessageGroup({required this.message});
+class ContextMessageGroup extends StatelessWidget {
+  const ContextMessageGroup({super.key, required this.message});
 
   final ContextLogMessage message;
 
@@ -1482,7 +1482,7 @@ class _ContextSegmentBlockState extends State<_ContextSegmentBlock> {
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  _contextSourceLabel(l10n, widget.segment.source),
+                  contextSourceLabel(l10n, widget.segment.source),
                   style: TextStyle(
                     fontSize: 12.5,
                     fontWeight: AppFontWeights.emphasis,
@@ -2008,6 +2008,9 @@ Color _contextSourceColor(BuildContext context, ContextSource source) {
   final cs = Theme.of(context).colorScheme;
   final colors = context.appColors;
   switch (source) {
+    case ContextSource.runtimeContext:
+    case ContextSource.workspace:
+    case ContextSource.skills:
     case ContextSource.systemPrompt:
       return cs.primary;
     case ContextSource.memoryRules:
@@ -2027,8 +2030,14 @@ Color _contextSourceColor(BuildContext context, ContextSource source) {
   }
 }
 
-String _contextSourceLabel(AppLocalizations l10n, ContextSource source) {
+String contextSourceLabel(AppLocalizations l10n, ContextSource source) {
   switch (source) {
+    case ContextSource.runtimeContext:
+      return l10n.harnessBuiltInContext;
+    case ContextSource.workspace:
+      return l10n.harnessWorkspace;
+    case ContextSource.skills:
+      return l10n.harnessSkills;
     case ContextSource.systemPrompt:
       return l10n.contextLogSourceSystemPrompt;
     case ContextSource.memoryRules:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -502,30 +502,7 @@
   "assistantEditVariableRole": "Role",
   "assistantEditVariableMessage": "Message",
   "assistantEditPreviewTitle": "Preview",
-  "assistantEditPromptTimeVarWarning": "Using time variables in the system prompt makes the beginning of every request different, so prompt caching cannot hit and both cost and time-to-first-token go up. If the model needs to know the current time, use the \"Append current time\" switch below.",
-  "assistantEditPromptAppendTimeTitle": "Append current time",
-  "assistantEditPromptAppendTimeSubtitle": "Append the send time to the end of each user message. Time stays at the end of the request, so prompt caching is unaffected.",
-  "assistantEditPromptAppendTimeInfoTitle": "Appended time format",
-  "assistantEditPromptAppendTimeInfoBody": "When enabled, a blank line and then the following tag are appended at the end of each user message:\n\n{example}\n\nThe timestamp is that message’s own send time, so it stays stable when you retry.",
-  "@assistantEditPromptAppendTimeInfoBody": {
-    "placeholders": {
-      "example": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptAppendTimeInfoClose": "Got it",
-  "assistantEditPromptTimeVarDialogTitle": "System prompt contains time variables",
-  "assistantEditPromptTimeVarDialogBody": "Your system prompt uses {variables}. The system prompt is re-rendered on every request, so time variables make the beginning of every request different and prompt caching cannot hit. Consider removing these variables and using \"Append current time\" instead — it puts the time at the end of the request and does not affect the prefix.",
-  "@assistantEditPromptTimeVarDialogBody": {
-    "placeholders": {
-      "variables": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptTimeVarDialogRemove": "Go remove",
-  "assistantEditPromptTimeVarDialogKeep": "Enable anyway",
+  "assistantEditPromptTimeVarWarning": "Time variables change the system prompt between requests. Built-in current time can be enabled above without editing your instructions.",
   "codeBlockPreviewButton": "Preview",
   "codeBlockSaveAsButton": "Save as file",
   "codeBlockCollapseButton": "Collapse",
@@ -4931,5 +4908,48 @@
   "mcpImportJsonHint": "Paste a Claude Desktop or Cursor MCP configuration. Preview and add servers without replacing existing ones.",
   "mcpImportPaste": "Paste from Clipboard",
   "mcpImportPreview": "Preview",
-  "mcpImportConfirm": "Import"
+  "mcpImportConfirm": "Import",
+  "harnessTitle": "Context",
+  "harnessBuiltInContext": "Built-in context",
+  "harnessAssistantScope": "Applies to this assistant. Changes take effect on the next generation.",
+  "harnessTime": "Current time and timezone",
+  "harnessTimeDescription": "Preview only · refreshed when sending. The get_time_info tool is configured separately.",
+  "harnessLocale": "App language",
+  "harnessLocaleDescription": "Provides the UI language without enforcing a response language.",
+  "harnessModel": "Model information",
+  "harnessModelDescription": "Configured model name and request ID, not verified server identity.",
+  "harnessRequestOnly": "Added only to the current request, outside your system prompt. Not saved in chat messages or exports.",
+  "harnessTimeConflict": "Your custom prompt also contains time variables. Both will be sent; your text is kept unchanged.",
+  "harnessCustomInstructions": "Custom instructions",
+  "harnessAdvanced": "Advanced · variables and message templates",
+  "harnessCurrentConfiguration": "Current configuration",
+  "harnessLatestRequest": "Latest prepared request",
+  "harnessPreparedOnly": "App-assembled context, not the final provider wire payload. Counts are estimates, not billed usage. Later tool rounds are not included.",
+  "harnessNoSnapshot": "No request snapshot in this session. Sending a message creates one; opening this panel sends nothing.",
+  "harnessDetails": "Context details",
+  "harnessToolsEstimate": "Tool schema tokens (estimated)",
+  "harnessClientTools": "Client tools",
+  "harnessNativeTools": "Provider-native tools",
+  "harnessOff": "Off",
+  "harnessAvailable": "Available",
+  "harnessUnavailable": "Configured but unavailable",
+  "harnessNotConfigured": "Not configured",
+  "harnessToolsUnsupported": "The selected model does not support client tools",
+  "harnessNativeExclusive": "The selected native tools exclude client tools on this model",
+  "harnessPlatformUnavailable": "Not available on this platform",
+  "harnessMcpDisconnected": "Selected servers are disconnected or have no enabled tools",
+  "harnessSkillReadUnavailable": "The read_file tool is disabled",
+  "harnessWorkspaceUnready": "Shell environment is not ready; file tools are checked separately",
+  "harnessReadinessPending": "Readiness will be checked when preparing a request",
+  "harnessMemory": "Memory and past chats",
+  "harnessMemoryReadOnly": "Memory context enabled; memory tools unavailable this round",
+  "harnessSearch": "Search",
+  "harnessLocalTools": "Local tools",
+  "harnessSkills": "Skills",
+  "harnessWorkspace": "Workspace",
+  "harnessClose": "Close context",
+  "harnessNotInjected": "Not injected",
+  "harnessFullRequest": "View full request context",
+  "harnessPreviewHint": "Preview of system instructions and current-turn context. Full history is loaded on demand.",
+  "harnessPartial": "Partly available"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2515,62 +2515,8 @@ abstract class AppLocalizations {
   /// No description provided for @assistantEditPromptTimeVarWarning.
   ///
   /// In en, this message translates to:
-  /// **'Using time variables in the system prompt makes the beginning of every request different, so prompt caching cannot hit and both cost and time-to-first-token go up. If the model needs to know the current time, use the \"Append current time\" switch below.'**
+  /// **'Time variables change the system prompt between requests. Built-in current time can be enabled above without editing your instructions.'**
   String get assistantEditPromptTimeVarWarning;
-
-  /// No description provided for @assistantEditPromptAppendTimeTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Append current time'**
-  String get assistantEditPromptAppendTimeTitle;
-
-  /// No description provided for @assistantEditPromptAppendTimeSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Append the send time to the end of each user message. Time stays at the end of the request, so prompt caching is unaffected.'**
-  String get assistantEditPromptAppendTimeSubtitle;
-
-  /// No description provided for @assistantEditPromptAppendTimeInfoTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Appended time format'**
-  String get assistantEditPromptAppendTimeInfoTitle;
-
-  /// No description provided for @assistantEditPromptAppendTimeInfoBody.
-  ///
-  /// In en, this message translates to:
-  /// **'When enabled, a blank line and then the following tag are appended at the end of each user message:\n\n{example}\n\nThe timestamp is that message’s own send time, so it stays stable when you retry.'**
-  String assistantEditPromptAppendTimeInfoBody(String example);
-
-  /// No description provided for @assistantEditPromptAppendTimeInfoClose.
-  ///
-  /// In en, this message translates to:
-  /// **'Got it'**
-  String get assistantEditPromptAppendTimeInfoClose;
-
-  /// No description provided for @assistantEditPromptTimeVarDialogTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'System prompt contains time variables'**
-  String get assistantEditPromptTimeVarDialogTitle;
-
-  /// No description provided for @assistantEditPromptTimeVarDialogBody.
-  ///
-  /// In en, this message translates to:
-  /// **'Your system prompt uses {variables}. The system prompt is re-rendered on every request, so time variables make the beginning of every request different and prompt caching cannot hit. Consider removing these variables and using \"Append current time\" instead — it puts the time at the end of the request and does not affect the prefix.'**
-  String assistantEditPromptTimeVarDialogBody(String variables);
-
-  /// No description provided for @assistantEditPromptTimeVarDialogRemove.
-  ///
-  /// In en, this message translates to:
-  /// **'Go remove'**
-  String get assistantEditPromptTimeVarDialogRemove;
-
-  /// No description provided for @assistantEditPromptTimeVarDialogKeep.
-  ///
-  /// In en, this message translates to:
-  /// **'Enable anyway'**
-  String get assistantEditPromptTimeVarDialogKeep;
 
   /// No description provided for @codeBlockPreviewButton.
   ///
@@ -20192,6 +20138,264 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Import'**
   String get mcpImportConfirm;
+
+  /// No description provided for @harnessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Context'**
+  String get harnessTitle;
+
+  /// No description provided for @harnessBuiltInContext.
+  ///
+  /// In en, this message translates to:
+  /// **'Built-in context'**
+  String get harnessBuiltInContext;
+
+  /// No description provided for @harnessAssistantScope.
+  ///
+  /// In en, this message translates to:
+  /// **'Applies to this assistant. Changes take effect on the next generation.'**
+  String get harnessAssistantScope;
+
+  /// No description provided for @harnessTime.
+  ///
+  /// In en, this message translates to:
+  /// **'Current time and timezone'**
+  String get harnessTime;
+
+  /// No description provided for @harnessTimeDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview only · refreshed when sending. The get_time_info tool is configured separately.'**
+  String get harnessTimeDescription;
+
+  /// No description provided for @harnessLocale.
+  ///
+  /// In en, this message translates to:
+  /// **'App language'**
+  String get harnessLocale;
+
+  /// No description provided for @harnessLocaleDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Provides the UI language without enforcing a response language.'**
+  String get harnessLocaleDescription;
+
+  /// No description provided for @harnessModel.
+  ///
+  /// In en, this message translates to:
+  /// **'Model information'**
+  String get harnessModel;
+
+  /// No description provided for @harnessModelDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Configured model name and request ID, not verified server identity.'**
+  String get harnessModelDescription;
+
+  /// No description provided for @harnessRequestOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Added only to the current request, outside your system prompt. Not saved in chat messages or exports.'**
+  String get harnessRequestOnly;
+
+  /// No description provided for @harnessTimeConflict.
+  ///
+  /// In en, this message translates to:
+  /// **'Your custom prompt also contains time variables. Both will be sent; your text is kept unchanged.'**
+  String get harnessTimeConflict;
+
+  /// No description provided for @harnessCustomInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom instructions'**
+  String get harnessCustomInstructions;
+
+  /// No description provided for @harnessAdvanced.
+  ///
+  /// In en, this message translates to:
+  /// **'Advanced · variables and message templates'**
+  String get harnessAdvanced;
+
+  /// No description provided for @harnessCurrentConfiguration.
+  ///
+  /// In en, this message translates to:
+  /// **'Current configuration'**
+  String get harnessCurrentConfiguration;
+
+  /// No description provided for @harnessLatestRequest.
+  ///
+  /// In en, this message translates to:
+  /// **'Latest prepared request'**
+  String get harnessLatestRequest;
+
+  /// No description provided for @harnessPreparedOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'App-assembled context, not the final provider wire payload. Counts are estimates, not billed usage. Later tool rounds are not included.'**
+  String get harnessPreparedOnly;
+
+  /// No description provided for @harnessNoSnapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'No request snapshot in this session. Sending a message creates one; opening this panel sends nothing.'**
+  String get harnessNoSnapshot;
+
+  /// No description provided for @harnessDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Context details'**
+  String get harnessDetails;
+
+  /// No description provided for @harnessToolsEstimate.
+  ///
+  /// In en, this message translates to:
+  /// **'Tool schema tokens (estimated)'**
+  String get harnessToolsEstimate;
+
+  /// No description provided for @harnessClientTools.
+  ///
+  /// In en, this message translates to:
+  /// **'Client tools'**
+  String get harnessClientTools;
+
+  /// No description provided for @harnessNativeTools.
+  ///
+  /// In en, this message translates to:
+  /// **'Provider-native tools'**
+  String get harnessNativeTools;
+
+  /// No description provided for @harnessOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Off'**
+  String get harnessOff;
+
+  /// No description provided for @harnessAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Available'**
+  String get harnessAvailable;
+
+  /// No description provided for @harnessUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Configured but unavailable'**
+  String get harnessUnavailable;
+
+  /// No description provided for @harnessNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'Not configured'**
+  String get harnessNotConfigured;
+
+  /// No description provided for @harnessToolsUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'The selected model does not support client tools'**
+  String get harnessToolsUnsupported;
+
+  /// No description provided for @harnessNativeExclusive.
+  ///
+  /// In en, this message translates to:
+  /// **'The selected native tools exclude client tools on this model'**
+  String get harnessNativeExclusive;
+
+  /// No description provided for @harnessPlatformUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Not available on this platform'**
+  String get harnessPlatformUnavailable;
+
+  /// No description provided for @harnessMcpDisconnected.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected servers are disconnected or have no enabled tools'**
+  String get harnessMcpDisconnected;
+
+  /// No description provided for @harnessSkillReadUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'The read_file tool is disabled'**
+  String get harnessSkillReadUnavailable;
+
+  /// No description provided for @harnessWorkspaceUnready.
+  ///
+  /// In en, this message translates to:
+  /// **'Shell environment is not ready; file tools are checked separately'**
+  String get harnessWorkspaceUnready;
+
+  /// No description provided for @harnessReadinessPending.
+  ///
+  /// In en, this message translates to:
+  /// **'Readiness will be checked when preparing a request'**
+  String get harnessReadinessPending;
+
+  /// No description provided for @harnessMemory.
+  ///
+  /// In en, this message translates to:
+  /// **'Memory and past chats'**
+  String get harnessMemory;
+
+  /// No description provided for @harnessMemoryReadOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Memory context enabled; memory tools unavailable this round'**
+  String get harnessMemoryReadOnly;
+
+  /// No description provided for @harnessSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get harnessSearch;
+
+  /// No description provided for @harnessLocalTools.
+  ///
+  /// In en, this message translates to:
+  /// **'Local tools'**
+  String get harnessLocalTools;
+
+  /// No description provided for @harnessSkills.
+  ///
+  /// In en, this message translates to:
+  /// **'Skills'**
+  String get harnessSkills;
+
+  /// No description provided for @harnessWorkspace.
+  ///
+  /// In en, this message translates to:
+  /// **'Workspace'**
+  String get harnessWorkspace;
+
+  /// No description provided for @harnessClose.
+  ///
+  /// In en, this message translates to:
+  /// **'Close context'**
+  String get harnessClose;
+
+  /// No description provided for @harnessNotInjected.
+  ///
+  /// In en, this message translates to:
+  /// **'Not injected'**
+  String get harnessNotInjected;
+
+  /// No description provided for @harnessFullRequest.
+  ///
+  /// In en, this message translates to:
+  /// **'View full request context'**
+  String get harnessFullRequest;
+
+  /// No description provided for @harnessPreviewHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview of system instructions and current-turn context. Full history is loaded on demand.'**
+  String get harnessPreviewHint;
+
+  /// No description provided for @harnessPartial.
+  ///
+  /// In en, this message translates to:
+  /// **'Partly available'**
+  String get harnessPartial;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1294,40 +1294,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get assistantEditPromptTimeVarWarning =>
-      'Using time variables in the system prompt makes the beginning of every request different, so prompt caching cannot hit and both cost and time-to-first-token go up. If the model needs to know the current time, use the \"Append current time\" switch below.';
-
-  @override
-  String get assistantEditPromptAppendTimeTitle => 'Append current time';
-
-  @override
-  String get assistantEditPromptAppendTimeSubtitle =>
-      'Append the send time to the end of each user message. Time stays at the end of the request, so prompt caching is unaffected.';
-
-  @override
-  String get assistantEditPromptAppendTimeInfoTitle => 'Appended time format';
-
-  @override
-  String assistantEditPromptAppendTimeInfoBody(String example) {
-    return 'When enabled, a blank line and then the following tag are appended at the end of each user message:\n\n$example\n\nThe timestamp is that message’s own send time, so it stays stable when you retry.';
-  }
-
-  @override
-  String get assistantEditPromptAppendTimeInfoClose => 'Got it';
-
-  @override
-  String get assistantEditPromptTimeVarDialogTitle =>
-      'System prompt contains time variables';
-
-  @override
-  String assistantEditPromptTimeVarDialogBody(String variables) {
-    return 'Your system prompt uses $variables. The system prompt is re-rendered on every request, so time variables make the beginning of every request different and prompt caching cannot hit. Consider removing these variables and using \"Append current time\" instead — it puts the time at the end of the request and does not affect the prefix.';
-  }
-
-  @override
-  String get assistantEditPromptTimeVarDialogRemove => 'Go remove';
-
-  @override
-  String get assistantEditPromptTimeVarDialogKeep => 'Enable anyway';
+      'Time variables change the system prompt between requests. Built-in current time can be enabled above without editing your instructions.';
 
   @override
   String get codeBlockPreviewButton => 'Preview';
@@ -11230,4 +11197,148 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get mcpImportConfirm => 'Import';
+
+  @override
+  String get harnessTitle => 'Context';
+
+  @override
+  String get harnessBuiltInContext => 'Built-in context';
+
+  @override
+  String get harnessAssistantScope =>
+      'Applies to this assistant. Changes take effect on the next generation.';
+
+  @override
+  String get harnessTime => 'Current time and timezone';
+
+  @override
+  String get harnessTimeDescription =>
+      'Preview only · refreshed when sending. The get_time_info tool is configured separately.';
+
+  @override
+  String get harnessLocale => 'App language';
+
+  @override
+  String get harnessLocaleDescription =>
+      'Provides the UI language without enforcing a response language.';
+
+  @override
+  String get harnessModel => 'Model information';
+
+  @override
+  String get harnessModelDescription =>
+      'Configured model name and request ID, not verified server identity.';
+
+  @override
+  String get harnessRequestOnly =>
+      'Added only to the current request, outside your system prompt. Not saved in chat messages or exports.';
+
+  @override
+  String get harnessTimeConflict =>
+      'Your custom prompt also contains time variables. Both will be sent; your text is kept unchanged.';
+
+  @override
+  String get harnessCustomInstructions => 'Custom instructions';
+
+  @override
+  String get harnessAdvanced => 'Advanced · variables and message templates';
+
+  @override
+  String get harnessCurrentConfiguration => 'Current configuration';
+
+  @override
+  String get harnessLatestRequest => 'Latest prepared request';
+
+  @override
+  String get harnessPreparedOnly =>
+      'App-assembled context, not the final provider wire payload. Counts are estimates, not billed usage. Later tool rounds are not included.';
+
+  @override
+  String get harnessNoSnapshot =>
+      'No request snapshot in this session. Sending a message creates one; opening this panel sends nothing.';
+
+  @override
+  String get harnessDetails => 'Context details';
+
+  @override
+  String get harnessToolsEstimate => 'Tool schema tokens (estimated)';
+
+  @override
+  String get harnessClientTools => 'Client tools';
+
+  @override
+  String get harnessNativeTools => 'Provider-native tools';
+
+  @override
+  String get harnessOff => 'Off';
+
+  @override
+  String get harnessAvailable => 'Available';
+
+  @override
+  String get harnessUnavailable => 'Configured but unavailable';
+
+  @override
+  String get harnessNotConfigured => 'Not configured';
+
+  @override
+  String get harnessToolsUnsupported =>
+      'The selected model does not support client tools';
+
+  @override
+  String get harnessNativeExclusive =>
+      'The selected native tools exclude client tools on this model';
+
+  @override
+  String get harnessPlatformUnavailable => 'Not available on this platform';
+
+  @override
+  String get harnessMcpDisconnected =>
+      'Selected servers are disconnected or have no enabled tools';
+
+  @override
+  String get harnessSkillReadUnavailable => 'The read_file tool is disabled';
+
+  @override
+  String get harnessWorkspaceUnready =>
+      'Shell environment is not ready; file tools are checked separately';
+
+  @override
+  String get harnessReadinessPending =>
+      'Readiness will be checked when preparing a request';
+
+  @override
+  String get harnessMemory => 'Memory and past chats';
+
+  @override
+  String get harnessMemoryReadOnly =>
+      'Memory context enabled; memory tools unavailable this round';
+
+  @override
+  String get harnessSearch => 'Search';
+
+  @override
+  String get harnessLocalTools => 'Local tools';
+
+  @override
+  String get harnessSkills => 'Skills';
+
+  @override
+  String get harnessWorkspace => 'Workspace';
+
+  @override
+  String get harnessClose => 'Close context';
+
+  @override
+  String get harnessNotInjected => 'Not injected';
+
+  @override
+  String get harnessFullRequest => 'View full request context';
+
+  @override
+  String get harnessPreviewHint =>
+      'Preview of system instructions and current-turn context. Full history is loaded on demand.';
+
+  @override
+  String get harnessPartial => 'Partly available';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1255,39 +1255,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get assistantEditPromptTimeVarWarning =>
-      '在系统提示词中使用时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中，费用和首字延迟都会上升。需要让模型知道当前时间时，请改用下方的「追加当前时间」开关。';
-
-  @override
-  String get assistantEditPromptAppendTimeTitle => '追加当前时间';
-
-  @override
-  String get assistantEditPromptAppendTimeSubtitle =>
-      '在每条用户消息末尾追加发送时刻。时间在请求末尾，不影响 Prompt 缓存。';
-
-  @override
-  String get assistantEditPromptAppendTimeInfoTitle => '追加时间格式';
-
-  @override
-  String assistantEditPromptAppendTimeInfoBody(String example) {
-    return '开启后，会在每条用户消息末尾先空一行，再追加如下标签：\n\n$example\n\n时间取该消息自己的发送时刻，重试时保持不变。';
-  }
-
-  @override
-  String get assistantEditPromptAppendTimeInfoClose => '知道了';
-
-  @override
-  String get assistantEditPromptTimeVarDialogTitle => '系统提示词中含时间变量';
-
-  @override
-  String assistantEditPromptTimeVarDialogBody(String variables) {
-    return '你的系统提示词里用了 $variables。系统提示词每次请求都会重新渲染，含时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中。建议移除这些变量，改用「追加当前时间」——它把时间放在请求末尾，不影响前缀。';
-  }
-
-  @override
-  String get assistantEditPromptTimeVarDialogRemove => '去移除';
-
-  @override
-  String get assistantEditPromptTimeVarDialogKeep => '仍然开启';
+      '时间变量会让每次请求的系统提示词改变。可在上方开启内置当前时间，无需修改自定义指令。';
 
   @override
   String get codeBlockPreviewButton => '预览';
@@ -10748,6 +10716,136 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get mcpImportConfirm => '导入';
+
+  @override
+  String get harnessTitle => '上下文';
+
+  @override
+  String get harnessBuiltInContext => '内置上下文';
+
+  @override
+  String get harnessAssistantScope => '作用于当前助手，下次生成生效。';
+
+  @override
+  String get harnessTime => '当前时间与时区';
+
+  @override
+  String get harnessTimeDescription => '仅供预览，实际发送时刷新。get_time_info 工具单独配置。';
+
+  @override
+  String get harnessLocale => '应用语言';
+
+  @override
+  String get harnessLocaleDescription => '提供应用界面语言，不强制回复语言。';
+
+  @override
+  String get harnessModel => '模型信息';
+
+  @override
+  String get harnessModelDescription => '当前配置的模型名称与请求 ID，不代表已验证的服务端模型身份。';
+
+  @override
+  String get harnessRequestOnly => '仅附加到当前请求，不修改自定义系统提示词，不保存到聊天消息或导出内容。';
+
+  @override
+  String get harnessTimeConflict => '自定义提示词中也包含时间变量，两者都会发送；保留你的原文，不自动删除。';
+
+  @override
+  String get harnessCustomInstructions => '自定义指令';
+
+  @override
+  String get harnessAdvanced => '高级设置 · 变量与消息模板';
+
+  @override
+  String get harnessCurrentConfiguration => '当前配置';
+
+  @override
+  String get harnessLatestRequest => '最近请求准备快照';
+
+  @override
+  String get harnessPreparedOnly =>
+      '应用组装的上下文，不等于 provider 最终请求体。用量为估算，不是计费用量；不包含后续工具轮次。';
+
+  @override
+  String get harnessNoSnapshot => '本次运行中暂无请求快照。发送消息后生成；打开此面板不会发送请求。';
+
+  @override
+  String get harnessDetails => '展开上下文详情';
+
+  @override
+  String get harnessToolsEstimate => '工具定义 token（估算）';
+
+  @override
+  String get harnessClientTools => '客户端工具';
+
+  @override
+  String get harnessNativeTools => '模型服务原生工具';
+
+  @override
+  String get harnessOff => '已关闭';
+
+  @override
+  String get harnessAvailable => '可用';
+
+  @override
+  String get harnessUnavailable => '已配置但本轮不可用';
+
+  @override
+  String get harnessNotConfigured => '尚未配置';
+
+  @override
+  String get harnessToolsUnsupported => '当前模型不支持客户端工具';
+
+  @override
+  String get harnessNativeExclusive => '此模型启用的原生工具与客户端工具互斥';
+
+  @override
+  String get harnessPlatformUnavailable => '当前平台暂不可用';
+
+  @override
+  String get harnessMcpDisconnected => '所选服务尚未连接或没有已启用的工具';
+
+  @override
+  String get harnessSkillReadUnavailable => 'read_file 工具已关闭';
+
+  @override
+  String get harnessWorkspaceUnready => 'Shell 环境未就绪；文件工具单独检查';
+
+  @override
+  String get harnessReadinessPending => '准备请求时检查运行状态';
+
+  @override
+  String get harnessMemory => '记忆与历史对话';
+
+  @override
+  String get harnessMemoryReadOnly => '记忆上下文已开启；本轮记忆工具不可用';
+
+  @override
+  String get harnessSearch => '搜索';
+
+  @override
+  String get harnessLocalTools => '本地工具';
+
+  @override
+  String get harnessSkills => 'Skills';
+
+  @override
+  String get harnessWorkspace => '工作区';
+
+  @override
+  String get harnessClose => '关闭上下文面板';
+
+  @override
+  String get harnessNotInjected => '未注入';
+
+  @override
+  String get harnessFullRequest => '查看完整请求上下文';
+
+  @override
+  String get harnessPreviewHint => '预览系统指令与本轮上下文；完整历史按需查看。';
+
+  @override
+  String get harnessPartial => '部分可用';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -12001,39 +12099,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get assistantEditPromptTimeVarWarning =>
-      '在系统提示词中使用时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中，费用和首字延迟都会上升。需要让模型知道当前时间时，请改用下方的「追加当前时间」开关。';
-
-  @override
-  String get assistantEditPromptAppendTimeTitle => '追加当前时间';
-
-  @override
-  String get assistantEditPromptAppendTimeSubtitle =>
-      '在每条用户消息末尾追加发送时刻。时间在请求末尾，不影响 Prompt 缓存。';
-
-  @override
-  String get assistantEditPromptAppendTimeInfoTitle => '追加时间格式';
-
-  @override
-  String assistantEditPromptAppendTimeInfoBody(String example) {
-    return '开启后，会在每条用户消息末尾先空一行，再追加如下标签：\n\n$example\n\n时间取该消息自己的发送时刻，重试时保持不变。';
-  }
-
-  @override
-  String get assistantEditPromptAppendTimeInfoClose => '知道了';
-
-  @override
-  String get assistantEditPromptTimeVarDialogTitle => '系统提示词中含时间变量';
-
-  @override
-  String assistantEditPromptTimeVarDialogBody(String variables) {
-    return '你的系统提示词里用了 $variables。系统提示词每次请求都会重新渲染，含时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中。建议移除这些变量，改用「追加当前时间」——它把时间放在请求末尾，不影响前缀。';
-  }
-
-  @override
-  String get assistantEditPromptTimeVarDialogRemove => '去移除';
-
-  @override
-  String get assistantEditPromptTimeVarDialogKeep => '仍然开启';
+      '时间变量会让每次请求的系统提示词改变。可在上方开启内置当前时间，无需修改自定义指令。';
 
   @override
   String get codeBlockPreviewButton => '预览';
@@ -21420,6 +21486,136 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get mcpImportConfirm => '导入';
+
+  @override
+  String get harnessTitle => '上下文';
+
+  @override
+  String get harnessBuiltInContext => '内置上下文';
+
+  @override
+  String get harnessAssistantScope => '作用于当前助手，下次生成生效。';
+
+  @override
+  String get harnessTime => '当前时间与时区';
+
+  @override
+  String get harnessTimeDescription => '仅供预览，实际发送时刷新。get_time_info 工具单独配置。';
+
+  @override
+  String get harnessLocale => '应用语言';
+
+  @override
+  String get harnessLocaleDescription => '提供应用界面语言，不强制回复语言。';
+
+  @override
+  String get harnessModel => '模型信息';
+
+  @override
+  String get harnessModelDescription => '当前配置的模型名称与请求 ID，不代表已验证的服务端模型身份。';
+
+  @override
+  String get harnessRequestOnly => '仅附加到当前请求，不修改自定义系统提示词，不保存到聊天消息或导出内容。';
+
+  @override
+  String get harnessTimeConflict => '自定义提示词中也包含时间变量，两者都会发送；保留你的原文，不自动删除。';
+
+  @override
+  String get harnessCustomInstructions => '自定义指令';
+
+  @override
+  String get harnessAdvanced => '高级设置 · 变量与消息模板';
+
+  @override
+  String get harnessCurrentConfiguration => '当前配置';
+
+  @override
+  String get harnessLatestRequest => '最近请求准备快照';
+
+  @override
+  String get harnessPreparedOnly =>
+      '应用组装的上下文，不等于 provider 最终请求体。用量为估算，不是计费用量；不包含后续工具轮次。';
+
+  @override
+  String get harnessNoSnapshot => '本次运行中暂无请求快照。发送消息后生成；打开此面板不会发送请求。';
+
+  @override
+  String get harnessDetails => '展开上下文详情';
+
+  @override
+  String get harnessToolsEstimate => '工具定义 token（估算）';
+
+  @override
+  String get harnessClientTools => '客户端工具';
+
+  @override
+  String get harnessNativeTools => '模型服务原生工具';
+
+  @override
+  String get harnessOff => '已关闭';
+
+  @override
+  String get harnessAvailable => '可用';
+
+  @override
+  String get harnessUnavailable => '已配置但本轮不可用';
+
+  @override
+  String get harnessNotConfigured => '尚未配置';
+
+  @override
+  String get harnessToolsUnsupported => '当前模型不支持客户端工具';
+
+  @override
+  String get harnessNativeExclusive => '此模型启用的原生工具与客户端工具互斥';
+
+  @override
+  String get harnessPlatformUnavailable => '当前平台暂不可用';
+
+  @override
+  String get harnessMcpDisconnected => '所选服务尚未连接或没有已启用的工具';
+
+  @override
+  String get harnessSkillReadUnavailable => 'read_file 工具已关闭';
+
+  @override
+  String get harnessWorkspaceUnready => 'Shell 环境未就绪；文件工具单独检查';
+
+  @override
+  String get harnessReadinessPending => '准备请求时检查运行状态';
+
+  @override
+  String get harnessMemory => '记忆与历史对话';
+
+  @override
+  String get harnessMemoryReadOnly => '记忆上下文已开启；本轮记忆工具不可用';
+
+  @override
+  String get harnessSearch => '搜索';
+
+  @override
+  String get harnessLocalTools => '本地工具';
+
+  @override
+  String get harnessSkills => 'Skills';
+
+  @override
+  String get harnessWorkspace => '工作区';
+
+  @override
+  String get harnessClose => '关闭上下文面板';
+
+  @override
+  String get harnessNotInjected => '未注入';
+
+  @override
+  String get harnessFullRequest => '查看完整请求上下文';
+
+  @override
+  String get harnessPreviewHint => '预览系统指令与本轮上下文；完整历史按需查看。';
+
+  @override
+  String get harnessPartial => '部分可用';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -22673,39 +22869,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get assistantEditPromptTimeVarWarning =>
-      '在系統提示詞中使用時間變數會讓每一輪請求的開頭都不同，Prompt 快取無法命中，費用和首字延遲都會上升。需要讓模型知道當前時間時，請改用下方的「追加當前時間」開關。';
-
-  @override
-  String get assistantEditPromptAppendTimeTitle => '追加當前時間';
-
-  @override
-  String get assistantEditPromptAppendTimeSubtitle =>
-      '在每條使用者訊息末尾追加傳送時刻。時間在請求末尾，不影響 Prompt 快取。';
-
-  @override
-  String get assistantEditPromptAppendTimeInfoTitle => '追加時間格式';
-
-  @override
-  String assistantEditPromptAppendTimeInfoBody(String example) {
-    return '開啟後，會在每條使用者訊息末尾先空一行，再追加如下標籤：\n\n$example\n\n時間取該訊息自己的傳送時刻，重試時保持不變。';
-  }
-
-  @override
-  String get assistantEditPromptAppendTimeInfoClose => '知道了';
-
-  @override
-  String get assistantEditPromptTimeVarDialogTitle => '系統提示詞中含時間變數';
-
-  @override
-  String assistantEditPromptTimeVarDialogBody(String variables) {
-    return '你的系統提示詞裡用了 $variables。系統提示詞每次請求都會重新渲染，含時間變數會讓每一輪請求的開頭都不同，Prompt 快取無法命中。建議移除這些變數，改用「追加當前時間」——它把時間放在請求末尾，不影響前綴。';
-  }
-
-  @override
-  String get assistantEditPromptTimeVarDialogRemove => '去移除';
-
-  @override
-  String get assistantEditPromptTimeVarDialogKeep => '仍然開啟';
+      '時間變數會讓每次請求的系統提示詞改變。可在上方啟用內建目前時間，無需修改自訂指令。';
 
   @override
   String get codeBlockPreviewButton => '預覽';
@@ -32171,4 +32335,134 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get mcpImportConfirm => '匯入';
+
+  @override
+  String get harnessTitle => '上下文';
+
+  @override
+  String get harnessBuiltInContext => '內建上下文';
+
+  @override
+  String get harnessAssistantScope => '套用至目前助手，下次生成生效。';
+
+  @override
+  String get harnessTime => '目前時間與時區';
+
+  @override
+  String get harnessTimeDescription => '僅供預覽，實際傳送時更新。get_time_info 工具另行設定。';
+
+  @override
+  String get harnessLocale => '應用程式語言';
+
+  @override
+  String get harnessLocaleDescription => '提供介面語言，不強制回覆語言。';
+
+  @override
+  String get harnessModel => '模型資訊';
+
+  @override
+  String get harnessModelDescription => '目前設定的模型名稱與請求 ID，不代表已驗證的伺服器模型身分。';
+
+  @override
+  String get harnessRequestOnly => '僅附加到目前請求，不修改自訂系統提示詞，不儲存至聊天訊息或匯出內容。';
+
+  @override
+  String get harnessTimeConflict => '自訂提示詞也包含時間變數，兩者都會傳送；保留你的原文，不會自動刪除。';
+
+  @override
+  String get harnessCustomInstructions => '自訂指令';
+
+  @override
+  String get harnessAdvanced => '進階設定 · 變數與訊息範本';
+
+  @override
+  String get harnessCurrentConfiguration => '目前設定';
+
+  @override
+  String get harnessLatestRequest => '最近請求準備快照';
+
+  @override
+  String get harnessPreparedOnly =>
+      '應用程式組裝的上下文，不等於 provider 最終請求內容。用量為估算而非計費用量；不包含後續工具輪次。';
+
+  @override
+  String get harnessNoSnapshot => '本次執行中尚無請求快照。傳送訊息後產生；開啟此面板不會傳送請求。';
+
+  @override
+  String get harnessDetails => '展開上下文詳情';
+
+  @override
+  String get harnessToolsEstimate => '工具定義 token（估算）';
+
+  @override
+  String get harnessClientTools => '用戶端工具';
+
+  @override
+  String get harnessNativeTools => '模型服務原生工具';
+
+  @override
+  String get harnessOff => '已關閉';
+
+  @override
+  String get harnessAvailable => '可用';
+
+  @override
+  String get harnessUnavailable => '已設定但本輪不可用';
+
+  @override
+  String get harnessNotConfigured => '尚未設定';
+
+  @override
+  String get harnessToolsUnsupported => '目前模型不支援用戶端工具';
+
+  @override
+  String get harnessNativeExclusive => '此模型啟用的原生工具與用戶端工具互斥';
+
+  @override
+  String get harnessPlatformUnavailable => '目前平台暫不可用';
+
+  @override
+  String get harnessMcpDisconnected => '所選服務尚未連線或沒有已啟用的工具';
+
+  @override
+  String get harnessSkillReadUnavailable => 'read_file 工具已關閉';
+
+  @override
+  String get harnessWorkspaceUnready => 'Shell 環境尚未就緒；檔案工具另行檢查';
+
+  @override
+  String get harnessReadinessPending => '準備請求時檢查執行狀態';
+
+  @override
+  String get harnessMemory => '記憶與歷史對話';
+
+  @override
+  String get harnessMemoryReadOnly => '記憶上下文已啟用；本輪記憶工具不可用';
+
+  @override
+  String get harnessSearch => '搜尋';
+
+  @override
+  String get harnessLocalTools => '本機工具';
+
+  @override
+  String get harnessSkills => 'Skills';
+
+  @override
+  String get harnessWorkspace => '工作區';
+
+  @override
+  String get harnessClose => '關閉上下文面板';
+
+  @override
+  String get harnessNotInjected => '未注入';
+
+  @override
+  String get harnessFullRequest => '檢視完整請求上下文';
+
+  @override
+  String get harnessPreviewHint => '預覽系統指令與本輪上下文；完整歷史按需檢視。';
+
+  @override
+  String get harnessPartial => '部分可用';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -362,30 +362,7 @@
   "assistantEditVariableRole": "助手",
   "assistantEditVariableMessage": "内容",
   "assistantEditPreviewTitle": "预览",
-  "assistantEditPromptTimeVarWarning": "在系统提示词中使用时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中，费用和首字延迟都会上升。需要让模型知道当前时间时，请改用下方的「追加当前时间」开关。",
-  "assistantEditPromptAppendTimeTitle": "追加当前时间",
-  "assistantEditPromptAppendTimeSubtitle": "在每条用户消息末尾追加发送时刻。时间在请求末尾，不影响 Prompt 缓存。",
-  "assistantEditPromptAppendTimeInfoTitle": "追加时间格式",
-  "assistantEditPromptAppendTimeInfoBody": "开启后，会在每条用户消息末尾先空一行，再追加如下标签：\n\n{example}\n\n时间取该消息自己的发送时刻，重试时保持不变。",
-  "@assistantEditPromptAppendTimeInfoBody": {
-    "placeholders": {
-      "example": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptAppendTimeInfoClose": "知道了",
-  "assistantEditPromptTimeVarDialogTitle": "系统提示词中含时间变量",
-  "assistantEditPromptTimeVarDialogBody": "你的系统提示词里用了 {variables}。系统提示词每次请求都会重新渲染，含时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中。建议移除这些变量，改用「追加当前时间」——它把时间放在请求末尾，不影响前缀。",
-  "@assistantEditPromptTimeVarDialogBody": {
-    "placeholders": {
-      "variables": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptTimeVarDialogRemove": "去移除",
-  "assistantEditPromptTimeVarDialogKeep": "仍然开启",
+  "assistantEditPromptTimeVarWarning": "时间变量会让每次请求的系统提示词改变。可在上方开启内置当前时间，无需修改自定义指令。",
   "codeBlockPreviewButton": "预览",
   "codeBlockSaveAsButton": "另存为文件",
   "codeBlockCollapseButton": "折叠",
@@ -3984,5 +3961,48 @@
   "mcpImportJsonHint": "粘贴 Claude Desktop 或 Cursor 的 MCP 配置，预览后添加服务器，不覆盖现有配置。",
   "mcpImportPaste": "从剪贴板粘贴",
   "mcpImportPreview": "预览",
-  "mcpImportConfirm": "导入"
+  "mcpImportConfirm": "导入",
+  "harnessTitle": "上下文",
+  "harnessBuiltInContext": "内置上下文",
+  "harnessAssistantScope": "作用于当前助手，下次生成生效。",
+  "harnessTime": "当前时间与时区",
+  "harnessTimeDescription": "仅供预览，实际发送时刷新。get_time_info 工具单独配置。",
+  "harnessLocale": "应用语言",
+  "harnessLocaleDescription": "提供应用界面语言，不强制回复语言。",
+  "harnessModel": "模型信息",
+  "harnessModelDescription": "当前配置的模型名称与请求 ID，不代表已验证的服务端模型身份。",
+  "harnessRequestOnly": "仅附加到当前请求，不修改自定义系统提示词，不保存到聊天消息或导出内容。",
+  "harnessTimeConflict": "自定义提示词中也包含时间变量，两者都会发送；保留你的原文，不自动删除。",
+  "harnessCustomInstructions": "自定义指令",
+  "harnessAdvanced": "高级设置 · 变量与消息模板",
+  "harnessCurrentConfiguration": "当前配置",
+  "harnessLatestRequest": "最近请求准备快照",
+  "harnessPreparedOnly": "应用组装的上下文，不等于 provider 最终请求体。用量为估算，不是计费用量；不包含后续工具轮次。",
+  "harnessNoSnapshot": "本次运行中暂无请求快照。发送消息后生成；打开此面板不会发送请求。",
+  "harnessDetails": "展开上下文详情",
+  "harnessToolsEstimate": "工具定义 token（估算）",
+  "harnessClientTools": "客户端工具",
+  "harnessNativeTools": "模型服务原生工具",
+  "harnessOff": "已关闭",
+  "harnessAvailable": "可用",
+  "harnessUnavailable": "已配置但本轮不可用",
+  "harnessNotConfigured": "尚未配置",
+  "harnessToolsUnsupported": "当前模型不支持客户端工具",
+  "harnessNativeExclusive": "此模型启用的原生工具与客户端工具互斥",
+  "harnessPlatformUnavailable": "当前平台暂不可用",
+  "harnessMcpDisconnected": "所选服务尚未连接或没有已启用的工具",
+  "harnessSkillReadUnavailable": "read_file 工具已关闭",
+  "harnessWorkspaceUnready": "Shell 环境未就绪；文件工具单独检查",
+  "harnessReadinessPending": "准备请求时检查运行状态",
+  "harnessMemory": "记忆与历史对话",
+  "harnessMemoryReadOnly": "记忆上下文已开启；本轮记忆工具不可用",
+  "harnessSearch": "搜索",
+  "harnessLocalTools": "本地工具",
+  "harnessSkills": "Skills",
+  "harnessWorkspace": "工作区",
+  "harnessClose": "关闭上下文面板",
+  "harnessNotInjected": "未注入",
+  "harnessFullRequest": "查看完整请求上下文",
+  "harnessPreviewHint": "预览系统指令与本轮上下文；完整历史按需查看。",
+  "harnessPartial": "部分可用"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -362,30 +362,7 @@
   "assistantEditVariableRole": "角色",
   "assistantEditVariableMessage": "内容",
   "assistantEditPreviewTitle": "预览",
-  "assistantEditPromptTimeVarWarning": "在系统提示词中使用时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中，费用和首字延迟都会上升。需要让模型知道当前时间时，请改用下方的「追加当前时间」开关。",
-  "assistantEditPromptAppendTimeTitle": "追加当前时间",
-  "assistantEditPromptAppendTimeSubtitle": "在每条用户消息末尾追加发送时刻。时间在请求末尾，不影响 Prompt 缓存。",
-  "assistantEditPromptAppendTimeInfoTitle": "追加时间格式",
-  "assistantEditPromptAppendTimeInfoBody": "开启后，会在每条用户消息末尾先空一行，再追加如下标签：\n\n{example}\n\n时间取该消息自己的发送时刻，重试时保持不变。",
-  "@assistantEditPromptAppendTimeInfoBody": {
-    "placeholders": {
-      "example": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptAppendTimeInfoClose": "知道了",
-  "assistantEditPromptTimeVarDialogTitle": "系统提示词中含时间变量",
-  "assistantEditPromptTimeVarDialogBody": "你的系统提示词里用了 {variables}。系统提示词每次请求都会重新渲染，含时间变量会让每一轮请求的开头都不同，Prompt 缓存无法命中。建议移除这些变量，改用「追加当前时间」——它把时间放在请求末尾，不影响前缀。",
-  "@assistantEditPromptTimeVarDialogBody": {
-    "placeholders": {
-      "variables": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptTimeVarDialogRemove": "去移除",
-  "assistantEditPromptTimeVarDialogKeep": "仍然开启",
+  "assistantEditPromptTimeVarWarning": "时间变量会让每次请求的系统提示词改变。可在上方开启内置当前时间，无需修改自定义指令。",
   "codeBlockPreviewButton": "预览",
   "codeBlockSaveAsButton": "另存为文件",
   "codeBlockCollapseButton": "折叠",
@@ -3960,5 +3937,48 @@
   "mcpImportJsonHint": "粘贴 Claude Desktop 或 Cursor 的 MCP 配置，预览后添加服务器，不覆盖现有配置。",
   "mcpImportPaste": "从剪贴板粘贴",
   "mcpImportPreview": "预览",
-  "mcpImportConfirm": "导入"
+  "mcpImportConfirm": "导入",
+  "harnessTitle": "上下文",
+  "harnessBuiltInContext": "内置上下文",
+  "harnessAssistantScope": "作用于当前助手，下次生成生效。",
+  "harnessTime": "当前时间与时区",
+  "harnessTimeDescription": "仅供预览，实际发送时刷新。get_time_info 工具单独配置。",
+  "harnessLocale": "应用语言",
+  "harnessLocaleDescription": "提供应用界面语言，不强制回复语言。",
+  "harnessModel": "模型信息",
+  "harnessModelDescription": "当前配置的模型名称与请求 ID，不代表已验证的服务端模型身份。",
+  "harnessRequestOnly": "仅附加到当前请求，不修改自定义系统提示词，不保存到聊天消息或导出内容。",
+  "harnessTimeConflict": "自定义提示词中也包含时间变量，两者都会发送；保留你的原文，不自动删除。",
+  "harnessCustomInstructions": "自定义指令",
+  "harnessAdvanced": "高级设置 · 变量与消息模板",
+  "harnessCurrentConfiguration": "当前配置",
+  "harnessLatestRequest": "最近请求准备快照",
+  "harnessPreparedOnly": "应用组装的上下文，不等于 provider 最终请求体。用量为估算，不是计费用量；不包含后续工具轮次。",
+  "harnessNoSnapshot": "本次运行中暂无请求快照。发送消息后生成；打开此面板不会发送请求。",
+  "harnessDetails": "展开上下文详情",
+  "harnessToolsEstimate": "工具定义 token（估算）",
+  "harnessClientTools": "客户端工具",
+  "harnessNativeTools": "模型服务原生工具",
+  "harnessOff": "已关闭",
+  "harnessAvailable": "可用",
+  "harnessUnavailable": "已配置但本轮不可用",
+  "harnessNotConfigured": "尚未配置",
+  "harnessToolsUnsupported": "当前模型不支持客户端工具",
+  "harnessNativeExclusive": "此模型启用的原生工具与客户端工具互斥",
+  "harnessPlatformUnavailable": "当前平台暂不可用",
+  "harnessMcpDisconnected": "所选服务尚未连接或没有已启用的工具",
+  "harnessSkillReadUnavailable": "read_file 工具已关闭",
+  "harnessWorkspaceUnready": "Shell 环境未就绪；文件工具单独检查",
+  "harnessReadinessPending": "准备请求时检查运行状态",
+  "harnessMemory": "记忆与历史对话",
+  "harnessMemoryReadOnly": "记忆上下文已开启；本轮记忆工具不可用",
+  "harnessSearch": "搜索",
+  "harnessLocalTools": "本地工具",
+  "harnessSkills": "Skills",
+  "harnessWorkspace": "工作区",
+  "harnessClose": "关闭上下文面板",
+  "harnessNotInjected": "未注入",
+  "harnessFullRequest": "查看完整请求上下文",
+  "harnessPreviewHint": "预览系统指令与本轮上下文；完整历史按需查看。",
+  "harnessPartial": "部分可用"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -354,30 +354,7 @@
   "assistantEditVariableRole": "角色",
   "assistantEditVariableMessage": "內容",
   "assistantEditPreviewTitle": "預覽",
-  "assistantEditPromptTimeVarWarning": "在系統提示詞中使用時間變數會讓每一輪請求的開頭都不同，Prompt 快取無法命中，費用和首字延遲都會上升。需要讓模型知道當前時間時，請改用下方的「追加當前時間」開關。",
-  "assistantEditPromptAppendTimeTitle": "追加當前時間",
-  "assistantEditPromptAppendTimeSubtitle": "在每條使用者訊息末尾追加傳送時刻。時間在請求末尾，不影響 Prompt 快取。",
-  "assistantEditPromptAppendTimeInfoTitle": "追加時間格式",
-  "assistantEditPromptAppendTimeInfoBody": "開啟後，會在每條使用者訊息末尾先空一行，再追加如下標籤：\n\n{example}\n\n時間取該訊息自己的傳送時刻，重試時保持不變。",
-  "@assistantEditPromptAppendTimeInfoBody": {
-    "placeholders": {
-      "example": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptAppendTimeInfoClose": "知道了",
-  "assistantEditPromptTimeVarDialogTitle": "系統提示詞中含時間變數",
-  "assistantEditPromptTimeVarDialogBody": "你的系統提示詞裡用了 {variables}。系統提示詞每次請求都會重新渲染，含時間變數會讓每一輪請求的開頭都不同，Prompt 快取無法命中。建議移除這些變數，改用「追加當前時間」——它把時間放在請求末尾，不影響前綴。",
-  "@assistantEditPromptTimeVarDialogBody": {
-    "placeholders": {
-      "variables": {
-        "type": "String"
-      }
-    }
-  },
-  "assistantEditPromptTimeVarDialogRemove": "去移除",
-  "assistantEditPromptTimeVarDialogKeep": "仍然開啟",
+  "assistantEditPromptTimeVarWarning": "時間變數會讓每次請求的系統提示詞改變。可在上方啟用內建目前時間，無需修改自訂指令。",
   "codeBlockPreviewButton": "預覽",
   "codeBlockSaveAsButton": "另存為檔案",
   "codeBlockCollapseButton": "摺疊",
@@ -3984,5 +3961,48 @@
   "mcpImportJsonHint": "貼上 Claude Desktop 或 Cursor 的 MCP 設定，預覽後新增伺服器，不覆蓋現有設定。",
   "mcpImportPaste": "從剪貼簿貼上",
   "mcpImportPreview": "預覽",
-  "mcpImportConfirm": "匯入"
+  "mcpImportConfirm": "匯入",
+  "harnessTitle": "上下文",
+  "harnessBuiltInContext": "內建上下文",
+  "harnessAssistantScope": "套用至目前助手，下次生成生效。",
+  "harnessTime": "目前時間與時區",
+  "harnessTimeDescription": "僅供預覽，實際傳送時更新。get_time_info 工具另行設定。",
+  "harnessLocale": "應用程式語言",
+  "harnessLocaleDescription": "提供介面語言，不強制回覆語言。",
+  "harnessModel": "模型資訊",
+  "harnessModelDescription": "目前設定的模型名稱與請求 ID，不代表已驗證的伺服器模型身分。",
+  "harnessRequestOnly": "僅附加到目前請求，不修改自訂系統提示詞，不儲存至聊天訊息或匯出內容。",
+  "harnessTimeConflict": "自訂提示詞也包含時間變數，兩者都會傳送；保留你的原文，不會自動刪除。",
+  "harnessCustomInstructions": "自訂指令",
+  "harnessAdvanced": "進階設定 · 變數與訊息範本",
+  "harnessCurrentConfiguration": "目前設定",
+  "harnessLatestRequest": "最近請求準備快照",
+  "harnessPreparedOnly": "應用程式組裝的上下文，不等於 provider 最終請求內容。用量為估算而非計費用量；不包含後續工具輪次。",
+  "harnessNoSnapshot": "本次執行中尚無請求快照。傳送訊息後產生；開啟此面板不會傳送請求。",
+  "harnessDetails": "展開上下文詳情",
+  "harnessToolsEstimate": "工具定義 token（估算）",
+  "harnessClientTools": "用戶端工具",
+  "harnessNativeTools": "模型服務原生工具",
+  "harnessOff": "已關閉",
+  "harnessAvailable": "可用",
+  "harnessUnavailable": "已設定但本輪不可用",
+  "harnessNotConfigured": "尚未設定",
+  "harnessToolsUnsupported": "目前模型不支援用戶端工具",
+  "harnessNativeExclusive": "此模型啟用的原生工具與用戶端工具互斥",
+  "harnessPlatformUnavailable": "目前平台暫不可用",
+  "harnessMcpDisconnected": "所選服務尚未連線或沒有已啟用的工具",
+  "harnessSkillReadUnavailable": "read_file 工具已關閉",
+  "harnessWorkspaceUnready": "Shell 環境尚未就緒；檔案工具另行檢查",
+  "harnessReadinessPending": "準備請求時檢查執行狀態",
+  "harnessMemory": "記憶與歷史對話",
+  "harnessMemoryReadOnly": "記憶上下文已啟用；本輪記憶工具不可用",
+  "harnessSearch": "搜尋",
+  "harnessLocalTools": "本機工具",
+  "harnessSkills": "Skills",
+  "harnessWorkspace": "工作區",
+  "harnessClose": "關閉上下文面板",
+  "harnessNotInjected": "未注入",
+  "harnessFullRequest": "檢視完整請求上下文",
+  "harnessPreviewHint": "預覽系統指令與本輪上下文；完整歷史按需檢視。",
+  "harnessPartial": "部分可用"
 }

--- a/test/chat_api_runtime_context_test.dart
+++ b/test/chat_api_runtime_context_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/models/assistant.dart';
+import 'package:Kelivo/core/models/auto_retry_options.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/chat_api_service.dart';
+import 'package:Kelivo/core/services/chat/runtime_context.dart';
+import 'package:Kelivo/core/services/logging/context_log_models.dart';
+import 'package:Kelivo/core/utils/multimodal_input_utils.dart';
+
+List<Map<String, dynamic>> preparedMessages() {
+  final messages = <Map<String, dynamic>>[
+    {'role': 'system', 'content': 'Stable system instructions'},
+    {'role': 'user', 'content': 'hello', multimodalInternalRevisionIdKey: 'u'},
+  ];
+  injectRuntimeContext(
+    messages,
+    RuntimeContextSnapshot.capture(
+      assistant: const Assistant(
+        id: 'a',
+        name: 'A',
+        appendCurrentTimeToUserMessage: true,
+      ),
+      now: DateTime.utc(2026, 9, 10, 12),
+      appLocale: '',
+      modelName: '',
+      modelId: '',
+    ),
+  );
+  for (final message in messages) {
+    message.remove(multimodalInternalRevisionIdKey);
+    message.remove(kelivoContextSegmentsKey);
+  }
+  return messages;
+}
+
+void main() {
+  for (final protocol in ['chat', 'responses', 'claude', 'gemini']) {
+    test(
+      '$protocol serializes runtime metadata once without changing system instructions',
+      () async {
+        final requests = <Map<String, dynamic>>[];
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          requests.add(
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>,
+          );
+          final response = switch (protocol) {
+            'responses' => {
+              'id': 'resp_1',
+              'object': 'response',
+              'status': 'completed',
+              'output_text': 'ok',
+              'output': [],
+            },
+            'claude' => {
+              'id': 'msg_1',
+              'type': 'message',
+              'role': 'assistant',
+              'content': [
+                {'type': 'text', 'text': 'ok'},
+              ],
+              'stop_reason': 'end_turn',
+              'usage': {'input_tokens': 5, 'output_tokens': 1},
+            },
+            'gemini' => {
+              'candidates': [
+                {
+                  'content': {
+                    'role': 'model',
+                    'parts': [
+                      {'text': 'ok'},
+                    ],
+                  },
+                  'finishReason': 'STOP',
+                },
+              ],
+            },
+            _ => {
+              'choices': [
+                {
+                  'message': {'role': 'assistant', 'content': 'ok'},
+                  'finish_reason': 'stop',
+                },
+              ],
+            },
+          };
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(jsonEncode(response));
+          await request.response.close();
+        });
+        final kind = switch (protocol) {
+          'claude' => ProviderKind.claude,
+          'gemini' => ProviderKind.google,
+          _ => ProviderKind.openai,
+        };
+        await ChatApiService.sendMessageStream(
+          config: ProviderConfig(
+            id: 'fixture',
+            name: 'Fixture',
+            enabled: true,
+            baseUrl: 'http://${server.address.address}:${server.port}/v1',
+            apiKey: 'fixture-key',
+            providerType: kind,
+            useResponseApi: protocol == 'responses',
+          ),
+          modelId: switch (protocol) {
+            'claude' => 'claude-sonnet-4-6',
+            'gemini' => 'gemini-3.1-flash',
+            _ => 'gpt-4.1',
+          },
+          messages: preparedMessages(),
+          stream: false,
+          thinkingBudget: 0,
+          retryOverride: const AutoRetryOptions.defaults(),
+        ).toList();
+        expect(requests, hasLength(1));
+        final encoded = jsonEncode(requests.single);
+        expect('<runtime_context>'.allMatches(encoded), hasLength(1));
+        expect(encoded, contains('2026-09-10T12:00:00+00:00'));
+        expect(encoded, contains('Stable system instructions'));
+        expect(encoded, isNot(contains('_kelivo_')));
+        if (protocol == 'claude') {
+          expect(
+            jsonEncode(requests.single['system']),
+            isNot(contains('runtime_context')),
+          );
+        } else if (protocol == 'gemini') {
+          expect(
+            jsonEncode(requests.single['systemInstruction']),
+            isNot(contains('runtime_context')),
+          );
+        } else if (protocol == 'responses') {
+          expect(
+            jsonEncode(requests.single['instructions']),
+            isNot(contains('runtime_context')),
+          );
+          expect(
+            jsonEncode(requests.single['instructions']),
+            contains('Stable system instructions'),
+          );
+        } else {
+          final items =
+              (requests.single[protocol == 'chat' ? 'messages' : 'input']
+                  as List);
+          expect(jsonEncode(items.first), isNot(contains('runtime_context')));
+        }
+      },
+    );
+  }
+
+  test(
+    'HTTP retry and client-tool continuation retain the same time block',
+    () async {
+      final bodies = <Map<String, dynamic>>[];
+      var executed = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        bodies.add(
+          jsonDecode(await utf8.decoder.bind(request).join())
+              as Map<String, dynamic>,
+        );
+        request.response.headers.contentType = ContentType.json;
+        if (bodies.length == 1) {
+          request.response.statusCode = 503;
+          request.response.write('{"error":{"message":"retry"}}');
+        } else {
+          request.response.write(
+            jsonEncode({
+              'choices': [
+                {
+                  'finish_reason': bodies.length == 2 ? 'tool_calls' : 'stop',
+                  'message': bodies.length == 2
+                      ? {
+                          'role': 'assistant',
+                          'content': '',
+                          'tool_calls': [
+                            {
+                              'id': 'call_1',
+                              'type': 'function',
+                              'function': {'name': 'probe', 'arguments': '{}'},
+                            },
+                          ],
+                        }
+                      : {'role': 'assistant', 'content': 'done'},
+                },
+              ],
+            }),
+          );
+        }
+        await request.response.close();
+      });
+      await ChatApiService.sendMessageStream(
+        config: ProviderConfig(
+          id: 'fixture',
+          name: 'Fixture',
+          enabled: true,
+          apiKey: 'fixture-key',
+          baseUrl: 'http://${server.address.address}:${server.port}/v1',
+          providerType: ProviderKind.openai,
+        ),
+        modelId: 'gpt-4.1',
+        messages: preparedMessages(),
+        stream: false,
+        tools: [
+          {
+            'type': 'function',
+            'function': {
+              'name': 'probe',
+              'parameters': {'type': 'object', 'properties': {}},
+            },
+          },
+        ],
+        onToolCall: (name, args, {toolCallId}) async {
+          executed++;
+          return 'done';
+        },
+        retryOverride: const AutoRetryOptions.defaults().copyWith(
+          enabled: true,
+          maxRetries: 1,
+          initialDelayMs: 1,
+          maxDelayMs: 1,
+          jitter: false,
+        ),
+      ).toList();
+      expect(bodies, hasLength(3));
+      expect(executed, 1);
+      for (final body in bodies) {
+        final encoded = jsonEncode(body);
+        expect('<runtime_context>'.allMatches(encoded), hasLength(1));
+        expect(encoded, contains('2026-09-10T12:00:00+00:00'));
+      }
+      final messages = bodies.last['messages'] as List;
+      expect(messages.map((message) => message['role']), [
+        'system',
+        'user',
+        'assistant',
+        'tool',
+      ]);
+      expect(messages.last['tool_call_id'], 'call_1');
+    },
+  );
+}

--- a/test/core/services/api/generation/generation_capabilities_test.dart
+++ b/test/core/services/api/generation/generation_capabilities_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/api/generation/generation_capabilities.dart';
+import 'package:Kelivo/core/services/memory/memory_prompts.dart';
+
+void main() {
+  final clients = <Map<String, dynamic>>[
+    {
+      'type': 'function',
+      'function': {'name': 'read_file'},
+    },
+  ];
+  ProviderConfig config(
+    ProviderKind kind, {
+    String upstream = 'gemini-2.5-pro',
+    List<String> native = const [],
+    bool responses = false,
+  }) => ProviderConfig(
+    id: 'fixture',
+    name: 'fixture',
+    enabled: true,
+    apiKey: '',
+    baseUrl: kind == ProviderKind.claude
+        ? 'https://api.anthropic.com/v1'
+        : 'https://example.invalid/v1',
+    providerType: kind,
+    useResponseApi: responses,
+    modelOverrides: {
+      'alias': {'apiModelId': upstream, 'builtInTools': native},
+    },
+  );
+
+  test(
+    'Gemini 2 native tools displace clients, Gemini 3 coexists, aliases are respected',
+    () {
+      for (final upstream in ['gemini-2.5-pro', 'gemini-3.1-pro']) {
+        final result = GenerationCapabilities.resolve(
+          config: config(
+            ProviderKind.google,
+            upstream: upstream,
+            native: ['search'],
+          ),
+          modelId: 'alias',
+          clientTools: clients,
+        );
+        expect(result.nativeTools, ['google_search']);
+        expect(result.allowsClientTools, upstream.contains('gemini-3'));
+        expect(result.clientTools.isNotEmpty, upstream.contains('gemini-3'));
+      }
+      final plain = GenerationCapabilities.resolve(
+        config: config(ProviderKind.google),
+        modelId: 'alias',
+        clientTools: clients,
+      );
+      expect(plain.clientTools, clients);
+      expect(plain.nativeTools, isEmpty);
+    },
+  );
+
+  test('Gemini 2 code execution wins over other native tools', () {
+    final result = GenerationCapabilities.resolve(
+      config: config(
+        ProviderKind.google,
+        native: ['search', 'code_execution', 'url_context'],
+      ),
+      modelId: 'alias',
+      clientTools: clients,
+    );
+    expect(result.nativeTools, ['code_execution']);
+    expect(result.clientTools, isEmpty);
+  });
+
+  test(
+    'OpenAI Responses and Chat Completions share native builders with providers',
+    () {
+      for (final responses in [false, true]) {
+        final result = GenerationCapabilities.resolve(
+          config: config(
+            ProviderKind.openai,
+            upstream: 'gpt-4.1',
+            native: ['code_interpreter'],
+            responses: responses,
+          ),
+          modelId: 'alias',
+          clientTools: clients,
+        );
+        expect(result.clientTools, clients);
+        expect(result.nativeTools.contains('code_interpreter'), responses);
+      }
+    },
+  );
+
+  test('built-in memory rules describe only available operations', () {
+    for (final lang in MemoryPromptLang.values) {
+      final template = lang == MemoryPromptLang.zh
+          ? MemoryPrompts.rulesZh
+          : MemoryPrompts.rulesEn;
+      final readOnly = MemoryPrompts.forAvailableTools(template, lang, {
+        'memory_search_profile',
+      });
+      expect(readOnly, contains('<user_profile>'));
+      expect(readOnly, contains('memory_search_profile'));
+      for (final tool in ['memory_update', 'memory_edit', 'memory_delete']) {
+        expect(RegExp(r'\b' + tool + r'\b').hasMatch(readOnly), isFalse);
+      }
+      expect(
+        MemoryPrompts.forAvailableTools('my own rules', lang, {}),
+        'my own rules',
+      );
+    }
+  });
+}

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -1,3 +1,5 @@
+import 'package:Kelivo/core/services/chat/prepared_context_store.dart';
+import 'package:Kelivo/core/services/logging/context_logger.dart';
 import 'package:Kelivo/core/models/message_part.dart';
 import 'package:Kelivo/core/models/chat_message.dart';
 import 'package:Kelivo/core/models/conversation.dart';
@@ -67,6 +69,48 @@ void main() {
     services.add(service);
     return service;
   }
+
+  test(
+    'context snapshots expire with temporary and deleted conversations',
+    () async {
+      final service = createService();
+      await service.init();
+      PreparedContextSnapshot snapshot(Conversation conversation) =>
+          PreparedContextSnapshot(
+            generationId: 'generation',
+            tools: [],
+            context: ContextLogger.buildSnapshot(
+              apiMessages: [],
+              conversationId: conversation.id,
+              assistantName: 'A',
+              provider: 'P',
+              model: 'M',
+            ),
+          );
+      final temporary = await service.createDraftConversation(
+        title: 'Temporary',
+        temporary: true,
+      );
+      final first = snapshot(temporary);
+      service.recordPreparedContext(first);
+      expect(service.preparedContexts.forConversation(temporary.id), isNotNull);
+      final persisted = await service.createConversation(title: 'Persistent');
+      expect(service.preparedContexts.forConversation(temporary.id), isNull);
+      service.recordPreparedContext(first);
+      expect(service.preparedContexts.forConversation(temporary.id), isNull);
+      await service.addMessage(
+        conversationId: persisted.id,
+        role: 'user',
+        content: 'hello',
+      );
+      final second = snapshot(persisted);
+      service.recordPreparedContext(second);
+      await service.deleteConversation(persisted.id);
+      expect(service.preparedContexts.forConversation(persisted.id), isNull);
+      service.recordPreparedContext(second);
+      expect(service.preparedContexts.forConversation(persisted.id), isNull);
+    },
+  );
 
   test('cold init clears every stale streaming flag', () async {
     final first = createService();

--- a/test/core/services/chat/prepared_context_store_test.dart
+++ b/test/core/services/chat/prepared_context_store_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/services/chat/prepared_context_store.dart';
+import 'package:Kelivo/core/services/logging/context_logger.dart';
+
+void main() {
+  PreparedContextSnapshot snapshot(String id, int revision) =>
+      PreparedContextSnapshot(
+        generationId: '$id-$revision',
+        context: ContextLogger.buildSnapshot(
+          apiMessages: [
+            {
+              'role': 'user',
+              'content': 'hello data:image/png;base64,AQIDBAUGBwgJCgsMDQ4PEA==',
+            },
+          ],
+          conversationId: id,
+          assistantName: 'A',
+          provider: 'P',
+          model: 'M',
+          timestamp: DateTime.utc(2026).add(Duration(seconds: revision)),
+        ),
+        tools: [
+          {
+            'type': 'function',
+            'function': {'name': 'read_file'},
+          },
+        ],
+      );
+
+  test('keeps one snapshot per conversation, evicts the oldest of eight', () {
+    final store = PreparedContextStore();
+    addTearDown(store.dispose);
+    for (var i = 0; i < 8; i++) {
+      store.record(snapshot('$i', i));
+    }
+    store.record(snapshot('0', 10));
+    store.record(snapshot('8', 11));
+    expect(store.forConversation('1'), isNull);
+    expect(store.forConversation('0')?.generationId, '0-10');
+    expect(store.forConversation('8')?.toolNames, ['read_file']);
+    expect(store.forConversation('8')!.toolTokens, greaterThan(0));
+    store.record(snapshot('0', 1));
+    expect(store.forConversation('0')?.generationId, '0-10');
+    store.remove('0');
+    expect(store.forConversation('0'), isNull);
+    expect(store.forConversation('8'), isNotNull);
+    store.clear();
+    expect(store.forConversation('8'), isNull);
+  });
+
+  test(
+    'retains readable text but elides binary data without enabling logs',
+    () {
+      final before = ContextLogger.enabled;
+      final value = snapshot('a', 1);
+      final text = value.context.messages.single.segments.single.text;
+      expect(text, contains('hello'));
+      expect(text, isNot(contains('AQIDBAUGBwgJCgsMDQ4PEA==')));
+      expect(ContextLogger.enabled, before);
+    },
+  );
+  test('large typed binary JSON is elided without changing request data', () {
+    final binary = 'A' * 5000;
+    final content = jsonEncode({'mime_type': 'image/png', 'data': binary});
+    final context = ContextLogger.buildSnapshot(
+      apiMessages: [
+        {'role': 'tool', 'content': content},
+      ],
+      conversationId: 'a',
+      assistantName: 'A',
+      provider: 'P',
+      model: 'M',
+    );
+    expect(
+      context.messages.single.segments.single.text,
+      isNot(contains(binary)),
+    );
+    expect(content, contains(binary));
+  });
+}

--- a/test/core/services/chat/runtime_context_test.dart
+++ b/test/core/services/chat/runtime_context_test.dart
@@ -1,0 +1,210 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/models/assistant.dart';
+import 'package:Kelivo/core/services/chat/runtime_context.dart';
+import 'package:Kelivo/core/services/logging/context_log_models.dart';
+import 'package:Kelivo/core/utils/multimodal_input_utils.dart';
+
+void main() {
+  RuntimeContextSnapshot snapshot(
+    Assistant assistant, {
+    DateTime? now,
+    Duration offset = const Duration(hours: 5, minutes: 45),
+  }) => RuntimeContextSnapshot.capture(
+    assistant: assistant,
+    now: now ?? DateTime.utc(2026, 12, 31, 23, 59, 59),
+    appLocale: 'zh-Hans',
+    modelName: 'My model',
+    modelId: 'upstream-id',
+    timezoneName: 'NPT',
+    utcOffset: offset,
+  );
+
+  test(
+    'time placeholder detection ignores timezone and preserves stable order',
+    () {
+      expect(
+        detectTimeVariablesInSystemPrompt(
+          '{cur_datetime} {timezone} {cur_date} {cur_time}',
+        ),
+        ['{cur_date}', '{cur_time}', '{cur_datetime}'],
+      );
+      expect(detectTimeVariablesInSystemPrompt('{timezone} {locale}'), isEmpty);
+    },
+  );
+
+  test('all eight independent toggle combinations round-trip', () {
+    for (var mask = 0; mask < 8; mask++) {
+      final assistant = const Assistant(id: 'a', name: 'A').copyWith(
+        appendCurrentTimeToUserMessage: mask & 1 != 0,
+        includeAppLocaleInContext: mask & 2 != 0,
+        includeModelInfoInContext: mask & 4 != 0,
+      );
+      final restored = Assistant.fromJson(assistant.toJson());
+      final values = snapshot(restored).values;
+      expect(values.containsKey('generation_time'), mask & 1 != 0);
+      expect(values.containsKey('app_locale'), mask & 2 != 0);
+      expect(values.containsKey('request_model_id'), mask & 4 != 0);
+      expect(snapshot(restored).toPrompt().isEmpty, mask == 0);
+    }
+    final existing = Assistant.fromJson({
+      'id': 'a',
+      'name': 'A',
+      'appendCurrentTimeToUserMessage': true,
+    });
+    expect(existing.appendCurrentTimeToUserMessage, isTrue);
+    expect(existing.includeAppLocaleInContext, isFalse);
+    expect(existing.includeModelInfoInContext, isFalse);
+  });
+
+  test(
+    'time includes seconds, weekday and positive / negative fractional offsets',
+    () {
+      const assistant = Assistant(
+        id: 'a',
+        name: 'A',
+        appendCurrentTimeToUserMessage: true,
+      );
+      final before = snapshot(assistant);
+      expect(before.formattedTime, '2026-12-31T23:59:59+05:45');
+      expect(before.weekday, 'Thursday');
+      final after = snapshot(
+        assistant,
+        now: DateTime.utc(2027),
+        offset: const Duration(minutes: -210),
+      );
+      expect(after.formattedTime, '2027-01-01T00:00:00-03:30');
+      expect(after.weekday, 'Friday');
+      expect(RuntimeContextSnapshot.formatOffset(Duration.zero), '+00:00');
+      expect(
+        RuntimeContextSnapshot.formatOffset(const Duration(hours: 2)),
+        '+02:00',
+      );
+      expect(
+        RuntimeContextSnapshot.formatOffset(const Duration(hours: 1)),
+        '+01:00',
+      );
+    },
+  );
+
+  test(
+    'locale/model-only context reveals no clock and keeps values as data',
+    () {
+      final value = RuntimeContextSnapshot.capture(
+        assistant: const Assistant(
+          id: 'a',
+          name: 'A',
+          includeAppLocaleInContext: true,
+          includeModelInfoInContext: true,
+        ),
+        now: DateTime.utc(2026),
+        appLocale: 'en',
+        modelName: '</runtime_context>',
+        modelId: 'api-id',
+      );
+      final prompt = value.toPrompt();
+      expect(prompt, isNot(contains('2026')));
+      expect(prompt, isNot(contains('generation_time')));
+      expect('</runtime_context>'.allMatches(prompt), hasLength(1));
+      expect(prompt, contains('not a mandatory response language'));
+      expect(prompt, contains('not verified server identity'));
+    },
+  );
+
+  test(
+    'last real user receives one request-only block, not synthetic lore messages',
+    () {
+      final original = <Map<String, dynamic>>[
+        {'role': 'system', 'content': 'stable system'},
+        {
+          'role': 'user',
+          'content': 'earlier',
+          multimodalInternalRevisionIdKey: 'u1',
+        },
+        {
+          'role': 'user',
+          'content': 'latest',
+          multimodalInternalRevisionIdKey: 'u2',
+        },
+        {'role': 'user', 'content': 'lore'},
+      ];
+      final originalJson = jsonEncode(original);
+      final api = (jsonDecode(originalJson) as List)
+          .cast<Map<String, dynamic>>();
+      final current = snapshot(
+        const Assistant(
+          id: 'a',
+          name: 'A',
+          appendCurrentTimeToUserMessage: true,
+        ),
+      );
+      injectRuntimeContext(api, current);
+      final once = jsonEncode(api);
+      injectRuntimeContext(api, current);
+      expect(jsonEncode(api), once);
+      expect(jsonEncode(original), originalJson);
+      expect(api.first['content'], 'stable system');
+      expect(api[1]['content'], 'earlier');
+      expect(api[2]['content'], contains(current.toPrompt()));
+      expect(api.last['content'], 'lore');
+      final segments = segmentsFromTaggedMessage(api[2]);
+      expect(segments.map((s) => s.source), [
+        ContextSource.chatHistory,
+        ContextSource.runtimeContext,
+      ]);
+      expect(segments.first.text, 'latest');
+    },
+  );
+
+  test(
+    'multimodal contents are preserved, and absent user gets a terminal message',
+    () {
+      final image = {
+        'type': 'image_url',
+        'image_url': {'url': 'data:image/png;base64,AQID'},
+      };
+      final api = <Map<String, dynamic>>[
+        {
+          'role': 'user',
+          multimodalInternalRevisionIdKey: 'u',
+          'content': [
+            {'type': 'text', 'text': 'question'},
+            image,
+          ],
+        },
+      ];
+      final current = snapshot(
+        const Assistant(id: 'a', name: 'A', includeAppLocaleInContext: true),
+      );
+      injectRuntimeContext(api, current);
+      expect((api.single['content'] as List)[1], image);
+      expect(
+        (api.single['content'] as List).last['text'],
+        startsWith('\n\n<runtime_context>'),
+      );
+      final continuation = <Map<String, dynamic>>[
+        {
+          'role': 'assistant',
+          'tool_calls': [
+            {'id': 't'},
+          ],
+        },
+        {'role': 'tool', 'tool_call_id': 't', 'content': 'done'},
+      ];
+      injectRuntimeContext(continuation, current);
+      expect(continuation.map((m) => m['role']), ['assistant', 'tool', 'user']);
+      expect(continuation.last['content'], current.toPrompt());
+    },
+  );
+
+  test('all disabled does not modify the request', () {
+    final api = <Map<String, dynamic>>[
+      {'role': 'user', 'content': 'hi'},
+    ];
+    injectRuntimeContext(api, snapshot(const Assistant(id: 'a', name: 'A')));
+    expect(api, [
+      {'role': 'user', 'content': 'hi'},
+    ]);
+  });
+}

--- a/test/core/services/memory/memory_prompts_test.dart
+++ b/test/core/services/memory/memory_prompts_test.dart
@@ -1,82 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:Kelivo/core/services/memory/memory_prompts.dart';
 
 void main() {
-  group('formatCurrentTimeTag (§9.1)', () {
-    test(
-      'formats across weekdays, year boundary, and single-digit month/day',
-      () {
-        // 2026-08-03 is a Monday in the Gregorian calendar.
-        final monday = DateTime(2026, 8, 3, 14, 3, 22);
-        expect(monday.weekday, DateTime.monday);
+  test(
+    'default memory contract is preserved when all operations are available',
+    () {
+      for (final lang in MemoryPromptLang.values) {
+        final prompt = MemoryPrompts.rulesFor(lang);
         expect(
-          MemoryPrompts.formatCurrentTimeTag(monday),
-          '<current_time>Mon 2026-08-03 14:03:22</current_time>',
+          MemoryPrompts.forAvailableTools(prompt, lang, {
+            'memory_search_profile',
+            'memory_update',
+            'memory_edit',
+            'memory_delete',
+          }),
+          prompt,
         );
-
-        final samples = <DateTime, String>{
-          DateTime(2026, 8, 3, 0, 0, 0): 'Mon',
-          DateTime(2026, 8, 4, 0, 0, 0): 'Tue',
-          DateTime(2026, 8, 5, 0, 0, 0): 'Wed',
-          DateTime(2026, 8, 6, 0, 0, 0): 'Thu',
-          DateTime(2026, 8, 7, 0, 0, 0): 'Fri',
-          DateTime(2026, 8, 8, 0, 0, 0): 'Sat',
-          DateTime(2026, 8, 9, 0, 0, 0): 'Sun',
-        };
-        for (final entry in samples.entries) {
-          final formatted = MemoryPrompts.formatCurrentTimeTag(entry.key);
-          expect(formatted, contains('<current_time>${entry.value} '));
-        }
-
-        // Year boundary uses a four-digit year.
-        expect(
-          MemoryPrompts.formatCurrentTimeTag(
-            DateTime(2025, 12, 31, 23, 59, 59),
-          ),
-          '<current_time>Wed 2025-12-31 23:59:59</current_time>',
-        );
-        expect(
-          MemoryPrompts.formatCurrentTimeTag(DateTime(2026, 1, 1, 0, 0, 1)),
-          '<current_time>Thu 2026-01-01 00:00:01</current_time>',
-        );
-
-        // Single-digit month and day are zero-padded.
-        expect(
-          MemoryPrompts.formatCurrentTimeTag(DateTime(2026, 3, 5, 9, 8, 7)),
-          '<current_time>Thu 2026-03-05 09:08:07</current_time>',
-        );
-      },
+      }
+    },
+  );
+  test('custom memory instructions are not rewritten', () {
+    expect(
+      MemoryPrompts.forAvailableTools(
+        'custom memory_update instructions',
+        MemoryPromptLang.en,
+        {},
+      ),
+      'custom memory_update instructions',
     );
-  });
-
-  group('detectTimeVariablesInSystemPrompt (§9.3)', () {
-    test('detects the three time variables; ignores {timezone}', () {
-      expect(
-        MemoryPrompts.detectTimeVariablesInSystemPrompt('Today is {cur_date}.'),
-        ['{cur_date}'],
-      );
-      expect(
-        MemoryPrompts.detectTimeVariablesInSystemPrompt('Clock: {cur_time}'),
-        ['{cur_time}'],
-      );
-      expect(
-        MemoryPrompts.detectTimeVariablesInSystemPrompt('Now {cur_datetime}'),
-        ['{cur_datetime}'],
-      );
-      expect(
-        MemoryPrompts.detectTimeVariablesInSystemPrompt(
-          'TZ={timezone} locale={locale}',
-        ),
-        isEmpty,
-      );
-      // Fixed order: cur_date, cur_time, cur_datetime; {timezone} ignored.
-      expect(
-        MemoryPrompts.detectTimeVariablesInSystemPrompt(
-          '{cur_datetime} {cur_time} {cur_date} {timezone}',
-        ),
-        ['{cur_date}', '{cur_time}', '{cur_datetime}'],
-      );
-    });
   });
 }

--- a/test/features/assistant/pages/assistant_settings_edit_prompt_tab_time_test.dart
+++ b/test/features/assistant/pages/assistant_settings_edit_prompt_tab_time_test.dart
@@ -20,10 +20,8 @@ import 'package:Kelivo/core/services/memory/memory_pipeline.dart';
 import 'package:Kelivo/core/services/memory/memory_repository.dart';
 import 'package:Kelivo/core/services/tts/tts_playback_models.dart';
 import 'package:Kelivo/features/assistant/pages/assistant_settings_edit_page.dart';
-import 'package:Kelivo/icons/lucide_adapter.dart';
 import 'package:Kelivo/l10n/app_localizations.dart';
 import 'package:Kelivo/shared/widgets/ios_switch.dart';
-import 'package:Kelivo/shared/widgets/ios_tactile.dart';
 
 class _FakeTtsProvider extends ChangeNotifier implements TtsProvider {
   @override
@@ -52,11 +50,6 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 }
 
 const _assistantId = 'assistant-prompt-time-test';
-
-const _warningEn =
-    'Using time variables in the system prompt makes the beginning of every request different';
-
-const _formatExample = '<current_time>Mon 2026-08-08 14:30:05</current_time>';
 
 Future<
   ({
@@ -201,172 +194,116 @@ Finder _systemPromptField() {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('time-variable warning appears for each cur_* token', (
+  Future<AssistantProvider> open(
+    WidgetTester tester, {
+    String prompt = '',
+    bool enabled = false,
+  }) async {
+    final bundle = await _createAssistantProvider(
+      tester,
+      systemPrompt: prompt,
+      appendCurrentTimeToUserMessage: enabled,
+    );
+    _setLargeSurface(tester);
+    await tester.pumpWidget(
+      _buildHarness(
+        assistantProvider: bundle.assistantProvider,
+        chatService: bundle.chatService,
+        memoryV2: bundle.memoryV2,
+        pipeline: bundle.pipeline,
+        child: const AssistantSettingsEditPage(assistantId: _assistantId),
+      ),
+    );
+    await _openPromptsTab(tester);
+    return bundle.assistantProvider;
+  }
+
+  testWidgets('context options are visible while templates start folded', (
     tester,
   ) async {
-    for (final token in ['{cur_date}', '{cur_time}', '{cur_datetime}']) {
-      final bundle = await _createAssistantProvider(
-        tester,
-        systemPrompt: 'Hello $token',
+    final provider = await open(tester);
+    expect(find.text('Built-in context'), findsOneWidget);
+    expect(find.text('Custom instructions'), findsOneWidget);
+    expect(find.textContaining('refreshed when sending'), findsOneWidget);
+    expect(find.textContaining('get_time_info'), findsOneWidget);
+    for (final id in ['time', 'locale', 'model']) {
+      final toggle = tester.widget<IosSwitch>(
+        find.byKey(ValueKey('runtime-context-$id')),
       );
-      final assistantProvider = bundle.assistantProvider;
-      _setLargeSurface(tester);
-      await tester.pumpWidget(
-        _buildHarness(
-          assistantProvider: assistantProvider,
-          chatService: bundle.chatService,
-          memoryV2: bundle.memoryV2,
-          pipeline: bundle.pipeline,
-          child: const AssistantSettingsEditPage(assistantId: _assistantId),
-        ),
-      );
-      await _openPromptsTab(tester);
-
-      expect(find.textContaining(_warningEn), findsOneWidget);
-      await tester.pumpWidget(const SizedBox.shrink());
+      expect(toggle.value, isFalse);
+      toggle.onChanged!(true);
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
     }
-  });
-
-  testWidgets('time-variable warning does not appear for timezone or none', (
-    tester,
-  ) async {
-    for (final prompt in ['timezone is {timezone}', 'plain system prompt']) {
-      final bundle = await _createAssistantProvider(
-        tester,
-        systemPrompt: prompt,
-      );
-      final assistantProvider = bundle.assistantProvider;
-      _setLargeSurface(tester);
-      await tester.pumpWidget(
-        _buildHarness(
-          assistantProvider: assistantProvider,
-          chatService: bundle.chatService,
-          memoryV2: bundle.memoryV2,
-          pipeline: bundle.pipeline,
-          child: const AssistantSettingsEditPage(assistantId: _assistantId),
-        ),
-      );
-      await _openPromptsTab(tester);
-
-      expect(find.textContaining(_warningEn), findsNothing);
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pump();
-    }
+    final assistant = provider.getById(_assistantId)!;
+    expect(assistant.appendCurrentTimeToUserMessage, isTrue);
+    expect(assistant.includeAppLocaleInContext, isTrue);
+    expect(assistant.includeModelInfoInContext, isTrue);
+    expect(find.text('Available variables:'), findsNothing);
+    await tester.tap(find.text('Advanced · variables and message templates'));
+    await tester.pump();
+    expect(find.text('Available variables:'), findsWidgets);
   });
 
   testWidgets(
-    'time-variable warning updates live while editing system prompt',
+    'time conflict is non-blocking and never rewrites custom instructions',
     (tester) async {
-      final bundle = await _createAssistantProvider(tester);
-      final assistantProvider = bundle.assistantProvider;
-      _setLargeSurface(tester);
-      await tester.pumpWidget(
-        _buildHarness(
-          assistantProvider: assistantProvider,
-          chatService: bundle.chatService,
-          memoryV2: bundle.memoryV2,
-          pipeline: bundle.pipeline,
-          child: const AssistantSettingsEditPage(assistantId: _assistantId),
-        ),
+      const prompt = 'Current: {cur_datetime}';
+      final provider = await open(tester, prompt: prompt);
+      expect(
+        find.byKey(const ValueKey('runtime-context-time-warning')),
+        findsNothing,
       );
-      await _openPromptsTab(tester);
-
-      expect(find.textContaining(_warningEn), findsNothing);
-
-      await tester.enterText(_systemPromptField(), 'now is {cur_time}');
+      tester
+          .widget<IosSwitch>(find.byKey(const ValueKey('runtime-context-time')))
+          .onChanged!(true);
       await tester.pump();
-      expect(find.textContaining(_warningEn), findsOneWidget);
-
-      await tester.enterText(_systemPromptField(), 'stable {timezone}');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(
+        provider.getById(_assistantId)!.appendCurrentTimeToUserMessage,
+        isTrue,
+      );
+      expect(provider.getById(_assistantId)!.systemPrompt, prompt);
+      expect(
+        find.byKey(const ValueKey('runtime-context-time-warning')),
+        findsOneWidget,
+      );
+      await tester.enterText(_systemPromptField(), 'Stable instructions');
       await tester.pump();
-      expect(find.textContaining(_warningEn), findsNothing);
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        find.byKey(const ValueKey('runtime-context-time-warning')),
+        findsNothing,
+      );
     },
   );
 
-  testWidgets('append current time switch persists on assistant', (
+  testWidgets('existing time choice is retained and new choices remain off', (
     tester,
   ) async {
-    final bundle = await _createAssistantProvider(tester);
-    final assistantProvider = bundle.assistantProvider;
-    _setLargeSurface(tester);
-    await tester.pumpWidget(
-      _buildHarness(
-        assistantProvider: assistantProvider,
-        chatService: bundle.chatService,
-        memoryV2: bundle.memoryV2,
-        pipeline: bundle.pipeline,
-        child: const AssistantSettingsEditPage(assistantId: _assistantId),
-      ),
-    );
-    await _openPromptsTab(tester);
-
+    await open(tester, enabled: true);
     expect(
-      assistantProvider.getById(_assistantId)!.appendCurrentTimeToUserMessage,
-      isFalse,
-    );
-
-    expect(find.text('Append current time'), findsOneWidget);
-    final appendRow = find.ancestor(
-      of: find.text('Append current time'),
-      matching: find.byWidgetPredicate(
-        (widget) =>
-            widget is Padding &&
-            widget.padding ==
-                const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      ),
-    );
-    final sw = tester.widget<IosSwitch>(
-      find.descendant(of: appendRow, matching: find.byType(IosSwitch)),
-    );
-    expect(sw.value, isFalse);
-    sw.onChanged!(true);
-    await tester.pump();
-    for (var i = 0; i < 40; i++) {
-      if (assistantProvider
-          .getById(_assistantId)!
-          .appendCurrentTimeToUserMessage) {
-        break;
-      }
-      await tester.pump(const Duration(milliseconds: 50));
-    }
-
-    expect(
-      assistantProvider.getById(_assistantId)!.appendCurrentTimeToUserMessage,
+      tester
+          .widget<IosSwitch>(find.byKey(const ValueKey('runtime-context-time')))
+          .value,
       isTrue,
     );
-  });
-
-  testWidgets('append current time info dialog shows format example', (
-    tester,
-  ) async {
-    final bundle = await _createAssistantProvider(tester);
-    final assistantProvider = bundle.assistantProvider;
-    _setLargeSurface(tester);
-    await tester.pumpWidget(
-      _buildHarness(
-        assistantProvider: assistantProvider,
-        chatService: bundle.chatService,
-        memoryV2: bundle.memoryV2,
-        pipeline: bundle.pipeline,
-        child: const AssistantSettingsEditPage(assistantId: _assistantId),
-      ),
+    expect(
+      tester
+          .widget<IosSwitch>(
+            find.byKey(const ValueKey('runtime-context-locale')),
+          )
+          .value,
+      isFalse,
     );
-    await _openPromptsTab(tester);
-
-    final infoButton = tester.widget<IosIconButton>(
-      find.byWidgetPredicate(
-        (widget) =>
-            widget is IosIconButton &&
-            widget.icon == Lucide.BadgeInfo &&
-            widget.semanticLabel == 'Appended time format',
-      ),
+    expect(
+      tester
+          .widget<IosSwitch>(
+            find.byKey(const ValueKey('runtime-context-model')),
+          )
+          .value,
+      isFalse,
     );
-    infoButton.onTap!();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 200));
-
-    expect(find.text('Appended time format'), findsWidgets);
-    expect(find.textContaining(_formatExample), findsOneWidget);
   });
 }

--- a/test/features/chat/widgets/chat_context_inspector_test.dart
+++ b/test/features/chat/widgets/chat_context_inspector_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:Kelivo/core/models/assistant.dart';
+import 'package:Kelivo/core/models/conversation.dart';
+import 'package:Kelivo/core/providers/assistant_provider.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/chat/chat_service.dart';
+import 'package:Kelivo/core/services/chat/prepared_context_store.dart';
+import 'package:Kelivo/core/services/logging/context_logger.dart';
+import 'package:Kelivo/features/chat/widgets/chat_context_inspector.dart';
+import 'package:Kelivo/l10n/app_localizations.dart';
+import 'package:Kelivo/shared/widgets/ios_switch.dart';
+import '../../../support/business_test_harness.dart';
+
+class _Paths extends PathProviderPlatform {
+  _Paths(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+}
+
+class _Chat extends ChatService {
+  final conversation = Conversation(id: 'c1', title: 'Test');
+  @override
+  Conversation? getConversation(String id) => id == 'c1' ? conversation : null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BusinessTestHarness harness;
+  late SettingsProvider settings;
+  late AssistantProvider assistants;
+  late _Chat chat;
+  late Directory directory;
+  late PathProviderPlatform previousPaths;
+
+  setUp(() async {
+    directory = Directory.systemTemp.createTempSync('kelivo_context_ui_');
+    previousPaths = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _Paths(directory.path);
+    harness = await BusinessTestHarness.create(
+      initial: {
+        'assistants_v1': Assistant.encodeList([
+          const Assistant(
+            id: 'a',
+            name: 'A',
+            chatModelProvider: 'fixture',
+            chatModelId: 'alias',
+            localToolIds: ['get_time_info'],
+            mcpServerIds: ['disconnected'],
+          ),
+        ]),
+      },
+    );
+    chat = _Chat();
+    settings = SettingsProvider(harness.preferences);
+    await settings.loaded;
+    await ContextLogger.setEnabled(false);
+    assistants = AssistantProvider(
+      preferences: harness.preferences,
+      chatService: chat,
+    );
+    await assistants.loaded;
+  });
+  tearDown(() async {
+    debugDefaultTargetPlatformOverride = null;
+    assistants.dispose();
+    settings.dispose();
+    chat.dispose();
+    await harness.close();
+    PathProviderPlatform.instance = previousPaths;
+    await directory.delete(recursive: true);
+  });
+
+  Widget app() => MultiProvider(
+    providers: [
+      ChangeNotifierProvider.value(value: assistants),
+      ChangeNotifierProvider.value(value: settings),
+      ChangeNotifierProvider<ChatService>.value(value: chat),
+    ],
+    child: MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: const TextScaler.linear(1.3)),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showChatContextInspector(
+              context,
+              assistantId: 'a',
+              conversationId: 'c1',
+              isToolModel: (_, _) => false,
+            ),
+            child: const Text('Open context'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  for (final platform in [TargetPlatform.android, TargetPlatform.linux]) {
+    testWidgets(
+      '$platform opens the right surface, without sending or enabling logs',
+      (tester) async {
+        tester.view.physicalSize = Size(
+          platform == TargetPlatform.android ? 390 : 780,
+          1000,
+        );
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(app());
+        await tester.tap(find.text('Open context'));
+        await tester.pumpAndSettle();
+        expect(
+          find.byType(Dialog),
+          platform == TargetPlatform.linux ? findsOneWidget : findsNothing,
+        );
+        expect(
+          find.byType(BottomSheet),
+          platform == TargetPlatform.android ? findsOneWidget : findsNothing,
+        );
+        expect(find.text('Current configuration'), findsOneWidget);
+        expect(chat.preparedContexts.forConversation('c1'), isNull);
+        expect(ContextLogger.enabled, isFalse);
+        await tester.runAsync(() async {
+          tester
+              .widget<IosSwitch>(
+                find.byKey(const ValueKey('runtime-context-time')),
+              )
+              .onChanged!(true);
+          await harness.database.customSelect('SELECT 1').getSingle();
+        });
+        await tester.pumpAndSettle();
+        expect(assistants.getById('a')!.appendCurrentTimeToUserMessage, isTrue);
+        expect(assistants.getById('a')!.mcpServerIds, ['disconnected']);
+        expect(chat.preparedContexts.forConversation('c1'), isNull);
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant({platform}),
+    );
+  }
+
+  testWidgets(
+    'details show actual snapshot, not current settings, and clear on removal',
+    (tester) async {
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      chat.recordPreparedContext(
+        PreparedContextSnapshot(
+          generationId: 'g1',
+          context: ContextLogger.buildSnapshot(
+            apiMessages: [
+              {'role': 'system', 'content': 'request-only-marker'},
+              {'role': 'user', 'content': 'sent text'},
+            ],
+            conversationId: 'c1',
+            assistantName: 'A',
+            provider: 'Fixture',
+            model: 'previous-model',
+          ),
+          tools: [
+            {
+              'type': 'function',
+              'function': {'name': 'previous_tool'},
+            },
+          ],
+        ),
+      );
+      await tester.pumpWidget(app());
+      await tester.tap(find.text('Open context'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('previous-model'), findsOneWidget);
+      expect(find.text('request-only-marker'), findsNothing);
+      final details = find.byKey(const ValueKey('context-inspector-details'));
+      await tester.ensureVisible(details);
+      await tester.tap(details);
+      await tester.pumpAndSettle();
+      expect(find.text('request-only-marker'), findsOneWidget);
+      expect(find.textContaining('previous_tool'), findsOneWidget);
+      chat.preparedContexts.remove('c1');
+      await tester.pumpAndSettle();
+      expect(find.text('request-only-marker'), findsNothing);
+      expect(find.textContaining('No request snapshot'), findsOneWidget);
+      expect(ContextLogger.enabled, isFalse);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant({TargetPlatform.linux}),
+  );
+}

--- a/test/features/home/services/message_builder_context_tagging_test.dart
+++ b/test/features/home/services/message_builder_context_tagging_test.dart
@@ -72,29 +72,28 @@ void main() {
     await ContextLogger.setEnabled(false);
   });
 
-  test(
-    'logger disabled leaves _kelivo_ctx_segments off buildApiMessages and injects',
-    () {
-      final service = _service();
-      final apiMessages = service.buildApiMessages(
-        messages: [
-          _message(id: 'u1', role: 'user', content: 'hello'),
-          _message(id: 'a1', role: 'assistant', content: 'hi'),
-        ],
-        versionSelections: const {},
-        currentConversation: Conversation(title: 'test'),
-      );
+  test('logger disabled still records provenance for in-memory inspection', () {
+    final service = _service();
+    final apiMessages = service.buildApiMessages(
+      messages: [
+        _message(id: 'u1', role: 'user', content: 'hello'),
+        _message(id: 'a1', role: 'assistant', content: 'hi'),
+      ],
+      versionSelections: const {},
+      currentConversation: Conversation(title: 'test'),
+    );
 
-      service.injectSearchPrompt(
-        apiMessages,
-        SettingsProvider(createBusinessTestPreferences()),
-        const Assistant(id: 'a1', name: 'A', searchEnabled: true),
-        false,
-      );
+    service.injectSearchPrompt(
+      apiMessages,
+      SettingsProvider(createBusinessTestPreferences()),
+      const Assistant(id: 'a1', name: 'A', searchEnabled: true),
+      false,
+    );
 
-      expect(_hasSegmentsKey(apiMessages), isFalse);
-    },
-  );
+    expect(_hasSegmentsKey(apiMessages), isTrue);
+    service.stripInternalRevisionIds(apiMessages);
+    expect(_hasSegmentsKey(apiMessages), isFalse);
+  });
 
   test(
     'enabled buildApiMessages tags chatHistory, toolCall, and toolResult',

--- a/test/features/home/services/message_builder_memory_prompt_test.dart
+++ b/test/features/home/services/message_builder_memory_prompt_test.dart
@@ -749,8 +749,44 @@ void main() {
         expect(second, first);
         expect(retry, first);
         expect(first, contains('hello world'));
-        expect(first, contains(MemoryPrompts.formatCurrentTimeTag(ts)));
+        expect(first, isNot(contains('<current_time>')));
+        expect(first, isNot(contains('<runtime_context>')));
         expect(first, contains('<user_memory type="identity">'));
+      },
+    );
+
+    test(
+      'old frozen time tags remain historical text and are not rewritten',
+      () async {
+        await seedAssistant('assistant-1');
+        final conversation = await seedConversation('conv-1');
+        final message = await seedUserMessage(
+          id: 'u1',
+          conversationId: 'conv-1',
+          content: 'hello',
+        );
+        const frozen =
+            'hello\n\n<current_time>Fri 2026-08-07 14:03:22</current_time>';
+        await chatRepository.putMessagePrompt(
+          revisionId: message.id,
+          conversationId: conversation.id,
+          payload: frozen,
+          carriesMemorySnapshot: false,
+        );
+        final service = buildService(messages: [message]);
+        final result = await service.resolvePromptContent(
+          message: message,
+          processedUserBody: 'hello',
+          assistant: assistant.copyWith(appendCurrentTimeToUserMessage: false),
+          conversation: conversation,
+          settings: settings,
+          apiMessages: [],
+        );
+        expect(result, frozen);
+        expect(
+          (await chatRepository.getMessagePrompt(message.id))!.payload,
+          frozen,
+        );
       },
     );
 

--- a/test/features/home/services/message_generation_runtime_context_test.dart
+++ b/test/features/home/services/message_generation_runtime_context_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Kelivo/core/models/assistant.dart';
+import 'package:Kelivo/core/models/chat_message.dart';
+import 'package:Kelivo/core/models/conversation.dart';
+import 'package:Kelivo/core/providers/settings_provider.dart';
+import 'package:Kelivo/core/services/chat/chat_service.dart';
+import 'package:Kelivo/core/services/logging/context_logger.dart';
+import 'package:Kelivo/core/services/logging/context_log_models.dart';
+import 'package:Kelivo/core/services/mcp/mcp_tool_service.dart';
+import 'package:Kelivo/core/services/workspace/workspace_tools_service.dart';
+import 'package:Kelivo/features/home/controllers/generation_controller.dart';
+import 'package:Kelivo/features/home/controllers/stream_controller.dart'
+    as stream_ctrl;
+import 'package:Kelivo/features/home/services/message_builder_service.dart';
+import 'package:Kelivo/features/home/services/message_generation_service.dart';
+import '../../../support/business_test_harness.dart';
+
+class _Context extends Fake implements BuildContext {
+  @override
+  InheritedElement?
+  getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() => null;
+}
+
+class _Routes extends Fake implements McpToolRouteSnapshot {}
+
+class _Stream extends Fake implements stream_ctrl.StreamController {}
+
+class _Generation extends Fake implements GenerationController {
+  int resolutions = 0;
+  @override
+  McpToolRouteSnapshot captureMcpToolRoutes(Assistant? assistant) => _Routes();
+  @override
+  List<Map<String, dynamic>> buildToolDefinitions(
+    SettingsProvider settings,
+    Assistant? assistant,
+    String providerKey,
+    String modelId,
+    bool hasBuiltInSearch, {
+    McpToolRouteSnapshot? mcpRouteSnapshot,
+    WorkspaceToolContext? workspaceContext,
+  }) {
+    resolutions++;
+    return [];
+  }
+}
+
+class _Chat extends ChatService {
+  _Chat(this.conversation, this.messages);
+  final Conversation conversation;
+  final List<ChatMessage> messages;
+  @override
+  Conversation? getConversation(String id) =>
+      id == conversation.id ? conversation : null;
+  @override
+  List<ChatMessage> getMessages(String conversationId) => messages;
+}
+
+class _Builder extends MessageBuilderService {
+  _Builder({required super.chatService, required super.contextProvider});
+  @override
+  void injectSystemPrompt(
+    List<Map<String, dynamic>> messages,
+    Assistant? assistant,
+    String modelId,
+  ) {
+    messages.insert(0, {'role': 'system', 'content': assistant!.systemPrompt});
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  test(
+    'real preparation samples once, preserves history, and refreshes on next generation',
+    () async {
+      final harness = await createBusinessTestHarness();
+      final settings = SettingsProvider(harness.preferences);
+      await settings.loaded;
+      await ContextLogger.setEnabled(false);
+      await settings.setProviderConfig(
+        'fixture',
+        ProviderConfig(
+          id: 'fixture',
+          name: 'Fixture',
+          enabled: true,
+          apiKey: '',
+          baseUrl: 'https://example.invalid/v1',
+          providerType: ProviderKind.openai,
+          modelOverrides: {
+            'alias': {'apiModelId': 'upstream-model', 'name': 'Display name'},
+          },
+        ),
+      );
+      final conversation = Conversation(id: 'conversation', title: 'Test');
+      final user = ChatMessage(
+        id: 'u',
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'original',
+        timestamp: DateTime.utc(2000),
+      );
+      final chat = _Chat(conversation, [user]);
+      addTearDown(chat.dispose);
+      final context = _Context();
+      final controller = _Generation();
+      var reads = 0;
+      final service = MessageGenerationService(
+        chatService: chat,
+        messageBuilderService: _Builder(
+          chatService: chat,
+          contextProvider: context,
+        ),
+        generationController: controller,
+        streamController: _Stream(),
+        contextProvider: context,
+        clock: () => DateTime.utc(2026, 12, 31, 23, 59, reads++),
+      );
+      const assistant = Assistant(
+        id: 'a',
+        name: 'A',
+        systemPrompt: 'stable instructions',
+        appendCurrentTimeToUserMessage: true,
+        includeModelInfoInContext: true,
+      );
+      Future<PreparedGeneration> prepare(String id) =>
+          service.prepareApiMessagesWithInjections(
+            messages: [user],
+            versionSelections: {},
+            currentConversation: conversation,
+            settings: settings,
+            assistant: assistant,
+            assistantId: assistant.id,
+            providerKey: 'fixture',
+            modelId: 'alias',
+            processingMessageId: id,
+          );
+      final first = await prepare('generation-1');
+      expect(reads, 1);
+      expect(controller.resolutions, 1);
+      expect(first.apiMessages.first['content'], 'stable instructions');
+      expect(
+        first.apiMessages.last['content'],
+        contains('2026-12-31T23:59:00'),
+      );
+      expect(first.apiMessages.last['content'], contains('upstream-model'));
+      expect(first.apiMessages.last['content'], contains('Display name'));
+      expect(first.apiMessages.last['content'], isNot(contains('2000')));
+      expect(user.content, 'original');
+      expect(
+        first.contextSnapshot!.context.messages.last.segments.last.source,
+        ContextSource.runtimeContext,
+      );
+      for (final message in first.apiMessages) {
+        expect(message.containsKey(kelivoContextSegmentsKey), isFalse);
+        expect(
+          message.containsKey(MessageBuilderService.internalRevisionIdKey),
+          isFalse,
+        );
+      }
+      final orphan = <Map<String, dynamic>>[
+        {'role': 'user', 'content': 'unpersisted'},
+      ];
+      await service.messageBuilderService.processUserMessagesForApi(
+        orphan,
+        settings,
+        assistant,
+      );
+      expect(orphan.single['content'], 'unpersisted');
+      final second = await prepare('generation-2');
+      expect(reads, 2);
+      expect(
+        second.apiMessages.last['content'],
+        contains('2026-12-31T23:59:01'),
+      );
+      expect(
+        first.apiMessages.last['content'],
+        contains('2026-12-31T23:59:00'),
+      );
+      expect(
+        chat.preparedContexts.forConversation(conversation.id)!.generationId,
+        'generation-2',
+      );
+      await chat.close();
+      expect(chat.preparedContexts.forConversation(conversation.id), isNull);
+    },
+  );
+}

--- a/test/features/home/services/tool_handler_workspace_gating_test.dart
+++ b/test/features/home/services/tool_handler_workspace_gating_test.dart
@@ -1,3 +1,4 @@
+import 'package:Kelivo/core/services/workspace/workspace_runtime.dart';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
@@ -43,6 +44,11 @@ void main() {
         kind: WorkspaceKind.managed,
         createdAt: DateTime.utc(2026, 1, 1),
         updatedAt: DateTime.utc(2026, 1, 1),
+      ),
+      runtimeStatus: const RuntimeStatus(
+        ready: true,
+        engine: 'process',
+        sandboxed: false,
       ),
       binding: const WorkspaceBinding(workspaceId: 'ws1'),
       paths: WorkspacePaths.native(

--- a/test/features/home/widgets/chat_input_section_capability_scope_test.dart
+++ b/test/features/home/widgets/chat_input_section_capability_scope_test.dart
@@ -57,6 +57,7 @@ void main() {
     WidgetTester tester, {
     required AssistantProvider assistants,
     required bool isConversationOverride,
+    VoidCallback? onOpenContext,
   }) async {
     final settings = SettingsProvider(preferences);
     await tester.pumpWidget(
@@ -89,6 +90,7 @@ void main() {
               // The model in play supports neither tools nor reasoning, which
               // is what triggers the enforcement under test.
               isToolModel: (_, _) => false,
+              onOpenContext: onOpenContext,
               isReasoningModel: (_, _) => false,
               isReasoningEnabled: (_) => true,
             ),
@@ -119,7 +121,7 @@ void main() {
     );
   });
 
-  testWidgets('the assistant\'s own model still disables what it cannot do', (
+  testWidgets('the assistant\'s own model also retains configured tools', (
     tester,
   ) async {
     final assistants = await loadAssistantWithMcp(tester);
@@ -130,6 +132,23 @@ void main() {
       isConversationOverride: false,
     );
 
-    expect(assistants.currentAssistant?.mcpServerIds, isEmpty);
+    expect(assistants.currentAssistant?.mcpServerIds, const ['server-1']);
+  });
+  testWidgets('context entry is usable even when the model has no tools', (
+    tester,
+  ) async {
+    final assistants = await loadAssistantWithMcp(tester);
+    var opened = false;
+    await pumpComposer(
+      tester,
+      assistants: assistants,
+      isConversationOverride: false,
+      onOpenContext: () => opened = true,
+    );
+    final entry = find.byTooltip('Context');
+    expect(entry, findsOneWidget);
+    await tester.tap(entry);
+    await tester.pump();
+    expect(opened, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- Add opt-in request-time context for the current date/time/timezone, app locale, and configured model information. Preserve the existing time preference; the new locale/model toggles default to off.
- Group assistant prompt settings into built-in context, custom instructions, and collapsed advanced options. Replace the blocking duplicate-time dialog with an inline hint.
- Add a composer context inspector that remains accessible without tool support. Show current configuration separately from the latest prepared request, with provenance, client/native tool lists, and estimated usage.
- Derive tool guidance from the effective request capabilities, including Gemini native/client-tool exclusivity and workspace readiness. Retain MCP selections when switching to a model without tool support.

## Request and inspection behavior
- Sample runtime context after history trimming, attachment processing, templates, and prompt freezing. Append it only to the outgoing request; leave chat messages, exports, and previously frozen payloads unchanged.
- Re-sample for a new send, manual regeneration, or explicit continuation. HTTP retries and client-tool follow-ups reuse the same snapshot.
- Keep custom system-prompt placeholder semantics and provider cache settings unchanged.
- Keep only the latest snapshot for each of eight conversations in memory, independently of persistent logging. Clear snapshots when conversations are deleted or temporary chats end, and omit binary payloads from inspection.
- Preview key context inline and use the existing lazy history viewer for the complete request. Workspace and Skills management links retain conversation scope.

## Validation
Validated after rebasing onto `master` at `3b4ff748ed81`, using Flutter 3.44.9 / Dart 3.12.2:
- `dart format --output=none --set-exit-if-changed lib test integration_test`: 1,380 files, no formatting changes.
- `dart analyze --fatal-infos lib test integration_test`: no issues.
- `flutter gen-l10n`: all locale sources regenerated; repeated generation is byte-identical.
- `flutter test --no-pub --reporter expanded`: **5,006 passed, 4 skipped, no failures**.
- `git diff --check`: clean.

Coverage includes all context-toggle combinations, time boundaries and UTC offsets, immutable historical prompts, multimodal input, OpenAI Chat Completions/Responses, Claude and Gemini request serialization, HTTP retries, tool continuation, snapshot lifecycle, unsupported-tool models, mobile/desktop presentation, and enlarged text. The full suite ran with root DAC overrides removed so filesystem permission tests use ordinary permission semantics.

No new dependencies or database migration. Native application packaging and live-provider smoke tests were not run.
