### PR TITLE
fix(model-selector): follow the sheet surface instead of the card layer

### DIFF
--- a/lib/features/model/widgets/model_select_sheet.dart
+++ b/lib/features/model/widgets/model_select_sheet.dart
@@ -24,6 +24,7 @@ import '../../provider/widgets/provider_avatar.dart';
 import '../../provider/widgets/provider_balance_badge.dart';
 import '../../../core/services/model_override_resolver.dart';
 import '../../../theme/app_font_weights.dart';
+import 'package:Kelivo/shared/widgets/section_card.dart';
 import 'package:Kelivo/theme/app_semantic_colors.dart';
 
 class ModelSelection {
@@ -906,8 +907,9 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
               children: [
                 // Fixed header section with rounded corners
                 Container(
+                  key: const ValueKey('model-selector-header'),
                   decoration: BoxDecoration(
-                    color: context.appColors.surfaceCard,
+                    color: context.overlaySurface,
                     borderRadius: const BorderRadius.vertical(
                       top: Radius.circular(20),
                     ),
@@ -1035,9 +1037,9 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                 // Scrollable content
                 Expanded(
                   child: Container(
-                    color: context
-                        .appColors
-                        .surfaceCard, // Ensure background color continuity
+                    key: const ValueKey('model-selector-list'),
+                    // Ensure background color continuity
+                    color: context.overlaySurface,
                     child: _isLoading
                         ? const Center(child: CircularProgressIndicator())
                         : _buildContent(context),
@@ -1045,9 +1047,9 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                 ),
                 // Fixed bottom tabs
                 Container(
-                  color: context
-                      .appColors
-                      .surfaceCard, // Ensure background color continuity
+                  key: const ValueKey('model-selector-bottom-tabs'),
+                  // Ensure background color continuity
+                  color: context.overlaySurface,
                   child: _buildBottomTabs(context),
                 ),
               ],
@@ -1190,7 +1192,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                 right: 0,
                 child: ColoredBox(
                   key: const ValueKey('model-selector-top-seam-cover'),
-                  color: Theme.of(context).colorScheme.surface,
+                  color: context.overlaySurface,
                   child: const SizedBox(height: 1),
                 ),
               ),
@@ -1256,7 +1258,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       right: 0,
       child: DecoratedBox(
         key: const ValueKey('model-selector-sticky-provider'),
-        decoration: BoxDecoration(color: context.appColors.surfaceCard),
+        decoration: BoxDecoration(color: context.overlaySurface),
         child: SizedBox(
           height: _stickyProviderHeaderHeight + 1,
           child: ClipRect(
@@ -1427,7 +1429,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         ? (isDark
               ? cs.primary.withValues(alpha: 0.12)
               : cs.primary.withValues(alpha: 0.08))
-        : context.appColors.surfaceCard;
+        : sheetTileColor(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       child: RepaintBoundary(
@@ -1648,7 +1650,7 @@ class _ProviderChipState extends State<_ProviderChip> {
         ? (isDark
               ? cs.primary.withValues(alpha: 0.08)
               : cs.primary.withValues(alpha: 0.05))
-        : context.appColors.surfaceCard;
+        : sheetTileColor(context);
     final Color overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final Color bg = _pressed ? Color.alphaBlend(overlay, baseBg) : baseBg;
     // Slightly stronger border when selected; keep label color unchanged for subtlety
@@ -2134,7 +2136,7 @@ class _DesktopModelSelectDialogBodyState
           maxHeight: 560,
         ),
         child: Material(
-          color: context.appColors.surfaceCard,
+          color: context.overlaySurface,
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
@@ -2153,7 +2155,7 @@ class _DesktopModelSelectDialogBodyState
                 // Body
                 Expanded(
                   child: Container(
-                    color: context.appColors.surfaceCard,
+                    color: context.overlaySurface,
                     child: Column(
                       children: [
                         Padding(
@@ -2396,7 +2398,7 @@ class _DesktopModelSelectDialogBodyState
         ? (isDark
               ? cs.primary.withValues(alpha: 0.12)
               : cs.primary.withValues(alpha: 0.08))
-        : context.appColors.surfaceCard;
+        : sheetTileColor(context);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),

--- a/test/features/model/widgets/model_select_sheet_test.dart
+++ b/test/features/model/widgets/model_select_sheet_test.dart
@@ -12,6 +12,8 @@ import 'package:Kelivo/features/model/widgets/model_select_sheet.dart';
 import 'package:Kelivo/icons/lucide_adapter.dart';
 import 'package:Kelivo/l10n/app_localizations.dart';
 import 'package:Kelivo/shared/widgets/ios_tactile.dart';
+import 'package:Kelivo/theme/app_semantic_colors.dart';
+import 'package:Kelivo/theme/theme_factory.dart';
 
 ProviderConfig _providerConfig(String key, String name, List<String> models) {
   return ProviderConfig(
@@ -86,6 +88,7 @@ Future<SettingsProvider> _settingsWithLongSingleProvider(
 Future<void> _pumpModelSelector(
   WidgetTester tester, {
   required SettingsProvider settings,
+  ThemeData? theme,
   String? limitProviderKey,
   String? initialProviderKey,
   String? initialModelId,
@@ -100,6 +103,7 @@ Future<void> _pumpModelSelector(
         ),
       ],
       child: MaterialApp(
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -154,6 +158,20 @@ bool _hasInvisibleAncestor(WidgetTester tester, Finder finder) {
     return !hidden;
   });
   return hidden;
+}
+
+/// Fill of a painted surface inside the sheet, whichever widget paints it.
+Color _surfaceColor(WidgetTester tester, String key) {
+  final widget = tester.widget(find.byKey(ValueKey(key)));
+  if (widget is Container) {
+    final decoration = widget.decoration;
+    return decoration is BoxDecoration ? decoration.color! : widget.color!;
+  }
+  if (widget is DecoratedBox) {
+    return (widget.decoration as BoxDecoration).color!;
+  }
+  if (widget is ColoredBox) return widget.color;
+  throw StateError('$key does not paint a surface');
 }
 
 Future<void> _dismissModelSelector(WidgetTester tester) async {
@@ -535,4 +553,63 @@ void main() {
     },
     timeout: const Timeout(Duration(seconds: 20)),
   );
+
+  for (final layered in const [false, true]) {
+    testWidgets(
+      'mobile model selector paints every surface with the sheet colour '
+      '(layered surfaces ${layered ? 'on' : 'off'})',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        tester.view.physicalSize = const Size(390, 844);
+        tester.view.devicePixelRatio = 1;
+        try {
+          final settings = await _settingsWithProviders(tester);
+          await _pumpModelSelector(
+            tester,
+            settings: settings,
+            theme: layered
+                ? buildLightThemeForScheme(
+                    ColorScheme.fromSeed(seedColor: const Color(0xFF4D5C92)),
+                    layeredSurfaces: true,
+                  )
+                : null,
+          );
+          await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+          final sheetContext = tester.element(find.byType(BottomSheet));
+          final sheetSurface = sheetContext.overlaySurface;
+          final cardLayer = sheetContext.appColors.surfaceCard;
+          expect(
+            sheetSurface,
+            layered ? equals(cardLayer) : isNot(cardLayer),
+            reason:
+                'The sheet must sit on the layer this mode selects, or the '
+                'surface assertions below cannot fail.',
+          );
+
+          for (final key in const [
+            'model-selector-header',
+            'model-selector-list',
+            'model-selector-bottom-tabs',
+            'model-selector-sticky-provider',
+            'model-selector-top-seam-cover',
+          ]) {
+            expect(
+              _surfaceColor(tester, key),
+              sheetSurface,
+              reason:
+                  '$key must follow the sheet surface, or the SafeArea bottom '
+                  'inset shows a different shade underneath the list.',
+            );
+          }
+        } finally {
+          await _dismissModelSelector(tester);
+          debugDefaultTargetPlatformOverride = null;
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+  }
 }


### PR DESCRIPTION
## 问题 & 调查

设置了主题颜色之后，模型选择弹层的背景色不跟着变，只有最下方露出一条主题色；工具、思考那两个弹层没有这个情况。怀疑是模型选择弹层单独设了背景色，调查发现根因在 `284b5375`（*feat(theme): add an optional surface ladder so cards sit above a sunk page*）——它在同一个文件里对两侧做了相反的迁移：

| | 之前 | 之后（`useLayeredSurfaces` 默认 `false`） |
| --- | --- | --- |
| 弹层自身的 `backgroundColor` | `cs.surface` | `overlaySurface` → 仍是 `cs.surface` |
| header / 列表 / 底部 tabs / sticky header / tile / chip | `cs.surface` | `surfaceCard` → `alphaBlend(white@0.96, page)` |

legacy 公式下 `surfaceCard` 是 96% 的白盖在 page 上，主题色只剩 4%，所以这几块看着几乎是纯白、不跟主题走；而 `SafeArea` 的底部 inset 不在任何一个容器里，露出的仍是弹层自己的 `cs.surface`，那一档带着完整的主题色——就是最下方那条。工具（`chat_tools_sheet`）和思考（`reasoning_budget_sheet`）只设了 `backgroundColor: context.overlaySurface`，内部没有再刷底色，所以整片跟着主题走。

## 修复

- **所有背景改用 `overlaySurface`**，跟上面那两个弹层以及本文件弹层自身的 `backgroundColor` 一致。顶部接缝那 1px 来自更早的 `519e9ba1`，写死 `colorScheme.surface` 没被一起迁走，是 layered 开启时唯一落在 page 层的一片，一并纳入。
- **模型 tile 与供应商 chip 改用 `sheetTileColor`**，继续受 `useLayeredSheetTiles` 控制；否则背景降回 page 层之后它们会孤零零浮在上面。
- **桌面 dialog 同样处理**：它是 `showGeneralDialog` 里的一个裸 `Material`，没有 `dialogTheme` 给它上色。

两种模式的结果：legacy（默认）下 `overlaySurface == cs.surface`、`sheetTileColor == transparent`，正好还原 `284b5375` 之前的观感；layered 开启时背景不变，tile 升到 `surfaceCardFill`，正是 `useLayeredSheetTiles` 的意图。其余 sheet 里的 `surfaceCard` 都是输入框 `fillColor` 或 tile 用法，没有第二处把整片弹层背景刷成卡片层。

## 测试

`model_select_sheet_test.dart` 新增两个用例（分层开关各一），复用文件里已有的 `_pumpModelSelector`：断言 header / 列表 / 底部 tabs / sticky header / 顶部接缝五个面都等于弹层自己的 `overlaySurface`——锁的是"内外同色"这个不变量，不是写死的色值。每条前面有一句守卫，断言弹层确实坐在该模式选中的那一层，否则后面的断言不可能失败。

变异测试通过：把那几处改回 `surfaceCard`，关闭态在 header 变红；把顶部接缝改回 `colorScheme.surface`，只有开启态变红。三个原本没有 key 的容器为此加了 `ValueKey`。覆盖只到移动端弹层，桌面 dialog 那两处是按配色公式推导的。

`dart format` 无改动，`dart analyze --fatal-infos lib test` 无告警，`flutter test` 5196 个全过。

## 截图

### 修复前

<img width="300" alt="IMG_1021" src="https://github.com/user-attachments/assets/1964c0b0-34d6-4e73-a825-ca2fac3739c8" />
<img width="300" alt="IMG_1022" src="https://github.com/user-attachments/assets/85242a95-5fb2-42e9-a0d6-106fd4ad53ab" />

### 修复后

<img width="300" alt="IMG_1020" src="https://github.com/user-attachments/assets/9972d55a-0c9b-4ad5-af46-482d230ea154" />
<img width="300" alt="IMG_1023" src="https://github.com/user-attachments/assets/303e45e2-ac6e-4922-86e2-3ff5a653da62" />

